### PR TITLE
Contents of <style> shouldn't be entitified during serialization

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -148,11 +148,10 @@ exports.generateHtmlRecursive = function generateHtmlRecursive(element, rawText)
       element = element._entity;
     }
 
-    rawText = rawText || 
-        element.parentNode && 
-        element.parentNode.nodeName &&
-        element.parentNode.nodeName.toUpperCase() === 'SCRIPT';
-    
+    rawText = rawText ||
+        element.parentNode &&
+        /^(?:SCRIPT|STYLE)$/i.test(element.parentNode.nodeName);
+
     switch (element.nodeType) {
       case element.ELEMENT_NODE:
         var current = exports.stringifyElement(element);


### PR DESCRIPTION
Inline scripts and inline stylesheets should behave the same in this respect, but only the contents of script tags are considered raw text. This causes problems for stylesheets containing quoted data urls, among other things.

Here's a quick test case:

```
var document = require('jsdom').jsdom(
    '<html>'+
        '<style type="text/css">'+
            'body {'+
                'background-image: url("data:image/gif;base64,R0lGODlhAQABAMKAw78Aw4DDgMOAAAAAIcO5BAEAAAAALAAAAAABAAEAAAICRAEAOw==");'+
            '}'+
        '</style>'+
        '<script>'+
            'var foo = "";'+
        '</script>'+
    '</html>');

console.log(document.outerHTML);
```

The output:

```
<html>
    <style type="text/css">body {background-image: url(&quot;data:image/gif;base64,R0lGODlhAQABAMKAw78Aw4DDgMOAAAAAIcO5BAEAAAAALAAAAAABAAEAAAICRAEAOw==&quot;);}</style>
    <script>var foo = "";</script>
</html>
```
