### PR TITLE
Swap out CSSOM's style declaration handling for CSSStyleDeclaration's

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -2,6 +2,7 @@ var core = require("./core").dom.level2.core,
     html = require("./html").dom.level2.html,
     utils = require("../utils"),
     cssom = require("cssom"),
+    cssstyle = require("cssstyle"),
     assert = require('assert');
 
 // What works now:
@@ -28,7 +29,7 @@ core.CSSRule = cssom.CSSRule;
 core.CSSStyleRule = cssom.CSSStyleRule;
 core.CSSMediaRule = cssom.CSSMediaRule;
 core.CSSImportRule = cssom.CSSImportRule;
-core.CSSStyleDeclaration = cssom.CSSStyleDeclaration;
+core.CSSStyleDeclaration = cssstyle.CSSStyleDeclaration;
 
 // Relavant specs
 // http://www.w3.org/TR/DOM-Level-2-Style (2000)
@@ -120,7 +121,7 @@ function scanForImportRules(cssRules, baseUrl) {
 
 /**
  * @param {string} data
- * @param {cssom.CSSStyleDeclaration} style
+ * @param {cssstyle.CSSStyleDeclaration} style
  */
 function evaluateStyleAttribute(data) {
   // this is the element.
@@ -179,7 +180,7 @@ utils.intercept(core.AttrNodeMap, 'setNamedItem', function(_super, args, attr) {
 html.HTMLElement.prototype.__defineGetter__('style', function() {
   var style = this._cssStyleDeclaration;
   if (!style) {
-    style = this._cssStyleDeclaration = new cssom.CSSStyleDeclaration();
+    style = this._cssStyleDeclaration = new cssstyle.CSSStyleDeclaration();
     if (!this.getAttributeNode('style')) {
       this.setAttribute('style', '');
     }

--- a/package.json
+++ b/package.json
@@ -156,6 +156,11 @@
       {
         "name" : "John Roberts",
         "email" : "jroberts@logitech.com"
+      },
+      {
+        "name" : "Chad Walker",
+        "email" : "chad@chad-cat-lore-eddie.com",
+        "url" : "https://github.com/chad3814"
       }
     ],
     "bugs": {
@@ -180,7 +185,8 @@
     "dependencies": {
        "htmlparser" : "1.x",
        "request"    : "2.x",
-       "cssom"      : "0.2.x",
+       "cssom"      : ">=0.2.2",
+       "cssstyle"   : "0.2.x",
        "contextify" : "0.1.x"
     },
     "optionalDependencies": {

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -156,7 +156,7 @@ exports.tests = {
     doc.appendChild(doc.createElement('html'));
     doc.documentElement.style.color = 'black';
     doc.documentElement.style.backgroundColor = 'white';
-    test.equal(domToHtml.domToHtml(doc), '<html style="color: black; background-color: white"></html>\n', '');
+    test.equal(domToHtml.domToHtml(doc), '<html style="color: black; background-color: white;"></html>\n', '');
     test.done();
   },
 

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -18,12 +18,14 @@ exports.tests = {
 
   HTMLStyleAttribute01 : function (test) {
     jsdom.env(
-        '<html><body><p style="color:red">',
+        '<html><body><p style="color:red; background-color: blue">',
         jsdom.defaultLevel, function(err, win) {
       var p = win.document.body.lastChild;
-      test.equal(1, p.style.length);
+      test.equal(2, p.style.length);
       test.equal('color', p.style[0]);
       test.equal('red', p.style.color);
+      test.equal('background-color', p.style[1]);
+      test.equal('blue', p.style.backgroundColor);
       test.done();
     });
   },
@@ -60,6 +62,15 @@ exports.tests = {
       test.equal(p.getAttribute('style'), 'width: 20px;');
       p.style.removeProperty('width');
       test.equal(p.getAttribute('style'), '');
+      p.style.cssText = 'background-color: blue; z-index: 12;';
+      test.equal(2, p.style.length);
+      test.equal('blue', p.style.backgroundColor);
+      test.equal('12', p.style.zIndex);
+      p.style.removeProperty('z-index');
+      test.equal(1, p.style.length);
+      p.style.backgroundColor = 'green';
+      test.equal('background-color: green;', p.style.cssText);
+      test.equal('background-color', p.style.item(0));
       test.done();
     });
   },


### PR DESCRIPTION
Removed CSSOM's CSSStyleDeclaration class and put a stand alone class from the CSSStyleDeclaration module.

This is a squash and rebase of my previous pull request
- require cssstyle >=0.2.2
- add tests and modified existing ones with regard to css styling
- added Chad Walker to the contributors
