### PR TITLE
Should totalDocs be the total no. of scripts + src passed into jsdom.env?

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -1,4 +1,3 @@
-
 var dom      = exports.dom = require("./jsdom/level3/index").dom,
     features = require('./jsdom/browser/documentfeatures'),
     fs       = require("fs"),
@@ -170,7 +169,7 @@ exports.env = exports.jsdom.env = function() {
     window     = exports.html(html, null, options).createWindow(),
     features   = window.document.implementation._features,
     docsLoaded = 0,
-    totalDocs  = config.scripts.length,
+    totalDocs  = config.scripts.length + config.src.length,
     readyState = null,
     errors     = null;
 


### PR DESCRIPTION
Currently this causes jsdom.env to call the done() callback after each src is done loading, so in the e.g. below the done function would get called back 3 times:

```
jsdom.env
    html: markup
    src: [src1, src2, src3]
    done: (err, window) ->
         console.log 'done loading'
```
