### PR TITLE
simplified the appendChild(), insertBefore() and replaceChild() code

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -409,72 +409,58 @@ core.Node.prototype = {
 
   /* returns Node */
   insertBefore :  function(/* Node */ newChild, /* Node*/ refChild){
-
-    // readonly
     if (this._readonly === true) {
       throw new core.DOMException(NO_MODIFICATION_ALLOWED_ERR, 'Attempting to modify a read-only node');
+    }
+
+    // TODO - if (!newChild) then?
+    if (newChild._ownerDocument !== this._ownerDocument) {
+      throw new core.DOMException(WRONG_DOCUMENT_ERR);
     }
 
     if (newChild.nodeType && newChild.nodeType === ATTRIBUTE_NODE) {
       throw new core.DOMException(HIERARCHY_REQUEST_ERR);
     }
 
-    if (newChild._ownerDocument !== this._ownerDocument) {
-      throw new core.DOMException(WRONG_DOCUMENT_ERR);
-    }
+    // search for parents matching the newChild
+    var current = this;
+    do {
+      if (current === newChild) {
+        throw new core.DOMException(HIERARCHY_REQUEST_ERR);
+      }
+    } while((current = current._parentNode));
 
-    // if the newChild is already in the tree elsewhere, remove it first
-    if (newChild._parentNode) {
-      newChild._parentNode.removeChild(newChild);
-    }
+    // fragments are merged into the element
+    if (newChild.nodeType === DOCUMENT_FRAGMENT_NODE) {
+      var tmpNode;
+      while (newChild._childNodes.length > 0) {
+        tmpNode = newChild.removeChild(newChild.firstChild);
+        this.insertBefore(tmpNode, refChild);
+      }
+    } else {
+      // if the newChild is already in the tree elsewhere, remove it first
+      if (newChild._parentNode) {
+        newChild._parentNode.removeChild(newChild);
+      }
 
-    // if refChild is null, add to the end of the list
-    if (refChild === null) {
-      return this.appendChild(newChild);
-    }
-
-    var i         = 0,
-        found     = false,
-        children  = this._childNodes,
-        l         = children.length,
-        current   = this;
-
-    for (i; i<l ; i++) {
-      if (children[i] === refChild) {
-        current = this;
-        // search for parents matching the newChild
-        while ((current = current._parentNode)) {
-          if (current === newChild) {
-            throw new core.DOMException(HIERARCHY_REQUEST_ERR);
-          }
+      if (refChild == null) {
+        var refChildIndex = this._childNodes.length;
+      } else {
+        var refChildIndex = this._indexOf(refChild);
+        if (refChildIndex == -1) {
+          throw new core.DOMException(NOT_FOUND_ERR);
         }
+      }
 
-        // fragments are merged into the element
-        if (newChild.nodeType === DOCUMENT_FRAGMENT_NODE) {
-          var tmpNode;
-          while (newChild._childNodes.length > 0) {
-            tmpNode = newChild.removeChild(newChild.firstChild);
-            this.insertBefore(tmpNode, refChild);
-          }
-
-        } else {
-          children.splice(i, 0, newChild);
-          newChild._parentNode = this;
-          if (newChild._addIds) {
-            newChild._addIds();
-          }
-          this._modified();
-        }
-        found = true;
-        break;
+      this._childNodes.splice(refChildIndex, 0, newChild);
+      newChild._parentNode = this;
+      if (newChild._addIds) {
+        newChild._addIds();
       }
     }
 
-    if (!found) {
-      throw new core.DOMException(NOT_FOUND_ERR);
-    } else {
-      return newChild;
-    }
+    this._modified();
+    return newChild;
   }, // raises(DOMException);
 
   _modified: function() {
@@ -490,61 +476,8 @@ core.Node.prototype = {
 
   /* returns Node */
   replaceChild : function(/* Node */ newChild, /* Node */ oldChild){
-
-    // readonly
-    if (this._readonly === true) {
-      throw new core.DOMException(NO_MODIFICATION_ALLOWED_ERR, 'Attempting to modify a read-only node');
-    }
-
-    if (newChild.nodeType === ATTRIBUTE_NODE) {
-      throw new core.DOMException(HIERARCHY_REQUEST_ERR);
-    }
-
-    // moving elements across documents
-    if (newChild._ownerDocument !== this._ownerDocument) {
-      throw new core.DOMException(WRONG_DOCUMENT_ERR);
-    }
-
-    for (var i=0;i<this._childNodes.length;i++)
-    {
-      if (this._childNodes[i] === oldChild) {
-        var current = this;
-        // search for parents matching the newChild
-        while ((current = current._parentNode)) {
-          if (current === newChild) {
-            throw new core.DOMException(HIERARCHY_REQUEST_ERR);
-          }
-        }
-
-        this._childNodes.splice(i,1);
-
-        if (newChild._parentNode && newChild._parentNode.removeChild) {
-          newChild._parentNode.removeChild(newChild);
-        }
-        newChild._parentNode = this;
-
-        // insert the new child at this location
-        if (newChild.nodeType === DOCUMENT_FRAGMENT_NODE) {
-          var child;
-          for (var j = 0;j<newChild._childNodes.length;j++) {
-            child = newChild._childNodes[j];
-            this._childNodes.splice(i+j,0, child);
-            if (child._addIds) {
-                child._addIds();
-            }
-          }
-        } else {
-          this._childNodes.splice(i,0, newChild);
-          if (newChild._addIds) {
-            newChild._addIds();
-          }
-        }
-
-        this._modified();
-        return oldChild;
-      }
-    }
-    throw new core.DOMException(NOT_FOUND_ERR);
+    this.insertBefore(newChild, oldChild);
+    return this.removeChild(oldChild);
   }, //raises(DOMException);
 
   /* returns void */
@@ -575,102 +508,26 @@ core.Node.prototype = {
 
   /* returns Node */
   removeChild : function(/* Node */ oldChild){
-
-    // readonly
     if (this._readonly === true) {
       throw new core.DOMException(NO_MODIFICATION_ALLOWED_ERR);
     }
 
-    var i        = 0,
-        found    = false,
-        child,
-        children = this._childNodes,
-        l        = children.length;
-
-    for (i; i<l; i++) {
-      child = children[i];
-      if (child === oldChild) {
-        found=true;
-        children.splice(i,1);
-        oldChild._parentNode = null;
-        this._modified();
-        child._removeIds();
-        return oldChild;
-      }
+    // TODO - if (!oldChild) then?
+    var oldChildIndex = this._indexOf(oldChild);
+    if (oldChildIndex == -1) {
+      throw new core.DOMException(NOT_FOUND_ERR);
     }
 
-    // node was not found.
-    throw new core.DOMException(NOT_FOUND_ERR);
+    this._childNodes.splice(oldChildIndex, 1);
+    oldChild._parentNode = null;
+    this._modified();
+    oldChild._removeIds();
+    return oldChild;
   }, // raises(DOMException);
 
   /* returns Node */
   appendChild : function(/* Node */ newChild){
-    // readonly
-    if (this._readonly === true) {
-      throw new core.DOMException(NO_MODIFICATION_ALLOWED_ERR);
-    }
-
-    if (newChild.nodeType === ATTRIBUTE_NODE) {
-      throw new core.DOMException(HIERARCHY_REQUEST_ERR);
-    }
-
-    // avoid recursion
-    var cur = this;
-    do {
-      if (cur === newChild) {
-        throw new core.DOMException(HIERARCHY_REQUEST_ERR);
-      }
-    } while ((cur = cur._parentNode))
-
-    // only elements created with this._ownerDocument can be added here
-    if (newChild._ownerDocument &&
-        this._ownerDocument     &&
-        newChild._ownerDocument !== this._ownerDocument) {
-
-      throw new core.DOMException(WRONG_DOCUMENT_ERR);
-    }
-
-    if (newChild._parentNode == this) {
-      try {
-        this.removeChild(newChild);
-      } catch (e) { /* do nothing */ }
-    }
-
-    // fragments are merged into the element
-    if (newChild.nodeType === DOCUMENT_FRAGMENT_NODE) {
-
-      var transfer = [],
-          length   = newChild._childNodes.length,
-          i        = length-1,
-          tmpNode,
-          child;
-
-      // remove backwards so that item indexes stay stable while nodes are removed
-      for (; i>-1; i--) {
-        transfer.unshift(newChild.removeChild(newChild._childNodes[i]));
-      }
-
-      for (i=0;i<transfer.length;i++){
-        this.appendChild(transfer[i]);
-      }
-
-    } else {
-      if (newChild && newChild._parentNode) {
-        try {
-            newChild._parentNode.removeChild(newChild);
-        } catch (e) {}
-      }
-
-      // Attach the parent node.
-      newChild._parentNode = this;
-      this._childNodes.push(newChild);
-      this._modified();
-      if (newChild._addIds) {
-        newChild._addIds();
-      }
-    }
-
-    return newChild;
+    return this.insertBefore(newChild, null);
   }, // raises(DOMException);
 
   /* returns boolean */

--- a/test/level1/core/files/hc_staff.xml.js
+++ b/test/level1/core/files/hc_staff.xml.js
@@ -17,11 +17,11 @@ exports.hc_staff = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">

--- a/test/level1/html/files/hc_staff.html.js
+++ b/test/level1/html/files/hc_staff.html.js
@@ -17,11 +17,11 @@ exports.hc_staff = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">

--- a/test/level1/svg/files/hc_staff.svg.js
+++ b/test/level1/svg/files/hc_staff.svg.js
@@ -16,11 +16,11 @@ exports.hc_staff = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">

--- a/test/level2/core/files/hc_staff.xml.js
+++ b/test/level2/core/files/hc_staff.xml.js
@@ -19,11 +19,11 @@ exports.hc_staff = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">

--- a/test/level2/core/files/staff2.xml.js
+++ b/test/level2/core/files/staff2.xml.js
@@ -19,11 +19,11 @@ exports.staff2 = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">

--- a/test/level2/events/files/hc_staff.xml.js
+++ b/test/level2/events/files/hc_staff.xml.js
@@ -19,11 +19,11 @@ exports.hc_staff = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">

--- a/test/level3/core/files/hc_nodtdstaff.xml.js
+++ b/test/level3/core/files/hc_nodtdstaff.xml.js
@@ -19,11 +19,11 @@ exports.hc_staff = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">

--- a/test/level3/core/files/hc_staff.xml.js
+++ b/test/level3/core/files/hc_staff.xml.js
@@ -19,11 +19,11 @@ exports.hc_staff = function() {
   //       http://www.w3schools.com/tags/ref_symbols.asp
   var entities = new dom.EntityNodeMap(
     doc,
-    doc.createEntityNode("alpha", "α"),
-    doc.createEntityNode("beta", "&#946;"),
-    doc.createEntityNode("gamma", "&#947;"),
-    doc.createEntityNode("delta", "&#948;"),
-    doc.createEntityNode("epsilon", "&#949;")
+    doc.createEntityNode("alpha", doc.createTextNode("α")),
+    doc.createEntityNode("beta", doc.createTextNode("&#946;")),
+    doc.createEntityNode("gamma", doc.createTextNode("&#947;")),
+    doc.createEntityNode("delta", doc.createTextNode("&#948;")),
+    doc.createEntityNode("epsilon", doc.createTextNode("&#949;"))
   );
 
   // <!ATTLIST acronym dir CDATA "ltr">


### PR DESCRIPTION
1. simplified the insertBefore() code:
   a. the newChild was being removed before the refChild was confirmed to be found. This could lead to dangling newChild in case refChild wasn't found
2. resusing insertBefore() in replaceChild() and appendChild() thereby reducing the amount of code
3. in test code there were invalid calls - doc.createEntityNode("alpha", "a"); The second argument is not a Node, and so the code should have failed. However previously the code at appendChild() was being lenient and inserting the string as child node.
4. As a result of this, 8 test cases in level3/core suite have started passing!
