### PR TITLE
Fix the url argument pass to download() function issue. Add referrer support

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -19,7 +19,7 @@ core.resourceLoader = {
       var full = this.resolve(element._ownerDocument, href);
       url = URL.parse(full);
       if (url.hostname) {
-        this.download(full, this.enqueue(element, callback));
+        this.download(url, this.baseUrl(element._ownerDocument), this.enqueue(element, callback));
       }
       else {
         this.readFile(full, this.enqueue(element, callback, url));
@@ -57,15 +57,20 @@ core.resourceLoader = {
       element.dispatchEvent(ev);
     });
   },
+  baseUrl: function(document) {
+      var baseElements = document.getElementsByTagName('base'),
+          baseUrl      = document.URL;
+
+      if (baseElements.length > 0) {
+        baseUrl = baseElements.item(0).href;
+      }
+
+      return baseUrl;
+  },
   resolve: function(document, href) {
     if (href.match(/^\w+:\/\//)) return href;
  
-    var baseElements = document.getElementsByTagName('base'),
-        baseUrl      = document.URL;
-
-    if (baseElements.length > 0) {
-      baseUrl = baseElements.item(0).href;
-    }
+    var baseUrl = this.baseUrl(document);
 
     // See RFC 2396 section 3 for this weirdness. URLs without protocol
     // have their protocol default to the current one.
@@ -78,7 +83,7 @@ core.resourceLoader = {
 
     return URL.resolve(baseUrl, href);
   },
-  download: function(url, callback) {
+  download: function(url, referrer, callback) {
     var path    = url.pathname + (url.search || ''),
         options = {'method': 'GET', 'host': url.hostname, 'path': url.pathname},
         request;
@@ -88,6 +93,11 @@ core.resourceLoader = {
     } else {
       options.port = url.port || 80;
       request = http.request(options);
+    }
+
+    // set header.
+    if(referrer) {
+        request.setHeader('Referer', referrer);
     }
 
     request.on('response', function (response) {


### PR DESCRIPTION
Fix the url argument pass to download() function issue. Add http referrer support for download() function.
