### PR TITLE
el.children should not return non-element nodes

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -230,7 +230,18 @@ core.Node.prototype = {
   get DOCUMENT_FRAGMENT_NODE() { return 11;},
   get NOTATION_NODE() { return 12;},
 
-  get children() { return this._children;},
+  get children() {
+    //el.children list should not contain non-element nodes (el.tagName)
+    var ret = [];
+    var c = this._children;
+    c.toArray().forEach(function(v) {
+        if (v.tagName) {
+            ret.push(v);
+        }
+    });
+    ret = new core.NodeList(this, function() { return ret })
+    return ret;
+  },
   get nodeValue() { return this._nodeValue;},
   set nodeValue(value) {
     // readonly


### PR DESCRIPTION
el.childNodes should return all nodes.
el.children should only return Element nodes
