### PR TITLE
windowAugmentation should expose dom to window object

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -28,6 +28,9 @@ exports.windowAugmentation = function(dom, options) {
     options.document.write('<html><head></head><body></body></html>');
   }
 
+  for (key in dom)
+    window[key] = dom[key];
+
   var doc = window.document = options.document;
 
   if (doc.addEventListener) {

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -116,8 +116,16 @@ exports.tests = {
       assertEquals("js should not be executed",
                    'hello from html',
                    doc2.getElementById("test").innerHTML);
-      
-    }
+
+    };
+  },
+
+  window_is_augmented_with_dom_features : function() {
+    var document = jsdom.jsdom(),
+        window   = document.createWindow();
+
+    assertEquals("window must be augmented", true, window._augmented);
+    assertNotNull("window must include Element", window.Element);
   }
 
 };


### PR DESCRIPTION
The window object is missing classes like `Element`, `Node`, ... that exist on the dom. These should be copied over to the window when augmented.
