### PR TITLE
getComputedStyle crashes on some pages

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -249,7 +249,7 @@ exports.createWindow = function(dom, options) {
 
       forEach.call(node.ownerDocument.styleSheets, function (sheet) {
         forEach.call(sheet.cssRules, function (ruleSet) {
-          selectors = ruleSet.selectorText.split(/\s*,\s*/);
+          selectors = ruleSet.selectorText ? ruleSet.selectorText.split(/\s*,\s*/) : [];
           matched = false;
           selectors.forEach(function (selectorText) {
             if (!matched && matchesDontThrow(node, selectorText)) {


### PR DESCRIPTION
It happens because we are calling split on undefined on line 252. This fix checks ruleSet.selectorText before calling split on it.
