### PR TITLE
HTML-Encoding issue with script tags

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -156,7 +156,7 @@ var generateHtmlRecursive = function(element) {
         ret += current.end;
         break;
       case element.TEXT_NODE:
-        ret += element.nodeValue;
+        ret += HTMLEncode(element.nodeValue);
         break; 
       case element.COMMENT_NODE:
         ret += '<!--' + element.nodeValue + '-->';


### PR DESCRIPTION
The test for the script and style tag in browser/index.js both use assertSame to compare string values, which won't fail, because it's actually comparing undefined with undefined.

<pre>
exports.assertSame = function(descr, expected, actual) {
  if(expected != actual) {
      assertEquals(descr, expected.nodeType, actual.nodeType);
      assertEquals(descr, expected.nodeValue, actual.nodeValue);
  }
}
</pre>


When you ask for the .innerHTML of a script tag, it returns the contents, but html-encoded, which it shouldn't. As far as I know, innerHTML should always return the raw contents of the element, and innerText might return it html-encoded.
