### PR TITLE
Adds config.headers, for HTTP requests

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -247,8 +247,12 @@ exports.env = exports.jsdom.env = function() {
   } else {
     var url = URL.parse(config.html);
     if (url.hostname) {
-      request({uri: url, encoding: config.encoding || 'utf8'}, function(err, request, body) {
-        processHTML(err, body);
+      request({ uri: url,
+                encoding: config.encoding || 'utf8',
+                headers: config.headers || {}
+              },
+              function(err, request, body) {
+                processHTML(err, body);
       });
     } else {
       fs.readFile(url.pathname, processHTML);


### PR DESCRIPTION
Added configuration property 'headers' for HTTP request headers. Example usage:

```
jsdom.env({
    html: "http://en.wikipedia.org/wiki/France",
    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_7) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.71 Safari/534.24'},
    scripts: ['http://code.jquery.com/jquery-1.5.min.js'],
    done: function(errors, window) {
        console.log('Probably lat,lng for Paris', window.$('.geo').eq(0).text());
    }
});
```
