### PR TITLE
Screwy definition for the ldquo entity.

### DIFF
--- a/lib/jsdom/browser/htmlencoding.js
+++ b/lib/jsdom/browser/htmlencoding.js
@@ -416,7 +416,7 @@ var charByEntityName = {
   'ldquo': '“',
   'rdquo': '”', // http://www.w3.org/TR/html4/sgml/entities.html
   'rdquor': '”', // http://www.w3.org/TR/html5/named-character-references.html
-  'ldquo': '„', // http://www.w3.org/TR/html4/sgml/entities.html
+  'ldquo': '“', // http://www.w3.org/TR/html4/sgml/entities.html
   'ldquor': '„', // http://www.w3.org/TR/html5/named-character-references.html
   'dagger': '†',
   'Dagger': '‡', // http://www.w3.org/TR/html4/sgml/entities.html


### PR DESCRIPTION
I've got a program that loads content from a page and exports it as an RSS feed and had quotes characters geting changed from &ldquo; to &ldquor;.

According to http://www.w3.org/TR/html5/named-character-references.html ldquo should be &#8220; not ldquor &#8222; (unlike rsquo and rsquor which are both &#8217;).
