### PR TITLE
Wrapped callback with `process.nextTick` to avoid accidental exception swallowing

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -196,7 +196,7 @@ exports.env = exports.jsdom.env = function() {
           errors = errors.concat(window.document.errors || []);
         }
 
-        callback(errors, window);
+        process.nextTick(function() { callback(errors, window); });
       }
     }
 


### PR DESCRIPTION
Several times I've ran into situation where an error in the callback for `jsdom.env` was inadvertently swallowed by the try/catch statement in `/jsdom/lib/jsdom/level2/events.js:202`.  Wrapping the callback in a `process.nextTick` got rid of the problem and let exception bubble to the top.
