### PR TITLE
Adopt unowned nodes when added to the tree

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -424,6 +424,9 @@ core.Node.prototype = {
       throw new core.DOMException(NO_MODIFICATION_ALLOWED_ERR, 'Attempting to modify a read-only node');
     }
 
+    // Adopt unowned children, for weird nodes like DocumentType
+    if (!newChild._ownerDocument) newChild._ownerDocument = this._ownerDocument;
+
     // TODO - if (!newChild) then?
     if (newChild._ownerDocument !== this._ownerDocument) {
       throw new core.DOMException(WRONG_DOCUMENT_ERR);


### PR DESCRIPTION
This seems to be the simplest way to make creating a DocumentType node and adding it to the tree work, since they're created by the DOMImplementation, not a specific document. (who the hell designs these APIs anyway?!)
