### PR TITLE
add Element::matchesSelector when the QuerySelector options is on

### DIFF
--- a/lib/jsdom/selectors/index.js
+++ b/lib/jsdom/selectors/index.js
@@ -16,6 +16,14 @@ exports.applyQuerySelector = function(doc, dom) {
     return new dom.NodeList(addSizzle(this)(selector, this));
   };
 
+  var matchingSelector = false;
+  doc.matchesSelector = function(selector) {
+    matchingSelector = true;
+    var matches = addSizzle(doc).matchesSelector(this, selector);
+    matchingSelector = false;
+    return matches;
+  };
+
   var _createElement = doc.createElement;
   doc.createElement = function() {
       var element = _createElement.apply(this, arguments);
@@ -31,6 +39,13 @@ exports.applyQuerySelector = function(doc, dom) {
           el.appendChild(this);
         }
         return new dom.NodeList(addSizzle(this.ownerDocument)(selector, el.parentNode || el));
+      };
+
+      element.matchesSelector = function(selector) {
+        if (!matchingSelector) { // prevent infinite loop
+          return doc.matchesSelector.call(this, selector);
+        }
+        return false;
       };
 
       return element;


### PR DESCRIPTION
Hey, I added the `element.matchesSelector` method.

``` js
element.matchesSelector('#content p'); // boolean
```

It (of course) relies on the `QuerySelector` option to be turned on.

There is some strange loop in Sizzle which made me implement the helper variable. Without the `if (matchingSelector)` statement, the maximum call stack exception is thrown.
