### PR TITLE
Fix package dir require path

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     },
     "engines" : { "node" : ">=0.1.9" },
     "directories": {
-        "lib": "lib"
+        "lib": "./lib/jsdom"
     },
     "main": "./lib/jsdom"
 }


### PR DESCRIPTION
npm lib dir should be set to the root dir of your require path. Because npm already namespaces your lib when it installs it, libs that already have a namespaced lib dir get nested one more time.

Currently

```
jsdom
├── index.js
├── jsdom
│   ├── browser
│   ├── level1
│   ├── level2
│   └── level3
└── jsdom.js
```

This is incorrect because you have to do `require("jsdom/jsdom/browser")`. This patch fixes that so those nested requires will work as expected. `require("jsdom/browser")`.

After

```
jsdom
├── browser
├── index.js
├── level1
├── level2
└── level3
```
