### PR TITLE
Avoid unnecessary Document creation by HTML5.Parser when setting innerHTML

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -84,9 +84,14 @@ var HtmlToDom = function(parser){
   } else if(parser && parser.moduleName == 'HTML5') { /* HTML5 parser */
     this.appendHtmlToElement = function(html, element) {
       if(typeof html !== 'string') html += '';
-      var p = new parser.Parser({document: element.ownerDocument});
-      p.parse_fragment(html, element);
-      element.appendChild(p.fragment);
+      if  (element.nodeType == 9) {
+        // #document
+        new parser.Parser({document: element}).parse(html);
+      } else {
+        var p = new parser.Parser({document: element.ownerDocument});
+        p.parse_fragment(html, element);
+        element.appendChild(p.fragment);
+      }
     }
   } else {
     


### PR DESCRIPTION
When setting document.innerHTML, HTML5.Parser will create a jsdom Document with default options because document.ownerDocument is null. 

jsdom/browser/htmltodom.js
    var p = new parser.Parser({document: element.ownerDocument});
    p.parse_fragment(html, element);  
    element.appendChild(p.fragment);

html5/parser.js
    if(!this.document) {
        var l2 = require('jsdom/level2/core').dom.level2.core; 
        var browser = require('jsdom/browser')
        var DOM = browser.browserAugmentation(l2) 
        this.document = new DOM.Document('html');
    }
This is undesired because it doesn't make sense to create a Document for a Document. Also, options specified for the document are not respected. e.g. Disabling loading external resources/script evaluation will not take effect.
