### PR TITLE
innerHTML setter didn't clear all children

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -283,9 +283,11 @@ var browserAugmentation = exports.browserAugmentation = function(dom, options) {
 
     //Clear the children first:
     var self = this;
-    this._childNodes.forEach(function(child) {
+    
+    var child;
+    while ((child = this._childNodes[0])) {
       self.removeChild(child);
-    });
+    }
 
     if (this.nodeName === '#document') {
       parseDocType(this, html);

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -176,5 +176,12 @@ exports.tests = {
 	assertEquals('',
                '<html style="color: black; background-color: white"></html>\r\n',
                require('../../lib/jsdom/browser/domtohtml').domToHtml(doc));
+  },
+  
+  innerhtml_removeallchildren: function() {
+    var doc = new browser.HTMLDocument();
+    doc.write('<html><body><p></p><p></p></body></html>');
+    doc.body.innerHTML = '';
+    assertTrue('still has children', doc.body.childNodes.length == 0);
   }
 };


### PR DESCRIPTION
removeChild splices the _childNodes array so forEach will skip elements

```
this._childNodes.forEach(function(child) {
    self.removeChild(child);
});
```

Fixed with a while loop.
