### PR TITLE
Removed a comma from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
           "email" : "N/A"
         },
         {
-          "name"  : "hij1nx (http://github.com/hij1nx)",
+          "name"  : "hij1nx (http://github.com/hij1nx)"
         }
     ],
     "bugs": {


### PR DESCRIPTION
I just removed a comma from package.json.

Now $ npm link . works.
