### PR TITLE
Patch and unit tests added for 'GetComputedStyle crash'

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -249,7 +249,7 @@ exports.createWindow = function(dom, options) {
 
       forEach.call(node.ownerDocument.styleSheets, function (sheet) {
         forEach.call(sheet.cssRules, function (ruleSet) {
-          selectors = ruleSet.selectorText.split(/\s*,\s*/);
+          selectors = typeof ruleSet.selectorText == 'string' ? ruleSet.selectorText.split(/\s*,\s*/) : [];
           matched = false;
           selectors.forEach(function (selectorText) {
             if (!matched && matchesDontThrow(node, selectorText)) {

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -582,6 +582,23 @@ exports.tests = {
     test.done();
   },
 
+  window_getComputedStyle_with_selectorText_undefined: function(test) {
+    var document = jsdom.jsdom(),
+        window   = document.createWindow(),
+        mockNode = {},
+        cssRules = [];
+
+    cssRules.push("dummyCssRules");
+    mockNode.style = {};
+    mockNode.ownerDocument = {};
+    mockNode.ownerDocument.styleSheets = [];
+    mockNode.ownerDocument.styleSheets.push({cssRules: cssRules});
+    
+    window.getComputedStyle( mockNode );
+    test.done();
+  },
+
+
   queryselector: function(test) {
     var html = '<html><body><div id="main"><p class="foo">Foo</p><p>Bar</p></div></body></html>',
         document = jsdom.jsdom(html),


### PR DESCRIPTION
I've added a unit test for the "GetComputedStyle crash." The unit tests will fail if no validation is done on property selectorText. 

The patch of @haraldrudell is included in my branch. 
