### PR TITLE
HTTP proxy support for jsdom

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -269,7 +269,8 @@ exports.env = exports.jsdom.env = function() {
       request({
         uri      : url,
         encoding : config.encoding || 'utf8',
-        headers  : config.headers || {}
+        headers  : config.headers || {},
+        proxy    : config.proxy || null
       },
       function(err, request, body) {
         processHTML(err, body);


### PR DESCRIPTION
Currently there's no easy way to use jsdom through a proxy server. I've added the "proxy" field to the config object and pass this through to the request object to switch this on.
