### PR TITLE
Fixed segfault

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -143,7 +143,7 @@ exports.createWindow = function(dom, options) {
 
       stopAllTimers();
 
-      this.window = this.self = this.parent = this.top = null;
+      this.dispose();
     },
     getComputedStyle: function(node) {
       var s = node.style,

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
        "htmlparser" : ">=1.7.0",
        "request"    : ">=1.0.0",
        "cssom"      : ">=0.2.0",
-       "contextify" : ">=0.0.1"
+       "contextify" : ">=0.0.3"
     },
     "devDependencies" : {
       "nodeunit" : ">=0.5.x",


### PR DESCRIPTION
- window.close() must be called to properly clean up resources.
- Bumped Contextify to 0.0.3.
