### PR TITLE
Fix for #118

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1565,7 +1565,13 @@ core.Text.prototype = {
     var newText = this._nodeValue.substring(offset);
     this._nodeValue = this._nodeValue.substring(0, offset);
     var newNode = this.ownerDocument.createTextNode(newText);
-    this._parentNode.appendChild(newNode);
+
+    if(this._parentNode.lastChild === this) {
+      this._parentNode.appendChild(newNode);
+    } else {
+      this._parentNode.insertBefore(newNode, this.nextSibling);
+    }
+
     return newNode;
   }, //raises: function(DOMException) {},
   toString: function() {


### PR DESCRIPTION
This fixes the bug described in a followup comment to Issue #118, where splitText indiscriminately puts the new node at the end of the parent node rather than immediately after the original text node.
