### PR TITLE
Handle case where two prefixes defined the same namespace

### DIFF
--- a/lib/jsdom/level2/core.js
+++ b/lib/jsdom/level2/core.js
@@ -323,7 +323,7 @@ core.Element.prototype.getAttributeNodeNS = function(/* string */ namespaceURI,
 {
   return this._attributes._map(function(attr) {
     if (namespaceURI === attr.namespaceURI &&
-        attr.localName === localName)
+        attr._localName === localName)
     {
       return true;
     }
@@ -337,9 +337,9 @@ core.Element.prototype.setAttributeNodeNS = function(/* Attr */ newAttr)
   }
 
   var existing = this.getAttributeNodeNS(newAttr.namespaceURI,
-                                         newAttr.localName);
+                                         newAttr._localName);
   if (existing) {
-    this.removeAttribute(existing.qualifiedName);
+    this.removeAttributeNode(existing);
   }
 
   newAttr._ownerElement = this;


### PR DESCRIPTION
With this, all xml5 tests pass, with some workarounds
