### PR TITLE
Mutation events need to ensure the document exists before issuing events

### DIFF
--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -287,7 +287,7 @@ core.Node.prototype.__proto__ = events.EventTarget.prototype;
 (function(level1) {
 	core.Node.prototype.appendChild = function(newChild) {
 		var ret = level1.call(this, newChild);
-		if (this.nodeType == 1) {
+		if (this.nodeType == 1 && this.ownerDocument) {
 			var ev = this.ownerDocument.createEvent("MutationEvents");
 			ev.initMutationEvent("DOMNodeInserted", true, false, this, null, null, null, null);
 			newChild.dispatchEvent(ev);


### PR DESCRIPTION
In certain cases that truthfully I don't fully understand this.ownerDocument will be null when trying to issue the DOM mutation events that wrap DOM Level 1's appendChild and removeChild methods. Calling createEvent on null is a runtime error, so to alleviate these cases we should ensure that this.ownerDocument exists before proceeding.
