### PR TITLE
Use different dependency format

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,13 +145,13 @@
         "http://www.w3.org/TR/REC-DOM-Level-1"
     ],
     "dependencies": {
-       "htmlparser" : ">=1.7.0",
-       "request"    : ">=1.0.0",
-       "cssom"      : ">=0.2.0",
-       "contextify" : ">=0.0.3"
+       "htmlparser" : "1.7.0",
+       "request"    : "1.0.0",
+       "cssom"      : "0.2.0",
+       "contextify" : "0.0.3"
     },
     "devDependencies" : {
-      "nodeunit" : ">=0.5.x",
+      "nodeunit" : "0.5.x",
       "console.log" : "*",
       "optimist"   : "*"
     },


### PR DESCRIPTION
Recently, CSSOM introduced a big bug NV/CSSOM#29.

This bug ruined tests in my projects, because jsdom uses **latest** cssom as dependency. I think this is bad decision. I propose to include only latest tested versions of dependencies.
