### PR TITLE
core.resourceLoader.baseUrl have implementation bug

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -70,7 +70,7 @@ core.resourceLoader = {
         baseUrl      = document.URL;
 
     if (baseElements.length > 0) {
-      baseUrl = baseElements.item(0).href;
+      baseUrl = baseElements.item(0).href || baseUrl;
     }
 
     return baseUrl;


### PR DESCRIPTION
if (baseElements.length > 0) {
    baseUrl = baseElements.item(0).href; ***
  }

  when baseElements have target property but not have href property, the logic is break, so it should changed to

  baseUrl = baseElements.item(0).href || baseUrl;  ***

In my site scanner(for test), it can not resolve a.href, all relative href is not prepend the base url, then I found the bug. 
