### PR TITLE
strict level2 adherence

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -240,7 +240,13 @@ html.HTMLStyleElement._init = function() {
       //console.log('bad type: ' + this.type)
       return;
     }
-    evaluateStylesheet.call(this, this.textContent, this.sheet, this._ownerDocument.URL);
+    var content = '';
+    Array.prototype.forEach.call(this.childNodes, function (child) {
+      if (child.nodeType === 3) { // text node
+        content += child.nodeValue;
+      }
+    });
+    evaluateStylesheet.call(this, content, this.sheet, this._ownerDocument.URL);
   });
 };
 html.HTMLStyleElement.prototype.__defineGetter__('sheet', getOrCreateSheet);

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -8,7 +8,7 @@ exports.tests = {
   HTMLStyleElement01 : function (test) {
     jsdom.env(
         '<html><head><style>p{color:red}</style></head><body>',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
       var style = win.document.head.lastChild;
       test.equal(1, style.sheet.cssRules.length);
       test.equal('p', style.sheet.cssRules[0].selectorText);
@@ -20,7 +20,7 @@ exports.tests = {
   HTMLStyleAttribute01 : function (test) {
     jsdom.env(
         '<html><body><p style="color:red; background-color: blue">',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
       var p = win.document.body.lastChild;
       test.equal(2, p.style.length);
       test.equal('color', p.style[0]);
@@ -34,7 +34,7 @@ exports.tests = {
   StylePropertyReflectsStyleAttribute : function (test) {
     jsdom.env(
         '<html>',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
       var p = win.document.createElement('p');
       p.setAttribute('style', 'color:red');
       test.equal(1, p.style.length);
@@ -53,7 +53,7 @@ exports.tests = {
   StyleAttributeReflectsStyleProperty : function (test) {
     jsdom.env(
         '<html>',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
       var p = win.document.createElement('p');
       p.style.setProperty('color', 'red');
       test.equal(p.getAttribute('style'), 'color: red;');
@@ -79,7 +79,7 @@ exports.tests = {
   getComputedStyleInline: function(test) {
     jsdom.env(
         '<html>',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
           var doc = win.document;
           var html = doc.createElement("html");
           doc.appendChild(html);
@@ -104,7 +104,7 @@ exports.tests = {
         '<html><head><style>#id1 .clazz { margin-left: 100px; }</style></head><body>' 
             + '<div id="id1"><p class="clazz"></p></div>' 
             + '</body></html>',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
           var doc = win.document;
           p = doc.getElementsByTagName("p")[0];
           var cs = win.getComputedStyle(p);
@@ -120,7 +120,7 @@ exports.tests = {
             + '<div id="id1"><p class="clazz"></p></div>' 
             + '<div id="id2"><p class="clazz"></p></div>' 
             + '</body></html>',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
           var doc = win.document;
           p = doc.getElementsByTagName("p")[0];
           var cs = win.getComputedStyle(p);
@@ -179,7 +179,7 @@ exports.tests = {
   getComputedStyleWithBadSelectors: function(test) {
     jsdom.env(
         '<html>',
-        jsdom.defaultLevel, function(err, win) {
+        jsdom.level('2', 'html'), function(err, win) {
           var doc = win.document;
           var html = doc.createElement("html");
           doc.appendChild(html);


### PR DESCRIPTION
fixes tmpvar/jsdom issue #542, concatenates all text nodes within a <style> tag
also, correct level2/style tests to use level2 html instead of defaultLevel

FWIW, there must be other level3 leakage though. Even after changing the level2/style tests to use jsdom.level(2, 'html') the .textContent property was on elements. I made the change so that it concatenates all text nodes, so if the level3 leak is found, it should still continue to work.
