### PR TITLE
Fix for HTMLDecode not decoding &apos; and &#39;

### DIFF
--- a/lib/jsdom/browser/htmlencoding.js
+++ b/lib/jsdom/browser/htmlencoding.js
@@ -196,7 +196,7 @@ var html_entity_decode = function(string, quote_style) {
             };
             if (isNaN(char)) char = null;
         };
-        return char != null ? String.fromCharCode(char) : '';
+        return char != null ? String.fromCharCode(char) : ent;
     });
 
     return tmp_str;


### PR DESCRIPTION
This deals with the issue raised in #65...

But there's a bigger problem, which is that its not decoding entities of the form &amp;#xxxx;... 
