### PR TITLE
Fix for dealing with document.innerHTML = '';

### DIFF
--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -299,9 +299,11 @@ core.Node.prototype.__proto__ = events.EventTarget.prototype;
 // Wrap the level-1 implementation of removeChild() to dispatch a DOMNodeRemoved event
 (function(level1) {
 	core.Node.prototype.removeChild = function(oldChild) {
-		var ev = this.ownerDocument.createEvent("MutationEvents");
-		ev.initMutationEvent("DOMNodeRemoved", true, false, this, null, null, null, null);
-		oldChild.dispatchEvent(ev);
+        if (this.ownerDocument) {
+            var ev = this.ownerDocument.createEvent("MutationEvents");
+            ev.initMutationEvent("DOMNodeRemoved", true, false, this, null, null, null, null);
+            oldChild.dispatchEvent(ev);
+        }
 		return level1.call(this, oldChild);
 	};
 })(core.Node.prototype.removeChild);


### PR DESCRIPTION
Added ownerDocument check to the level2 removeChild wrapper. If the node that is being removed is a document, this will error. Since a document doesn't have an ownerDocument.
