### PR TITLE
Support Gzip

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -105,8 +105,9 @@ core.resourceLoader = {
 
     // set header.
     if (referrer) {
-        request.setHeader('Referer', referrer);
+      request.setHeader('Referer', referrer);
     }
+    request.setHeader('Accept-Encoding', 'gzip');
 
     request.on('response', function (response) {
       var buffer = [];


### PR DESCRIPTION
- Sends `Accepts-Encoding: gzip` header when downloading resources.
- Unzips gzipped responses.

However, I just noticed that `jsdom` supports `>=0.1.9`, wow! I think `zlib` support was added sometime around `0.5.8`. If you are really considering pulling this in, I can fix it to check for zlib support and fallback to no gzip if it's not supported.
