### PR TITLE
Remove lowercase conversion of tag names in domtohtml conversion

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -35,7 +35,7 @@ var uncanon = function(str, letter) {
 var HTMLEncode = require('./htmlencoding').HTMLEncode;
 
 exports.stringifyElement = function stringifyElement(element) {
-  var tagName = element.tagName.toLowerCase(),
+  var tagName = element._tagName,
       ret = {
         start: "<" + tagName,
         end:''

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -795,8 +795,9 @@ exports.tests = {
         doc4 = jsdom.html("<body></body>").outerHTML.replace(spaces, ''),
         doc5 = jsdom.html("").outerHTML.replace(spaces, '');
 
-    test.ok(doc1 === doc2 && doc2 == doc3 && doc3 === doc4 && doc4 == doc5,
-            'they should all serialize the same');
+    test.ok(doc1 !== doc2 && doc2 !== doc3, 'case sensitivity should be honored');
+    test.ok(doc1.toLowerCase() === doc2.toLowerCase() && doc2.toLowerCase() === doc3 && doc3 === doc4 && doc4 === doc5, 
+    		'they should all serialize the same');
     test.done();
   },
 


### PR DESCRIPTION
- Replace element.tagName.toLowerCase() with element._tagName in
  domtohtml.js
- In the SVG specification there are multiple elements that should be
  rendered in camel case like: clipPath, textPath, linearGradient,
  radialGradient etc.
