### PR TITLE
Fix option#selected and select#selectedIndex, fixes #568 & #569

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -699,7 +699,7 @@ define('HTMLSelectElement', {
 
     get selectedIndex() {
       return this.options._toArray().reduceRight(function(prev, option, i) {
-        return option.defaultSelected ? i : prev;
+        return option.selected ? i : prev;
       }, -1);
     },
 
@@ -827,7 +827,7 @@ define('HTMLOptionElement', {
         if (select) {
           var options = select.options;
 
-          if (options.item(0) === this) {
+          if (options.item(0) === this && !select.hasAttribute('multiple')) {
             var found = false, optArray = options._toArray();
 
             for (var i = 1, l = optArray.length; i<l; i++) {

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -253,5 +253,245 @@ exports.tests = {
     var index = body.childNodes._toArray().indexOf(div);
     test.equal(index, -1, "indexOf 'span' in childNodes")
     test.done();
-  }
+  },
+
+  select_set_value_updates_value : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option value="x">x</option><option value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+
+    select.value = "x"
+    test.equal(select.value, "x", "select element value");
+
+    select.value = "y"
+    test.equal(select.value, "y", "select element selectedIndex");
+
+    test.done();
+  },
+
+  select_set_value_updates_selectedIndex : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option value="x">x</option><option value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+
+    select.value = "x"
+    test.equal(select.selectedIndex, 0, "select element selectedIndex");
+
+    select.value = "y"
+    test.equal(select.selectedIndex, 1, "select element selectedIndex");
+
+    test.done();
+  },
+
+  select_set_value_updates_option_selected : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option id="optX" value="x">x</option><option id="optY" value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+    var option0 = doc.getElementById("optX");
+    var option1 = doc.getElementById("optY");
+
+    select.value = "x";
+    test.ok(option0.selected, "option element selected");
+
+    select.value = "y";
+    test.ok(option1.selected, "option element selected");
+
+    test.done();
+  },
+
+  select_set_selectedIndex_updates_value : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option value="x">x</option><option value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+
+    select.selectedIndex = 0
+    test.equal(select.value, "x", "select element selectedIndex");
+
+    select.selectedIndex = 1
+    test.equal(select.value, "y", "select element selectedIndex");
+
+    test.done();
+  },
+
+  select_set_selectedIndex_updates_selectedIndex : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option value="x">x</option><option value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+
+    select.selectedIndex = 0
+    test.equal(select.selectedIndex, 0, "select element selectedIndex");
+
+    select.selectedIndex = 1
+    test.equal(select.selectedIndex, 1, "select element selectedIndex");
+
+    test.done();
+  },
+
+  select_set_selectedIndex_updates_option_selected : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option id="optX" value="x">x</option><option id="optY" value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+    var option0 = doc.getElementById("optX");
+    var option1 = doc.getElementById("optY");
+
+    select.selectedIndex = 0;
+    test.ok(option0.selected, "option element selected");
+    test.ok(!option1.selected, "option element selected");
+
+    select.selectedIndex = 1;
+    test.ok(option1.selected, "option element selected");
+    test.ok(!option0.selected, "option element selected");
+
+    test.done();
+  },
+
+  select_set_option_selected_updates_value : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option id="optX" value="x">x</option><option id="optY" value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+    var option0 = doc.getElementById("optX");
+    var option1 = doc.getElementById("optY");
+
+    select.selectedIndex = 0;
+    option0.selected = true;
+    test.equal(select.value, "x", "select element value");
+
+    option1.selected = true;
+    test.equal(select.value, "y", "select element value");
+
+    test.done();
+  },
+
+  select_set_option_selected_updates_selectedIndex : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option id="optX" value="x">x</option><option id="optY" value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+    var option0 = doc.getElementById("optX");
+    var option1 = doc.getElementById("optY");
+
+    option0.selected = true;
+    test.equal(select.selectedIndex, 0, "select element selectedIndex");
+
+    option1.selected = true;
+    test.equal(select.selectedIndex, 1, "select element selectedIndex");
+
+    test.done();
+  },
+
+  select_set_option_selected_updates_option_selected : function(test) {
+    var doc = new browser.Document();
+
+    var html = doc.createElement("html");
+    var body = doc.createElement("body");
+
+    doc.appendChild(html);
+    html.appendChild(body);
+
+    body.innerHTML =
+      '<select id="selectElement">' +
+        '<option id="optX" value="x">x</option><option id="optY" value="y">y</option>' +
+      '</select>';
+
+    var select = doc.getElementById("selectElement");
+    var option0 = doc.getElementById("optX");
+    var option1 = doc.getElementById("optY");
+
+    option0.selected = true;
+    test.ok(option0.selected, "option element selected");
+    test.ok(!option1.selected, "option element selected");
+
+    option1.selected = true;
+    test.ok(option1.selected, "option element selected");
+    test.ok(!option0.selected, "option element selected");
+
+    test.done();
+  },
 };


### PR DESCRIPTION
Thoroughly test select elements, and nail down the obvious expected
behavior that's not tested by the w3c tests.

  The addition to level2/html.js#702 makes sure selected options return
the index of the actual selected option, not the defaultSelected option

  The addition of the check for the `multiple` attribute at
level2/html.js#830 ensures that multi-select elements don't select
the first element by default.
