### PR TITLE
Make `name` property undefined except for certain tags.

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -842,7 +842,7 @@ core.NamedNodeMap.prototype = {
       throw new core.DOMException(INUSE_ATTRIBUTE_ERR);
     }
 
-    var name = arg.name;
+    var name = arg.name || arg.tagName;
     var ret = this._nodes[name];
     if (!ret) {
       this.length++;
@@ -993,7 +993,6 @@ core.Element.prototype = {
     return this._attributes;
   },
 
-  get name() { return this.nodeName;},
   /* returns string */
   getAttribute: function(/* string */ name) {
     var attribute = this._attributes.getNamedItem(name);

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -19728,5 +19728,26 @@ exports.tests = {
     test.equal(preventDefault, false, 'preventDefault should be *false*');
     test.ok(performedDefault, 'performedDefault');
     test.done();
+  },
+
+  only_special_tags_have_name_and_it_reflects_the_attribute: function(test) {
+    var doc = load("anchor");
+
+    ['a', 'applet', 'button', 'form', 'frame', 'iframe', 'img', 'input', 'map',
+     'meta', 'object', 'param', 'select', 'textarea'].forEach(function (tagName) {
+      var element = doc.createElement(tagName);
+      test.strictEqual(element.name, '', '<' + tagName + '> elements should have empty name properties by default.');
+
+      element.name = 'foo';
+      test.strictEqual(element.name, 'foo', '<' + tagName + '> elements should allow setting and retrieving their name properties.');
+      test.strictEqual(element.name, element.getAttribute('name'), '<' + tagName + '> elements should have name properties equal to their name attributes.');
+    });
+
+    ['section', 'abbr', 'label', 'option', 'customTag'].forEach(function (tagName) {
+      var element = doc.createElement(tagName);
+      test.strictEqual(element.name, undefined, '<' + tagName + '> elements should not have a value for the name property');
+    });
+
+    test.done();
   }
 }


### PR DESCRIPTION
Tags listed at https://developer.mozilla.org/en/DOM/element.name.

Fixes #452.

---

I didn't replicate behavior like

``` js
"name" in document.createElement("a") // true
"name" in document.createElement("section") // false
```

because it seemed like a much further-ranging change.

Test included; pretty sure I put it in the right place.
