### PR TITLE
Fix NPM warning: 'web' vs. 'url'

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     ],
     "bugs": {
         "mail": "tmpvar@gmail.com",
-        "web": "http://github.com/tmpvar/jsdom/issues"
+        "url": "http://github.com/tmpvar/jsdom/issues"
     },
     "licenses": [
         {


### PR DESCRIPTION
NPM warning: package.json: bugs['web'] should probably be bugs['url']
