### PR TITLE
node 0.6.1 compatibility issue. sys renamed to util

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -99,7 +99,11 @@ function HtmlToDom(parser) {
   } else {
 
     this.appendHtmlToElement = function(){
-      var sys = require('sys');
+			try {
+				var sys = require('util');
+			} catch(e) {
+				var sys = require('sys');
+			}
       sys.puts('');
       sys.puts('###########################################################');
       sys.puts('#  WARNING: No HTML parser could be found.');

--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -1,5 +1,9 @@
-var sys           = require('sys'),
-    http          = require('http'),
+try {
+	var sys = require('util');
+} catch(e) {
+	var sys = require('sys');
+}
+var http          = require('http'),
     URL           = require('url'),
     HtmlToDom     = require('./htmltodom').HtmlToDom,
     domToHtml     = require('./domtohtml').domToHtml,

--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -4,8 +4,12 @@
  *
  */
 var core = require("./core").dom.level2.core,
-    utils = require("../utils"),
-    sys = require("sys");
+    utils = require("../utils");
+try {
+	var sys = require('util');
+} catch(e) {
+	var sys = require('sys');
+}
 
 // modify cloned instance for more info check: https://github.com/tmpvar/jsdom/issues/325
 core = Object.create(core);


### PR DESCRIPTION
Patch to fix silent warnings I'm getting

```
The "sys" module is now called "util". It should have a similar interface.
```

I think it has to do with node 0.6.1.
