### PR TITLE
Fix default url when jsdom is required from npm

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -9,7 +9,9 @@ var createWindow = exports.createWindow = require("./jsdom/browser/index").creat
 exports.jsdom = function (html, level, options) {
   options = options || {};
   if (!options.url) {
-    options.url = module.parent.filename;
+    options.url = module.parent.id == 'jsdom' ?
+      module.parent.parent.filename :
+      module.parent.filename;
   }
 
   var browser = exports.browserAugmentation(level || exports.defaultLevel, options),


### PR DESCRIPTION
When jsdom is required from npm, `module.parent` is a stub file in ".node_libraries/jsdom/index" so the wrong url is set. We can detect this and go up one more parent to file the actual file.
