### PR TITLE
Canvas

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1067,7 +1067,20 @@ var tagRegEx = /[^\w:\d_-]+/i;
 var entRegEx = /[^\w\d_\-&;]+/;
 
 core.Document.prototype = {
-  _elementBuilders : {},
+  _elementBuilders : {
+    canvas : function(document, tagName) {
+      // require node-canvas
+      var Canvas = require('canvas');
+      var canvas = new Canvas(0, 0);
+      var element = new core.Element(document, tagName);
+      for (attr in element) {
+        if (!canvas[attr]) {
+          canvas[attr] = element[attr];
+        }
+      }
+      return canvas;
+    }
+  },
   _defaultElementBuilder: function(document, tagName) {
     return new core.Element(document, tagName);
   },


### PR DESCRIPTION
Added a canvas elementBuilder to _elementBuilders.
Imports node-canvas and instances a new canvas.
Instances a new core.Element and copies attributes from the core Element to the node-canvas canvas to ensure the canvas behaves like any other jsdom element. (probably there is a more elegant way to do this...but its a rough and effective go at it).
elementBuilder returns a new jsdom compatible canvas element.

Ultimately I'd like to leverage canvas within jsdom with Nude.js (node-nude) and castaneum. This work effectively lay the ground work for a server-side site parser that is capable of detecting nudity and responding accordingly (i.e. ewww nudity or ohhhh nudity!!!)...whichever. :) Theres a race condition within canvas / node (libeio I think) just now but they are working on it in the next day or so I'm told.
