### PR TITLE
Another issue with resolving remote URLs

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -55,15 +55,16 @@ core.resourceLoader = {
     });
   },
   resolve: function(document, path) {
-    if (['/','.'].indexOf(path.charAt(0)) !== -1) {
+    if (document.URL) {
+      path = URL.resolve(document.URL, path);
+      return path;
+    } else if (['/','.'].indexOf(path.charAt(0)) !== -1) {
       if (!document._documentRoot) {
         throw new Error('document._documentRoot must be set to resolve absolute paths.');
       }
       path = require('path').join(document._documentRoot, path);
-    } else if (document.URL) {
-      path = URL.resolve(document.URL, path);
+      return path.replace(/^file:/, '').replace(/^([\/]*)/, "/");
     }
-    return path.replace(/^file:/, '').replace(/^([\/]*)/, "/");
   },
   download: function(url, callback) {
     var path = url.pathname + (url.search || ''),


### PR DESCRIPTION
Currently resourceLoader.resolve prepends a '/' to every return value:

var html = '<a href="test.html">Link</a>';
var options = {url: 'http://google.com/a/b/cindex.html'}
var document = require('jsdom').jsdom(html, null, options)
console.log(document.getElementsByTagName('a')[0].href);

Expected output:
http://google.com/a/b/test.html

Actual output:
/http://google.com/a/b/test.html

Also, the path joiner is used instead of the URL resolver, even when a value for URL is present, which results in strange behavior:

var html = '<a href=".">Link</a>';
var options = {url: 'http://google.com/a/b/cindex.html'}
var document = require('jsdom').jsdom(html, null, options)
console.log(document.getElementsByTagName('a')[0].href);

Expected output:
http://google.com/a/b

Actual output:
/http:/google.com/a/b

This patch should fix both of these issues.
