### PR TITLE
Fix a crash when setChild() fails to create a new DOM element

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -148,6 +148,9 @@ function setChild(parent, node) {
     break;
   }
 
+  if (!newNode)
+    return null;
+
   if (node.attribs) {
     for (c in node.attribs) {
       // catchin errors here helps with improperly escaped attributes


### PR DESCRIPTION
There are a handful of parsing bugs in the underlying node-htmlparser that have been discussed in other open tickets. This quick patch prevents jsdom from crashing on many of them by sanity checking if a newNode object was actually created in setChild() before recursively calling setChild() with newNode (which may be null).

Test case:

```
var jsdom = require('jsdom').jsdom;
var doc = jsdom('<html><body><div id="<"></div></body></html>');
console.log('done');
```

Before:

```
TypeError: Cannot read property '_ownerDocument' of undefined
    at Object.<anonymous> (.../jsdom/lib/jsdom/level1/core.js:458:18)
    at Object.insertBefore (.../jsdom/lib/jsdom/level2/events.js:325:20)
    at Object.appendChild (.../jsdom/lib/jsdom/level1/core.js:574:17)
    at setChild (.../jsdom/lib/jsdom/browser/htmltodom.js:170:17)
    ...
```

After:

```
done
```
