### PR TITLE
Test for callback context

### DIFF
--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -1062,7 +1062,8 @@ document.write("<SCR"+"IPT TYPE=\'text/javascript\' SRC=\'...\'><\/SCR"+"IPT>");
         "<head></head>" +
         "<body>" +
         "  <div onclick='window.divClicked = true;'" +
-        "       onmouseover='window.divMousedOver = true;'>" +
+        "       onmouseover='window.divMousedOver = true;'" +
+        "       onmouseout='window.divCalledFrom = this.tagName;'>" +
         "    <a></a>" +
         "  </div>" +
         "</body>" +
@@ -1083,6 +1084,11 @@ document.write("<SCR"+"IPT TYPE=\'text/javascript\' SRC=\'...\'><\/SCR"+"IPT>");
     mouseOver.initMouseEvent('mouseover', false, false);
     div.dispatchEvent(mouseOver);
     test.equal(window.divMousedOver, true);
+
+    var mouseOut = doc.createEvent('MouseEvents');
+    mouseOut.initMouseEvent('mouseout', false, false);
+    div.dispatchEvent(mouseOut);
+    test.equal(window.divMousedCalledFrom, "DIV");
 
     test.done();
   },


### PR DESCRIPTION
Old-style inline callbacks are executing in the context of the window, rather than of the element that triggered the event. This causes problems when we have a callback like:

```
onclick="doSomething(this)"
```

I got as far as writing a failing test, but then I looked at the Contextify stuff and realized I wasn't sure what was going on, so I didn't code up a fix. I hope this is enough to help.
