### PR TITLE
Fix 2 bugs in test/jsdom/index.js

### DIFF
--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -155,7 +155,7 @@ exports.tests = {
     // Monkey patch https.request so it emits 'close' instead of 'end.
     https.request = function () {
       // Mock the request object.
-      var req = { setHeader : function () {} };
+      var req = { setHeader : function () {}, end : function () {} };
       req.__proto__ = new EventEmitter();
       process.nextTick(function () {
         req.emit('response', res);
@@ -347,6 +347,10 @@ exports.tests = {
         },
         deferClose : true
       });
+    // iframe.html sets onload handler to call loadComplete, so we mock it.
+    window = doc.createWindow();
+    doc.parent = window;
+    window.loadComplete = function () {};
 
     test.ok(doc._queue.paused, 'resource queue should be paused');
 


### PR DESCRIPTION
1.) env_with_https mocks out a request object, but was missing the end() function, which was causing a warning.

2.) load_multiple_resources_with_defer_close loads an iframe that expects the parent window to have a loadComplete() function, which didn't exist.  Added a mocked version like we have in the level2/html tests.
