### PR TITLE
The first parameter of function download should be object returned by URL

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -19,7 +19,7 @@ core.resourceLoader = {
       var full = this.resolve(element._ownerDocument, href);
       url = URL.parse(full);
       if (url.hostname) {
-        this.download(full, this.enqueue(element, callback));
+        this.download(url, this.enqueue(element, callback));
       }
       else {
         this.readFile(full, this.enqueue(element, callback, url));


### PR DESCRIPTION
The first parameter of function download should be object returned by URL.parse().
