### PR TITLE
prevent errors when using anchors have no hrefs ( including unit test )

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -76,6 +76,11 @@ core.resourceLoader = {
     return baseUrl;
   },
   resolve: function(document, href) {
+    // if getAttribute returns null, there is no href
+    // lets resolve to an empty string (nulls are not expected farther up)
+    if(href === null)
+      return '';
+
     if (href.match(/^\w+:\/\//)) {
       return href;
     }

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -454,6 +454,19 @@ exports.tests = {
 
   /**
    *
+   HTMLAnchorElement.href should show the pathname of the href
+   * @author eleith
+   */
+  HTMLAnchorElement18: function(test) {
+    var doc = load("anchorEmpty");
+    var nodeList = doc.getElementsByTagName("a");
+    test.equal(nodeList.length, 1, 'A size');
+    test.equal(nodeList.item(0).href, '', 'A.href is empty');
+    test.done();
+  },
+
+  /**
+   *
    The align attribute specifies the alignment of the object(Vertically
    or Horizontally) with respect to its surrounding text.
    Retrieve the align attribute and examine its value.

--- a/test/level2/html/files/anchorEmpty.html
+++ b/test/level2/html/files/anchorEmpty.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+ "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; CHARSET=utf-8">
+<TITLE>NIST DOM HTML Test - Anchor</TITLE>
+</HEAD>
+<BODY onload="parent.loadComplete()">
+<P>
+<A NAME="empty">I AM EMPTY. That is OK</A>
+</P>
+</BODY>
+</HTML>


### PR DESCRIPTION
the goal here is to prevent this error

```
Cannot call method 'match' of null TypeError: Cannot call method 'match' of null
    at Object.core.resourceLoader.resolve (../node_modules/jsdom/lib/jsdom/level2/html.js:84:14)
```

this error is triggered when processing html files with anchors that have no hrefs in them. 

this pull request contains tests that would fail without the code change that is also in this pull request.
