### PR TITLE
Mark scripts added by jsdom with a marker class

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -111,6 +111,7 @@ exports.jQueryify = exports.jsdom.jQueryify = function (window /* path [optional
       callback = (typeof(args[args.length - 1]) === 'function') && args.pop(),
       path,
       jQueryTag = window.document.createElement("script");
+      jQueryTag.className = "jsdom";
 
   if (args.length > 1 && typeof(args[1] === 'string')) {
     path = args[1];
@@ -202,6 +203,7 @@ exports.env = exports.jsdom.env = function() {
     if (config.scripts.length > 0 || config.src.length > 0) {
       config.scripts.forEach(function(src) {
         var script = window.document.createElement('script');
+        script.className = "jsdom";
         script.onload = function() {
           scriptComplete()
         };

--- a/test/window/files/js/jquery.js
+++ b/test/window/files/js/jquery.js
@@ -1,0 +1,1 @@
+../../../browser/files/js/jquery.js

--- a/test/window/script.js
+++ b/test/window/script.js
@@ -1,4 +1,5 @@
-var jsdom = require('../../lib/jsdom');
+var jsdom = require('../../lib/jsdom'),
+    jQueryPath = __dirname + '/files/js/jquery.js';
 
 exports.tests = {
   scripts_share_a_global_context: function(test) {
@@ -35,6 +36,23 @@ exports.tests = {
     test.equal(window.imOnAWindow, true, 'setting this in the outer context should apply to the window');
     test.equal(window.object.a, 1, 'prototypes should be maintained across contexts');
     test.done();
+  },
+
+  scripts_jquerify_have_jsdom_class: function(test) {
+    var window = jsdom.jsdom().createWindow();
+    jsdom.jQueryify(window, [jQueryPath] , function(dom) {
+      test.ok(dom.window.$('script').hasClass("jsdom"));
+      test.done();
+    });
+  },
+
+  scripts_env_have_jsdom_class: function(test) {
+    var htmlString = '<html><head></head><body></body></html>';
+
+    jsdom.env(htmlString, [jQueryPath] , function(error, dom) {
+      test.ok(dom.window.$('script').hasClass("jsdom"));
+      test.done();
+    });
   },
 
   global_is_window_in_scripts: function(test){


### PR DESCRIPTION
I needed a clean way to remove these after I was done manipulating the DOM but before rendering back to HTML. There are 4 sizzle tests that are failing in master, but the tests I added for this change pass.
