### PR TITLE
Fix for issue #364

### DIFF
--- a/lib/jsdom/selectors/index.js
+++ b/lib/jsdom/selectors/index.js
@@ -17,12 +17,8 @@ exports.applyQuerySelectorPrototype = function(dom) {
 
   dom.Element.prototype.querySelectorAll = function(selector) {
     var self = this;
-    if( !this.parentNode ){
-      self = this.ownerDocument.createElement("div");
-      self.appendChild(this);
-    }
     return new dom.NodeList(self.ownerDocument, function() {
-      return Sizzle(selector, self.parentNode || self);
+      return Sizzle(selector, self);
     });
   };
 };


### PR DESCRIPTION
Hi,
there is obviously an error about what querySelectorAll should return.
http://www.w3.org/TR/selectors-api/#queryselectorall
says it searches "within the node’s subtrees".
This patch fixes #364.
