### PR TITLE
Changes to package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "implements": [
         "http://www.w3.org/TR/REC-DOM-Level-1"
     ],
+    "dependencies": {
+       "htmlparser": ">=1.7.0"
+    },
     "engines" : { "node" : ">=0.1.9" },
     "directories": {
         "lib": "lib"


### PR DESCRIPTION
Though mjsunit is required to run the tests, I don't think it should be included in the package dependencies. Its not a necessary runtime requirement. Its too bar npm doesn't have development dependencies like rubygems.

Another change suggestion is to add the htmlparser to the dependencies list. Its much friendlier to have it automatically installed than printing out a message telling people to download it.

I understand that both this changes are somewhat opinionated, but accepting either of the two commits would be welcome.
