### PR TITLE
#267 - Override CSSOM to update style attribute

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -146,17 +146,59 @@ function evaluateStyleAttribute(data) {
     }
   }
 }
+
+/**
+ * Parses style attribute if it changes.
+ *
+ * @this {html.HTMLElement}
+ * @param {Event} e
+ */
+function styleAttributeListener(e)
+{
+  //console.log('style modified')
+  if ('style' === e.attrName) {
+    evaluateStyleAttribute.call(this, e.newValue);
+  }
+}
+
+/**
+ * Update style attribute after calling a CSSStyleDeclaration method.
+ *
+ * @this {html.HTMLElement}
+ * @param {Function} method  CSSStyleDeclaration method
+ * @param {Array} args       Arguments to pass to method
+ */
+function callCSSOMAndUpdateStyle(method, args)
+{
+  method.apply(this._cssStyleDeclaration, args);
+
+  // Bypass listener so style attribute isn't parsed
+  this.removeEventListener('DOMAttrModified', styleAttributeListener);
+  this.setAttribute('style', this.style.cssText);
+  this.addEventListener('DOMAttrModified', styleAttributeListener);
+}
+
 html.HTMLElement.prototype.__defineGetter__('style', function() {
   if (!this._cssStyleDeclaration) {
     this._cssStyleDeclaration = new cssom.CSSStyleDeclaration;
     //console.log('creating style atribute on ' + this.nodeName)
-    this.addEventListener('DOMAttrModified', function(e) {
-      //console.log('style modified')
-      if ('style' === e.attrName) {
-        evaluateStyleAttribute.call(this, e.newValue);
-      }
-    });
+    this.addEventListener('DOMAttrModified', styleAttributeListener);
     evaluateStyleAttribute.call(this, this.getAttribute('style'));
+
+    // Override CSSOM to catch changes to properties and update style attribute
+    var self = this;
+    var oldSetProperty = this._cssStyleDeclaration.setProperty;
+    var oldRemoveProperty = this._cssStyleDeclaration.removeProperty;
+
+    this._cssStyleDeclaration.setProperty = function()
+    {
+      callCSSOMAndUpdateStyle.call(self, oldSetProperty, arguments);
+    };
+
+    this._cssStyleDeclaration.removeProperty = function()
+    {
+      callCSSOMAndUpdateStyle.call(self, oldRemoveProperty, arguments);
+    };
   }
   return this._cssStyleDeclaration;
 });

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -45,8 +45,21 @@ StylePropertyReflectsStyleAttribute : function (test) {
   });
 },
 
-// TODO: the other way should work too: setting p.style.color
-// should modify p.getAttribute('style').
-// We will have to fork or modify cssom library to listen for change events.
+StyleAttributeReflectsStyleProperty : function (test) {
+  jsdom.env(
+      '<html>',
+      jsdom.defaultLevel, function(err, win) {
+    var p = win.document.createElement('p');
+    p.style.setProperty('color', 'red');
+    test.equal(p.getAttribute('style'), 'color: red;');
+    p.style.setProperty('width', '20px');
+    test.equal(p.getAttribute('style'), 'color: red; width: 20px;');
+    p.style.removeProperty('color');
+    test.equal(p.getAttribute('style'), 'width: 20px;');
+    p.style.removeProperty('width');
+    test.equal(p.getAttribute('style'), '');
+    test.done();
+  });
+},
 
 }


### PR DESCRIPTION
This closes #267.  The style attribute is now updated whenever `element.style.setProperty()` or `element.style.removeProperty()` are called.  Also added a unit test for this.

However, setting a named property like this:  `element.style.color = "red";`  ...doesn't update the style attribute.  It doesn't look like CSSOM fully supports setting properties like this yet.
