### PR TITLE
Make the contextify dependency optional.

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -6,7 +6,44 @@ var http          = require('http'),
     HTMLEncode    = htmlencoding.HTMLEncode,
     HTMLDecode    = htmlencoding.HTMLDecode,
     jsdom         = require('../../jsdom'),
-    Contextify    = require('contextify');
+    Contextify    = null;
+
+try {
+  Contextify = require('contextify');
+} catch (e) {
+  // Shim for when the contextify compilation fails.
+  // This is not quite as correct, but it gets the job done.
+  Contextify = function(sandbox) {
+    var vm = require('vm');
+    var global = null;
+
+    sandbox.run = function(code, filename) {
+      return vm.runInContext(code, sandbox, filename);
+    };
+
+    sandbox.getGlobal = function() {
+      if (!global) {
+        global = vm.runInContext('this', sandbox);
+      }
+      return global;
+    };
+
+    sandbox.dispose = function() {
+      global = null;
+      sandbox.run = function () {
+        throw new Error("Called run() after dispose().");
+      };
+      sandbox.getGlobal = function () {
+        throw new Error("Called getGlobal() after dispose().");
+      };
+      sandbox.dispose = function () {
+        throw new Error("Called dispose() after dispose().");
+      };
+    };
+
+    return sandbox;
+  };
+}
 
 function NOT_IMPLEMENTED(target) {
   return function() {

--- a/package.json
+++ b/package.json
@@ -150,6 +150,9 @@
        "cssom"      : "0.2.x",
        "contextify" : "0.0.x"
     },
+    "optionalDependencies": {
+       "contextify" : "0.0.x"
+    },
     "devDependencies" : {
       "nodeunit" : ">=0.5.x",
       "console.log" : "*",


### PR DESCRIPTION
This works around cases where node-waf currently fails on windows.
We'll have a better solution soon.
