### PR TITLE
Preserve the style attribute until node.style is touched

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -142,23 +142,6 @@ function scanForImportRules(cssRules, baseUrl) {
 function evaluateStyleAttribute(data) {
   // this is the element.
 
-  // currently, cssom's parse doesn't really work if you pass in
-  // {state: 'name'}, so instead we just build a dummy sheet.
-  var styleSheet = cssom.parse('dummy{' + data + '}');
-  var style = this.style;
-  while (style.length) {
-    style.removeProperty(style[0]);
-  }
-  if (styleSheet.cssRules.length > 0 && styleSheet.cssRules[0].style) {
-    var newStyle = styleSheet.cssRules[0].style;
-    for (var i = 0; i < newStyle.length; ++i) {
-      var prop = newStyle[i];
-      style.setProperty(
-          prop,
-          newStyle.getPropertyValue(prop),
-          newStyle.getPropertyPriority(prop));
-    }
-  }
 }
 
 /**
@@ -167,14 +150,20 @@ function evaluateStyleAttribute(data) {
 function StyleAttr(node, value) {
   this._node = node;
   core.Attr.call(this, node.ownerDocument, 'style');
-  this.nodeValue = value;
+  if (!this._node._ignoreValueOfStyleAttr) {
+    this.nodeValue = value;
+  }
 }
 StyleAttr.prototype = {
   get nodeValue() {
-    return this._node.style.cssText;
+    if (typeof this._node._style === 'string') {
+      return this._node._style;
+    } else {
+      return this._node.style.cssText;
+    }
   },
   set nodeValue(value) {
-    evaluateStyleAttribute.call(this._node, value);
+    this._node._style = value;
   }
 };
 StyleAttr.prototype.__proto__ = core.Attr.prototype;
@@ -194,14 +183,33 @@ utils.intercept(core.AttrNodeMap, 'setNamedItem', function(_super, args, attr) {
  * Lazily create a CSSStyleDeclaration.
  */
 html.HTMLElement.prototype.__defineGetter__('style', function() {
-  var style = this._cssStyleDeclaration;
-  if (!style) {
-    style = this._cssStyleDeclaration = new cssstyle.CSSStyleDeclaration();
-    if (!this.getAttributeNode('style')) {
-      this.setAttribute('style', '');
+  if (typeof this._style === 'string') {
+    // currently, cssom's parse doesn't really work if you pass in
+    // {state: 'name'}, so instead we just build a dummy sheet.
+    var styleSheet = cssom.parse('dummy{' + this._style + '}');
+    this._style = new cssstyle.CSSStyleDeclaration();
+    if (styleSheet.cssRules.length > 0 && styleSheet.cssRules[0].style) {
+      var newStyle = styleSheet.cssRules[0].style;
+      for (var i = 0; i < newStyle.length; ++i) {
+        var prop = newStyle[i];
+        this._style.setProperty(
+            prop,
+            newStyle.getPropertyValue(prop),
+            newStyle.getPropertyPriority(prop));
+      }
     }
   }
-  return style;
+  if (!this._style) {
+    this._style = new cssstyle.CSSStyleDeclaration();
+
+  }
+  if (!this.getAttributeNode('style')) {
+    // Tell the StyleAttr constructor to not overwrite this._style
+    this._ignoreValueOfStyleAttr = true;
+    this.setAttribute('style');
+    this._ignoreValueOfStyleAttr = false;
+  }
+  return this._style;
 });
 
 assert.equal(undefined, html.HTMLLinkElement._init);

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -76,6 +76,24 @@ exports.tests = {
     });
   },
 
+  retainOriginalStyleAttributeUntilStyleGetter: function (test) {
+    jsdom.env(
+        '<html>',
+        jsdom.level('2', 'html'), function (err, win) {
+          var document = win.document;
+          var div = document.createElement('div');
+          div.setAttribute('style', 'font-weight: bold; font-weight: normal;');
+          test.equal(div.getAttribute('style'), 'font-weight: bold; font-weight: normal;');
+          div.innerHTML = '<div style="color: red; color: blue;"></div>';
+          test.equal(div.innerHTML, '<div style="color: red; color: blue;"></div>');
+          test.equal(div.firstChild.getAttribute('style'), 'color: red; color: blue;');
+          div.firstChild.style.color = 'maroon';
+          test.equal(div.firstChild.getAttribute('style'), 'color: maroon;');
+          test.done();
+        }
+     );
+  },
+
   getComputedStyleInline: function(test) {
     jsdom.env(
         '<html>',


### PR DESCRIPTION
The `style` attribute of a node might legitimately contain multiple definitions of the same property, for instance:

```
<div style="background-image: -moz-linear-gradient(top,rgb(126,255,247) 0%,rgb(255,255,255) 66%);
            background-image: -webkit-linear-gradient(top,rgb(126,255,247) 0%,rgb(255,255,255) 66%);">
```

Currently the value of the `style` attribute is immediately run through CSSOM, which by design (and per the spec) doesn't handle duplicate CSS properties, so in the above example, only the `-webkit-` definition would be left in `node.getAttribute('style')`.

I would like to be able to read the exact value of the `style` attribute, and for the document to serialize to the original contents. This is similar to https://github.com/NV/CSSOM/issues/16 for which I'm maintaining a workaround in a fork.

I'm suggesting a compromise where the `style` property behaves like in Firefox and Chrome:

```
var div = document.createElement('div');
div.setAttribute('style', 'color: black; color: white;')
div.getAttribute('style') // "color: black; color: white;"
div.style.backgroundColor = 'red'; // div.style gets populated here, "color: black;" is lost
div.getAttribute('style') // "color: white; background-color: red; "
```

(There's a minor difference, though: The attached code destroys the original `style` attribute when `node.style` is accessed, whereas Firefox and Chrome leave it until `node.style.something` is assigned to. As far as I can tell, we won't be able to mimic that exact behavior without a CSSOM implementation that uses Harmony proxies or getters and setters for each supported CSS property).

What do you think?
