### PR TITLE
Added a noformat option to domToHtml

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -166,7 +166,7 @@ var generateHtmlRecursive = function(element) {
   return ret;
 };
 
-exports.domToHtml = function(dom){
+exports.domToHtml = function(dom, noformat) {
   
   var ret = "";
   if(dom.item){
@@ -180,7 +180,10 @@ exports.domToHtml = function(dom){
     // single node
     ret = generateHtmlRecursive(dom);
   }
-  
-  return formatHTML(ret);
+  if (noformat) {
+    return ret;
+  } else {
+    return formatHTML(ret);
+  }
   
 }

--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -232,7 +232,7 @@ var browserAugmentation = exports.browserAugmentation = function(dom, options) {
   });
 
   dom.Element.prototype.__defineGetter__('innerHTML', function() {
-    return domToHtml(this.childNodes);
+    return domToHtml(this.childNodes, true);
   });
 dom.Element.prototype.__defineSetter__('innerHTML', function(html) {
     //Check for lib first


### PR DESCRIPTION
I added a noformat option to domToHtml for use with the innerHTML getter, but I left it in tact for the outerHTML getter.

I believe that the content of the innerHTML should not have added linefeeds to it for innerHTML. That content should be left alone.

If I have this:
<div>foo<div>

And I call this:
var html = el.innerHTML;

html should be:
"foo"

Not:
"foo
"
