### PR TITLE
Fixed a small bug with insertBefore and document fragments with more than one node

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -340,16 +340,13 @@ core.Node.prototype = {
 
         // fragments are merged into the element
         if (newChild.nodeType === this.DOCUMENT_FRAGMENT_NODE) {
-          var length = newChild.children.length;
-          var j;
-          var tmpNode;
-          var child;
-
-          for (j=0;j<length;j++)
-          {
+          var j, tmpNode, child;
+            
+          for (j = 0; j < newChild.children.length; j++) {
             tmpNode = newChild.removeChild(newChild.children.item(j));
             this.insertBefore(tmpNode, refChild);
           }
+        
         } else {
           this._children.splice(i,0,newChild);
           newChild._parentNode = this;


### PR DESCRIPTION
The issue here is that length was cached, but the array was being modified via removeChild, this kept the for loop looping even after all the nodes were removed from the document fragment. Replacing the cached length with newChild.children.length means that length is reused on each iteration and works as expected now.
