### PR TITLE
Fix to HTMLSelectElement's implementation of 'type' attribute

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+0.2.15
+ * Fix: HTMLSelectElement single selection implemented its type incorrectly as 'select' instead of 'select-one' (aomega)
 0.2.14
  * Fix: when serializing single tags use ' />' instead of '/>' (kapouer)
  * Fix: support for contextify simulation using vm.runInContext (trodrigues)

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -710,7 +710,7 @@ define('HTMLSelectElement', {
     },
 
     get type() {
-      return this.multiple ? 'select-multiple' : 'select';
+      return this.multiple ? 'select-multiple' : 'select-one';
     },
 
     add: function(opt, before) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsdom",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "description": "A javascript implementation of the W3C DOM",
     "keywords": [
       "dom",
@@ -141,6 +141,10 @@
          "name" : "Tiago Rodrigues",
          "email" : "tmcrodrigues@gmail.com",
          "web" : "http://trodrigues.net"
+      },
+      {
+         "name" : "John Roberts",
+         "email" : "jroberts@logitech.com"
       }
     ],
     "bugs": {


### PR DESCRIPTION
HTMLSelectElement implemented 'type' incorrectly. This simple fix changes it to 'select-one' and bumps version. Unit test result is the same before and after (6 tests are failing)
