### PR TITLE
css rule selectorText splitting

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -244,15 +244,21 @@ exports.createWindow = function(dom, options) {
     getComputedStyle: function(node) {
       var s = node.style,
           cs = new CSSStyleDeclaration(),
-          forEach = Array.prototype.forEach;
+          forEach = Array.prototype.forEach,
+          selectors, matched;
 
       forEach.call(node.ownerDocument.styleSheets, function (sheet) {
         forEach.call(sheet.cssRules, function (ruleSet) {
-          if (matchesDontThrow(node, ruleSet.selectorText)) {
-            forEach.call(ruleSet.style, function (property) {
-              cs.setProperty(property, ruleSet.style.getPropertyValue(property), ruleSet.style.getPropertyPriority(property));
-            });
-          }
+          selectors = ruleSet.selectorText.split(/\s*,\s*/);
+          matched = false;
+          selectors.forEach(function (selectorText) {
+            if (!matched && matchesDontThrow(node, selectorText)) {
+              matched = true;
+              forEach.call(ruleSet.style, function (property) {
+                cs.setProperty(property, ruleSet.style.getPropertyValue(property), ruleSet.style.getPropertyPriority(property));
+              });
+            }
+          });
         });
       });
 


### PR DESCRIPTION
pull request #540 added a new test to level2/style where the computed style did not take into consideration a style rule like:
`#id1 .clazz, #id2 .clazz {....}`
This patch splits the selectorText and iterates over them adding matched rules only once.
