### PR TITLE
Remove the selected bit from all other options in this group if the multiple attr is not present on the select

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -573,9 +573,16 @@ define('HTMLSelectElement', {
     },
 
     set value(val) {
+      var self = this;
       this.options.toArray().forEach(function(option) {
         if (option.value === val) {
           option.selected = true;
+        } else {
+          if (!self.hasAttribute('multiple')) {
+            // Remove the selected bit from all other options in this group
+            // if the multiple attr is not present on the select
+            option.selected = false;
+          }
         }
       });
     },
@@ -664,6 +671,17 @@ define('HTMLOptionElement', {
       this._initDefaultSelected();
       if (s) {
         this.setAttribute('selected', 'selected');
+        //Remove the selected bit from all other options in this group
+        if (this.parentNode) {
+          if (!this.parentNode.hasAttribute('multiple')) {
+            var o = this.parentNode.options;
+            for (var i = 0; i < o.length; i++) {
+                if (o[i] !== this) {
+                    o[i].selected = false;
+                }
+            }
+          }
+        }
       }
       else {
         this.removeAttribute('selected');


### PR DESCRIPTION
The .selected getter on an OPTION didn't reset other OPTION's. That left a chance that 2 OPTIONS would be set as selected even if the "multiple" attribute was not on the parent SELECT.
