### PR TITLE
(hackily) make sure that doctypes don't get set as the documentElement

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -252,7 +252,7 @@ function closest(e, tagName) {
 function descendants(e, tagName, recursive) {
   var owner = recursive ? e._ownerDocument || e : e;
   return new core.HTMLCollection(owner, core.mapper(e, function(n) {
-    return n.nodeName === tagName;
+    return n.nodeName === tagName && typeof n._publicId == 'undefined';
   }, recursive));
 }
 


### PR DESCRIPTION
This has been one of the causes of aredridel/html5#30, which I can now reproduce without Zombie.

It works fine if the HTML5 parser assembles the document from completely empty, but it explodes if jsdom has set up any of the structure.

This is just one possible implementation, though it works for me.
