### PR TITLE
Fix npm warning: bugs.web -> bugs.url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
       }
     ],
     "bugs": {
-        "mail": "tmpvar@gmail.com",
-        "web": "http://github.com/tmpvar/jsdom/issues"
+        "email": "tmpvar@gmail.com",
+        "url": "http://github.com/tmpvar/jsdom/issues"
     },
     "licenses": [
         {


### PR DESCRIPTION
Also, bugs.mail -> bugs.email.

See "npm help json"; I think this is now the standard format for this field.
