### PR TITLE
Fix bug in appendHtmlToElement with HTML5 parser.

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -93,7 +93,6 @@ function HtmlToDom(parser) {
         else {
           var p = new parser.Parser({document: element.ownerDocument});
           p.parse_fragment(html, element);
-          element.appendChild(p.fragment);
         }
       }
     };


### PR DESCRIPTION
The commit message below pretty much sums it up.  The main issue I was seeing was that DOMNodeInsertedIntoDocument was firing twice when using the HTML5 parser and innerHTML to insert nodes.  This was causing scripts to run twice.

**Commit message**:
When calling parse_fragment(html, element), the HTML5 parser already
appends new nodes to the target element.

Calling element.appendChild(p.fragment) after parse_fragment:
    \* rips the newly appended nodes off of the target element
    \* puts them into a new document fragment
    \* appends them back onto the target element

This causes DOMNodeInsertedIntoDocument to fire twice (once in
parse_fragment, then again in appendChild).

**Relevant parts of the HTML5 code**:
[parser.parse_fragment](https://github.com/aredridel/html5/blob/master/lib/html5/parser.js#L56-76) sets the target element to be the root of the tree, and then parses the HTML and appends noes to it.  [parser.fragment](https://github.com/aredridel/html5/blob/master/lib/html5/parser.js#L78-82) is a getter that calls [tree.getFragment](https://github.com/aredridel/html5/blob/master/lib/html5/treebuilder.js#L248-253), which removes the newly created nodes from the target element and puts them in a new document fragment using [reparentChildren](https://github.com/aredridel/html5/blob/master/lib/html5/treebuilder.js#L237-242).

I'm not sure how to add a unit test for this one, but this fixed the issue in my project that uses jsdom + html5.
