### PR TITLE
Fixed bug when config.html is a filepath containing spaces

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -275,7 +275,7 @@ exports.env = exports.jsdom.env = function() {
         processHTML(err, body);
       });
     } else {
-      fs.readFile(url.pathname, processHTML);
+      fs.readFile(config.html, processHTML);
     }
   }
 };

--- a/test/jsdom/files/folder space/space.html
+++ b/test/jsdom/files/folder space/space.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>hello, Node.js!</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -69,6 +69,16 @@ exports.tests = {
     });
   },
 
+  env_with_absolute_file_with_spaces: function(test) {
+    jsdom.env({
+      html: path.join(__dirname, 'files/folder space', 'space.html'),
+      done: function(errors, window) {
+        test.equal(errors, null, 'errors should be null');
+        test.done()
+      }
+    });
+  },
+
   env_with_html: function(test) {
     var html = "<html><body><p>hello world!</p></body></html>";
     jsdom.env({


### PR DESCRIPTION
Node's url#parse function will cut out anything after a space in the given url/path (see https://github.com/joyent/node/issues/1392)

You shouldn't use url.pathname when dealing with local files as the path may contain spaces and the path would be truncated.
