### PR TITLE
Make node type and error code constants available statically

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -238,7 +238,7 @@ var browserAugmentation = exports.browserAugmentation = function(dom, options) {
       }
 
       if (child.nodeType &&
-          child.nodeType === dom.Node.prototype.ENTITY_REFERENCE_NODE)
+          child.nodeType === dom.Node.ENTITY_REFERENCE_NODE)
       {
         child = child._entity;
       }
@@ -417,7 +417,7 @@ var browserAugmentation = exports.browserAugmentation = function(dom, options) {
       }
 
       if (child.nodeType &&
-          child.nodeType === dom.Node.prototype.ENTITY_REFERENCE_NODE)
+          child.nodeType === dom.Node.ENTITY_REFERENCE_NODE)
       {
         child = child._entity;
       }

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1315,7 +1315,7 @@ core.Document.prototype = {
   },
 
   appendChild : function(/* Node */ arg) {
-    if (this.documentElement && arg.nodeType == 1) {
+    if (this.documentElement && arg.nodeType == ELEMENT_NODE) {
       throw new core.DOMException(HIERARCHY_REQUEST_ERR);
     }
     return core.Node.prototype.appendChild.call(this, arg);
@@ -1332,13 +1332,12 @@ core.Document.prototype = {
   /* returns NodeList */
   getElementsByTagName: function(/* string */ name) {
     function filterByTagName(child) {
-      if (child.nodeType && child.nodeType ===
-          core.Node.prototype.ENTITY_REFERENCE_NODE)
+      if (child.nodeType && child.nodeType === ENTITY_REFERENCE_NODE)
       {
         child = child._entity;
       }
 
-      if (child.nodeName && child.nodeType === core.Node.prototype.ELEMENT_NODE)
+      if (child.nodeName && child.nodeType === ELEMENT_NODE)
       {
         if (name === "*") {
           return true;
@@ -1490,7 +1489,7 @@ core.Attr.prototype =  {
     var val = '';
     for (var i=0,len=this._childNodes.length;i<len;i++) {
       var child = this._childNodes[i];
-      if (child.nodeType === core.Node.prototype.ENTITY_REFERENCE_NODE) {
+      if (child.nodeType === ENTITY_REFERENCE_NODE) {
         val += child.childNodes.toArray().reduce(function(prev, c) {
           return prev += (c.nodeValue || c);
         }, '');

--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -306,11 +306,13 @@ events.EventTarget.prototype = {
 core.Node.prototype.__proto__ = events.EventTarget.prototype;
 
 function getDocument(el) {
-  return el.nodeType == 9 ? el : el._ownerDocument;
+  return el.nodeType == core.Node.DOCUMENT_NODE ? el : el._ownerDocument;
 }
 
 function mutationEventsEnabled(el) {
-  return (el.nodeType == 1 || el.nodeType == 4 || el.nodeType == 9) &&
+  return (el.nodeType == core.Node.ELEMENT_NODE ||
+          el.nodeType == core.Node.CDATA_SECTION_NODE ||
+          el.nodeType == core.Node.DOCUMENT_NODE) &&
       getDocument(el).implementation.hasFeature('MutationEvents');
 }
 
@@ -343,11 +345,11 @@ function dispatchInsertionEvent(ret, newChild, refChild) {
 
     ev.initMutationEvent("DOMNodeInserted", true, false, this, null, null, null, null);
     newChild.dispatchEvent(ev);
-    if (this.nodeType == 9 || this._attachedToDocument) {
+    if (this.nodeType == core.Node.DOCUMENT_NODE || this._attachedToDocument) {
       ev = doc.createEvent("MutationEvents");
       ev.initMutationEvent("DOMNodeInsertedIntoDocument", false, false, null, null, null, null, null);
       core.visitTree(newChild, function(el) { 
-        if (el.nodeType == 1) {
+        if (el.nodeType == core.Node.ELEMENT_NODE) {
           el.dispatchEvent(ev);
           el._attachedToDocument = true;
         }
@@ -367,7 +369,7 @@ function dispatchRemovalEvent(oldChild) {
     ev = doc.createEvent("MutationEvents");
     ev.initMutationEvent("DOMNodeRemovedFromDocument", false, false, null, null, null, null, null);
     core.visitTree(oldChild, function(el) { 
-      if (el.nodeType == 1) {
+      if (el.nodeType == core.Node.ELEMENT_NODE) {
         el.dispatchEvent(ev);
         el._attachedToDocument = false;
       }

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -28,7 +28,7 @@ core.resourceLoader = {
   },
   enqueue: function(element, callback, filename) {
     var loader = this,
-        doc    = element.nodeType === 9 ?
+        doc    = element.nodeType === core.Node.DOCUMENT_NODE ?
                  element                :
                  element._ownerDocument;
 


### PR DESCRIPTION
djcsdy@56eb37c0 makes the node type and error code constants available statically. In other words, you can do `Node.ELEMENT_NODE` to get the same value as `node.ELEMENT_NODE`, where `node` is an instance of `Node`. Surprisingly, this simple change fixes 102 test cases that were previously failing.

The other two revisions just do some related clean-up and are purely optional.
