### PR TITLE
jsdom.jsdom: Create an empty document if html is the empty string

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -49,10 +49,10 @@ exports.jsdom = function (html, level, options) {
 
   exports.applyDocumentFeatures(doc, options.features);
   
-  if (!!html) {
-    doc.write(html + '');
-  } else {
+  if (typeof html === 'undefined' || html === null) {
     doc.write('<html><head></head><body></body></html>');
+  } else {
+    doc.write(html + '');
   }
 
   if (doc.close && !options.deferClose) {


### PR DESCRIPTION
For various reasons I sometimes need to build a document from scratch. Because `jsdom.jsdom` falls back to writing `<html><head></head><body></body></html>` into the document if the html parameter is falsy, I currently have to do something like this in order to get an empty document:

```
var doc = require('jsdom').jsdom(' ');
doc.removeChild(doc.firstChild);
```

The proposed patch changes the check so only a value of `undefined` or `null` will cause the fall back to kick in.
