### PR TITLE
fix handling of 'checked' attribute

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -775,7 +775,10 @@ define('HTMLOptionElement', {
       else this.removeAttribute('selected');
     },
     get text() {
-        return (this.hasAttribute('value')) ? this.getAttribute('value') : this.innerHTML;
+        return (this.hasAttribute('text')) ? this.getAttribute('text') : this.innerHTML;
+    },
+    set text(val) {
+      this.setAttribute('text', val);
     },
     get value() {
         return (this.hasAttribute('value')) ? this.getAttribute('value') : this.innerHTML;


### PR DESCRIPTION
The attached patch sets and removes the 'checked' attribute as the 'checked' property is set to true/false to implement the HTML spec.
