### PR TITLE
using vm instead of evals.

### DIFF
--- a/lib/jsdom/level2/languages/javascript.js
+++ b/lib/jsdom/level2/languages/javascript.js
@@ -1,6 +1,4 @@
-var Context = process.binding('evals').Context,
-    // TODO: Remove .Script when bumping req'd node version to >= 5.0
-    Script = process.binding('evals').NodeScript || process.binding('evals').Script;
+var vm = require('vm');
 
 exports.javascript = function(element, code, filename) {
   var document = element.ownerDocument,
@@ -9,17 +7,17 @@ exports.javascript = function(element, code, filename) {
   if (window) {
     var ctx = window.__scriptContext;
     if (!ctx) {
-      window.__scriptContext = ctx = new Context();
+      window.__scriptContext = ctx = {};
       ctx.__proto__ = window;
     }
     var tracelimitbak = Error.stackTraceLimit;
     Error.stackTraceLimit = 100;
     try {
-      Script.runInContext(code, ctx, filename);
+      vm.runInNewContext(code, ctx, filename);
     }
     catch(e) {
       document.trigger(
-        'error', 'Running ' + filename + ' failed.', 
+        'error', 'Running ' + filename + ' failed.',
         {error: e, filename: filename}
       );
     }


### PR DESCRIPTION
From the version 2010.11.16, Version 0.3.1, the API process.binding('evals') move to require('vm').
