### PR TITLE
node-canvas was segfaulting because the canvas constructor was improperly called

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1107,7 +1107,7 @@ core.Document.prototype = {
 
       // require node-canvas and catch the error if it blows up
       try {
-        canvas = (require('canvas'))(0,0);
+        canvas = new (require('canvas'))(0,0);
         for (attr in element) {
           if (!canvas[attr]) {
             canvas[attr] = element[attr];


### PR DESCRIPTION
Very simple fix attached.  Terminal transcript of crash, which mirrors how it was being used in jsdom (happens about 5 seconds after calling "canvas(0,0)":

```
~/sources/jsdom(ehaas)$ node
> var canvas=require('canvas')
> canvas(0,0)
{}
> Segmentation fault
```
