### PR TITLE
Missing parent node

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -432,7 +432,6 @@ core.Node.prototype = {
       if (this._children[i] === oldChild) {
         found=true;
         this._children.remove(i,i);
-        oldChild._parentNode = null;
 
         if (this.id) {
           if (this._ownerDocument._ids) {


### PR DESCRIPTION
Think I've figured out how to do this properly. Sorry for being such a pain :)

Anyway, I was noticing some scripts (namely readability) failing in jsdom while working perfectly well in a browser. Apparently real browsers don't remove the parentNode reference when doing a removeChild. This was the simplest fix for the issue I could find and I'm fairly certain I didn't break any tests.
