### PR TITLE
Having a doctype is not a requirement for removing namespaced attributes

### DIFF
--- a/lib/jsdom/level2/core.js
+++ b/lib/jsdom/level2/core.js
@@ -243,7 +243,7 @@ core.NamedNodeMap.prototype.removeNamedItemNS = function(/*string */ namespaceUR
 
   var parent = this._parentNode,
       found = null,
-      defaults = parent.ownerDocument.doctype._attributes,
+      defaults,
       clone,
       defaultEl,
       defaultAttr;
@@ -254,7 +254,6 @@ core.NamedNodeMap.prototype.removeNamedItemNS = function(/*string */ namespaceUR
   {
     throw new core.DOMException(core.NO_MODIFICATION_ALLOWED_ERR);
   }
-  defaultEl = defaults.getNamedItemNS(parent._namespaceURI, parent._localName);
 
   if (this._nsStore[namespaceURI] &&
       this._nsStore[namespaceURI][localName])
@@ -266,6 +265,11 @@ core.NamedNodeMap.prototype.removeNamedItemNS = function(/*string */ namespaceUR
 
   if (!found) {
     throw new core.DOMException(core.NOT_FOUND_ERR);
+  }
+
+  if (parent.ownerDocument.doctype && parent.ownerDocument.doctype._attributes) {
+    defaults = parent.ownerDocument.doctype._attributes;
+    defaultEl = defaults.getNamedItemNS(parent._namespaceURI, parent._localName);
   }
 
   if (defaultEl) {
@@ -376,12 +380,17 @@ core.Element.prototype.removeAttributeNS = function(/* string */ namespaceURI,
     throw new core.DOMException(core.NO_MODIFICATION_ALLOWED_ERR);
   }
 
-  var defaults = this.ownerDocument.doctype._attributes,
+  var defaults,
       clone,
       found,
-      defaultEl = defaults.getNamedItemNS(namespaceURI, this.localName),
+      defaultEl,
       defaultAttr,
       clone;
+
+  if (parent.ownerDocument.doctype && parent.ownerDocument.doctype._attributes) {
+    defaults = this.ownerDocument.doctype._attributes;
+    defaultEl = defaults.getNamedItemNS(namespaceURI, this.localName);
+  }
 
   if (defaultEl) {
     defaultAttr = defaultEl.getAttributeNodeNS(namespaceURI, localName);


### PR DESCRIPTION
Test case:

```
var jsdom = require('jsdom');
var document = new (jsdom.dom.level3.core.Document)();
var node = document.createElementNS('a', 'a');
var attr;

attr = document.createAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:x')
attr.nodeValue = 'a';
node.setAttributeNodeNS(attr);

attr = document.createAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:y')
attr.nodeValue = 'a';
node.setAttributeNodeNS(attr);

attr = document.createAttributeNS('a', 'x:id')
attr.nodeValue = 'x';
node.setAttributeNodeNS(attr);

attr = document.createAttributeNS('a', 'y:id')
attr.nodeValue = 'x';
node.setAttributeNodeNS(attr);
```
