### PR TITLE
Untitled

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -46,7 +46,7 @@ core.resourceLoader = {
         catch(e) {
           err = e;
         }
-      } 
+      }
 
       if (err) {
         ev.initEvent('error', false, false);
@@ -68,8 +68,15 @@ core.resourceLoader = {
   },
   download: function(url, callback) {
     var path    = url.pathname + (url.search || ''),
-        client  = http.createClient(url.port || 80, url.hostname),
-        request = client.request('GET', path, {'host': url.hostname });
+        options = {'method': 'GET', 'host': url.hostname, 'path': url.pathname},
+        request;
+    if (url.protocol == 'https:') {
+      options.port = url.port || 443;
+      request = https.request(options);
+    } else {
+      options.port = url.port || 80;
+      request = http.request(options);
+    }
 
     request.on('response', function (response) {
       response.setEncoding('utf8');
@@ -80,7 +87,7 @@ core.resourceLoader = {
       response.on('end', function() {
         if ([301, 302, 303, 307].indexOf(response.statusCode) > -1) {
           var redirect = URL.resolve(url, response.headers["location"])
-          core.resourceLoader.download(redirect, callback);
+          core.resourceLoader.download(URL.parse(redirect), callback);
         } else {
           callback(null, data);
         }


### PR DESCRIPTION
UPDATE: ignore this... I had the code working in isolation, but need to do further work to get it working correctly in jsdom.

 was playing around trying to get an example from http://blog.nodejitsu.com/micro-templates-are-dead to work, but loading in scripts from https was causing errors so I tracked back the problem and wrote a fix.  I'm not sure what version of node.js you're targeting, but this probably only works for 0.4.1 (or higher) since the interface for http/https seems to have changed since 0.2.0.
     --Martin
