### PR TITLE
Whitelisted 'features' obj in processArguments

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -309,7 +309,8 @@ exports.env.processArguments = function(args) {
     'scripts' : false,
     'config'  : false,
     'url'     : false,  // the URL for location.href if different from html
-    'document': false   // HTMLDocument properties
+    'document': false,  // HTMLDocument properties
+    'features': true    // allows for features to be specified
   },
   propKeys = Object.keys(props),
   config = {


### PR DESCRIPTION
Fix for bug that prevents script tags from loading in a jsdom.env that passes in a features object. Previously the features object was being thrown away because of processArguments' whitelist did not include 'features': true.
