### PR TITLE
allow innerHTML to omit optional closing tags

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -16,6 +16,33 @@ var singleTags = {
   embed: 1
 };
 
+
+var blockTags = [
+  'address', 'article', 'aside', 'audio', 'blockquote', 'canvas', 'dd', 'div',
+  'dl', 'fieldset', 'figcaption', 'figure', 'figcaption', 'footer', 'form',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'noscript',
+  'ol', 'output', 'p', 'pre', 'section', 'table', 'tfoot', 'ul', 'video'
+];
+
+var closingOpeningTags = {
+  'body': [ 'body' ],
+  'colgroup': [ 'colgroup', 'tr' ],
+  'dd': [ 'dd', 'dt' ],
+  'dt': [ 'dd', 'dt' ],
+  'head': [ 'body' ],
+  'li': [ 'li' ],
+  'optgroup': [ 'optgroup' ],
+  'option': [ 'optgroup', 'option' ],
+  'p': blockTags,
+  'tbody': [ 'tbody' ],
+  'td': [ 'td', 'th' ],
+  'tfoot': [ 'tbody' ],
+  'th': [ 'td', 'th' ],
+  'thead': [ 'tfoot', 'tbody' ],
+  'tr': [ 'tfoot', 'tbody', 'tr' ]
+};
+
+
 var expr = {
   upperCaseChars: /([A-Z])/g,
   breakBetweenTags: /(<(\/?\w+).*?>)(?=<(?!\/\2))/gi,
@@ -34,7 +61,7 @@ var uncanon = function(str, letter) {
 
 var HTMLEncode = require('./htmlencoding').HTMLEncode;
 
-exports.stringifyElement = function stringifyElement(element) {
+exports.stringifyElement = function stringifyElement(element, optionalClosing) {
   var tagName = element.tagName.toLowerCase(),
       ret = {
         start: "<" + tagName,
@@ -60,6 +87,29 @@ exports.stringifyElement = function stringifyElement(element) {
   } else {
     ret.start += ">";
     ret.end = "</" + tagName + ">";
+
+    if (optionalClosing) {
+      // Determine whether the closing tag is optional or not.
+      var terminatingSiblings = closingOpeningTags[tagName];
+      if (terminatingSiblings) {
+        var node = element.nextSibling;
+        if (!node) {
+          ret.end = '';
+        }
+        while (node) {
+          if (node.nodeType === node.TEXT_NODE) {
+            break;
+          }
+          if (node.nodeType === node.ELEMENT_NODE) {
+            if (terminatingSiblings.indexOf(node.tagName.toLowerCase()) !== -1) {
+              ret.end = '';
+            }
+            break;
+          }
+          node = node.nextSibling
+        }
+      }
+    }
   }
 
   return ret;
@@ -92,7 +142,7 @@ function stringifyDoctype (doctype) {
   return dt;
 }
 
-exports.makeHtmlGenerator = function makeHtmlGenerator(indentUnit, eol) {
+exports.makeHtmlGenerator = function makeHtmlGenerator(indentUnit, eol, optionalClosing) {
   indentUnit = indentUnit || "";
   eol = eol || "";
 
@@ -109,7 +159,7 @@ exports.makeHtmlGenerator = function makeHtmlGenerator(indentUnit, eol) {
 
       switch (node.nodeType) {
         case node.ELEMENT_NODE:
-          current = exports.stringifyElement(node);
+          current = exports.stringifyElement(node, optionalClosing);
           if (childNodesRawText) {
             ret += curIndent + current.start;
           } else {
@@ -153,9 +203,10 @@ exports.makeHtmlGenerator = function makeHtmlGenerator(indentUnit, eol) {
   };
 };
 
-exports.domToHtml = function(dom, noformat, raw) {
+exports.domToHtml = function(dom, noformat, raw, optionalClosing) {
   var htmlGenerator = exports.makeHtmlGenerator(noformat ? "" : "  ",
-                                                noformat ? "" : "\n");
+                                                noformat ? "" : "\n",
+                                                optionalClosing);
   if (dom.toArray) {
     // node list
     dom = dom.toArray();

--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -415,22 +415,22 @@ var browserAugmentation = exports.browserAugmentation = function(dom, options) {
   });
 
   dom.Document.prototype.__defineGetter__('outerHTML', function() {
-    return domToHtml(this);
+    return domToHtml(this, null, null, options.optionalClosing);
   });
 
   dom.Element.prototype.__defineGetter__('outerHTML', function() {
-    return domToHtml(this);
+    return domToHtml(this, null, null, options.optionalClosing);
   });
 
   dom.Element.prototype.__defineGetter__('innerHTML', function() {
     if (/^(?:script|style)$/.test(this._tagName)) {
       var type = this.getAttribute('type');
       if (!type || /^text\//i.test(type) || /\/javascript$/i.test(type)) {
-        return domToHtml(this._childNodes, true, true);
+        return domToHtml(this._childNodes, true, true, options.optionalClosing);
       }
     }
 
-    return domToHtml(this._childNodes, true);
+    return domToHtml(this._childNodes, true, null, options.optionalClosing);
   });
 
   dom.Element.prototype.__defineSetter__('doctype', function() {
@@ -464,7 +464,7 @@ var browserAugmentation = exports.browserAugmentation = function(dom, options) {
 
 
   dom.Document.prototype.__defineGetter__('innerHTML', function() {
-    return domToHtml(this._childNodes, true);
+    return domToHtml(this._childNodes, true, null, options.optionalClosing);
   });
 
   dom.Document.prototype.__defineSetter__('innerHTML', function(html) {

--- a/package.json
+++ b/package.json
@@ -150,6 +150,10 @@
       {
         "name" : "John Roberts",
         "email" : "jroberts@logitech.com"
+      },
+      {
+        "name": "Jan Kuča",
+        "email": "jan@jankuca.com"
       }
     ],
     "bugs": {


### PR DESCRIPTION
Hi, I implemented an option to omit optional closing tags in innerHTML results.

The feature is turned off by default and you can allow it by specifying the `optionalClosing: true` option.

To illustrate, here are two examples of the output with and without the feature:

``` html
<div>
  <p>Lorem ipsum.</p>
  <p>Dolor sit amet.</p>
  I'm not in a paragraph.
</div>

<div>
  <p>Lorem ipsum.
  <p>Dolor sit amet.</p>
  I'm not in a paragraph.
</div>
```

``` html
<table>
  <tbody>
    <tr>
      <td>Lorem</td>
      <td>Ipsum</td>
    </tr>
  </tbody>
</table>

<table>
  <tbody>
    <tr>
      <td>Lorem
      <td>Ipsum
</table>
```

This feature follows the [Google HTML/CSS Style Guildelines](http://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml#Optional_tags).

No current functionality has been altered and no tests have been broken.
