### PR TITLE
Support running tests under html5 parser

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -340,7 +340,7 @@ exports.createWindow = function(dom, options) {
 * With cache: ~80ms
 */
 var defaultParser = null;
-function getDefaultParser() {
+var getDefaultParser = exports.getDefaultParser = function () {
   if (defaultParser === null) {
     try {
       defaultParser = require('htmlparser');
@@ -355,6 +355,17 @@ function getDefaultParser() {
     }
   }
   return defaultParser;
+}
+
+/**
+ * Export getter/setter of default parser to facilitate testing
+ * with different HTML parsers.
+ */
+exports.setDefaultParser = function (parser) {
+  if (typeof parser == 'object') {
+    defaultParser = parser;
+  } else if (typeof parser == 'string')
+    defaultParser = require(parser);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -191,7 +191,8 @@
        "contextify" : "0.1.x"
     },
     "optionalDependencies": {
-       "contextify" : "0.1.x"
+       "contextify" : "0.1.x",
+       "html5"      : ">=0.3.8"
     },
     "devDependencies" : {
       "nodeunit" : ">=0.5.x",

--- a/test/runner
+++ b/test/runner
@@ -20,6 +20,8 @@ var optimist = require('optimist')
     .describe('t', 'choose the test cases to run. ie: -t jquery')
     .alias('d', 'debug')
     .describe('d', 'run in node\'s interactive debugger mode')
+    .alias('p', 'parser')
+    .describe('p', 'the HTML parser to use (e.g. html5); default is htmlparser')
     .alias('v', 'verbose')
     .describe('v', 'show all tests that are being run');
 
@@ -133,6 +135,12 @@ files.map(function (p) {
     modulesToRun[p] = module;
   }
 });
+
+if (argv.parser) {
+  var browser = require("../lib/jsdom/browser/index");
+  console.log("Using parser " + argv.parser);
+  browser.setDefaultParser(argv.parser);
+}
 
 nodeunit.runModules(modulesToRun, {
   moduleStart: function (name) {


### PR DESCRIPTION
- add html5 as optional dependency to package.json
- add '-p' flag (-p html5) to test runner
- export setDefaultParser/getDefaultParser to browser/index.js
