### PR TITLE
Select level with string

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -18,11 +18,16 @@ exports.__defineGetter__('version', function() {
   return pkg.version;
 });
 
+exports.level = function (level, feature) {
+	if(!feature) feature = 'core'
+	return require('./jsdom/level' + level + '/' + feature).dom['level' + level][feature]
+}
+
 exports.jsdom = function (html, level, options) {
 
   options = options || {};
   if(typeof level == "string") {
-    level = require('./jsdom/' + level)
+    level = exports.level(level, 'html')
   } else {
     level   = level || exports.defaultLevel;
   }


### PR DESCRIPTION
This adds a `level(level, feature)` function that gets ahold of the right implementation. I don't like it, but the structure's deep and a bit arcane.

Thoughts very welcome, but it solves the immediate problem for me.
