### PR TITLE
Fix for lookup after element re-insertion

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -525,11 +525,11 @@ core.Node.prototype = {
       newChild._parentNode = this;
       this._children.push(newChild);
 
-      if (this.id) {
+      if (newChild.id) {
         if (!this._ownerDocument._ids) {
           this._ownerDocument._ids = {};
         }
-        this._ownerDocument._ids[this.id] = this;
+        this._ownerDocument._ids[newChild.id] = newChild;
       }
     }
 


### PR DESCRIPTION
This fixes a bug where `document.getElementById()` returns `undefined` for nodes that are first removed and later re-inserted into the document.
