### PR TITLE
insertBefore: no error if refChild === newChild.

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -481,6 +481,8 @@ core.Node.prototype = {
         tmpNode = newChild.removeChild(newChild.firstChild);
         this.insertBefore(tmpNode, refChild);
       }
+    } else if (newChild === refChild) {
+      return newChild;
     } else {
       // if the newChild is already in the tree elsewhere, remove it first
       if (newChild._parentNode) {

--- a/test/level1/core.js
+++ b/test/level1/core.js
@@ -13136,6 +13136,22 @@ exports.tests = {
   },
 
   /**
+   * If the "refChild" is the same as the "newChild" then don't do anything.
+   */
+  hc_nodeinsertbeforerefchildequal: function(test) {
+    var doc = hc_staff.hc_staff();
+    var elementList = doc.getElementsByTagName("p");
+    var employeeNode = elementList.item(1);
+    var childList = employeeNode.childNodes;
+
+    var refChild = childList.item(3);
+
+    employeeNode.insertBefore(refChild, refChild);
+
+    test.done();
+  },
+
+  /**
    *
    If the "refChild" is null then the
    "insertBefore(newChild,refChild)" method inserts the


### PR DESCRIPTION
This mirrors the behavior in current WebKit, Firefox and Opera.  The spec mentions removing the newChild from its parent if it has a parent, but this doesn't need to happen if newChild === refChild as no changes need to be made to the element order.
