### PR TITLE
Outputs xhtml by default, with a space before />, browsers love it that way

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -1,7 +1,3 @@
-//Make configurable from docType??
-//Set in option
-var isXHTML = false;
-
 //List from node-htmlparser
 var singleTags = {
   area: 1,
@@ -59,10 +55,7 @@ exports.stringifyElement = function stringifyElement(element) {
   ret.start += attributes.join(" ");
 
   if (singleTags[tagName]) {
-    if (isXHTML) {
-        ret.start += "/";
-    }
-    ret.start += ">";
+    ret.start += " />";
     ret.end = '';
   } else {
     ret.start += ">";


### PR DESCRIPTION
jsdom outputs html documents that trigger "quirks mode" on browsers, and that is really deceptive.
