### PR TITLE
Checked property on radio input mutually exclusive. Fixes #271

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -942,8 +942,11 @@ define('HTMLInputElement', {
     select: function() {
     },
     click: function() {
-      if (this.type === 'checkbox' || this.type === 'radio') {
+      if (this.type === 'checkbox') {
         this.checked = !this.checked;
+      }
+      else if (this.type === 'radio') {
+        this.checked = true;
       }
       else if (this.type === 'submit') {
         var form = this.form;

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -284,5 +284,22 @@ exports.tests = {
     test.ok(radio2.checked, "radio checked");
 
     test.done();
+  },
+
+  radio_no_click_deselected : function(test) {
+    doc = jsdom.jsdom(
+      '<html><head></head><body>' +
+        '<input type="radio" id="rad0" value="rad0" name="radioGroup0" />' +
+      '</body>')
+
+    var radio0 = doc.getElementById("rad0");
+
+    radio0.click();
+    test.ok(radio0.checked, "radio checked");
+
+    radio0.click();
+    test.ok(radio0.checked, "radio checked");
+
+    test.done();
   }
 };


### PR DESCRIPTION
make radio buttons mutually exclusive, i.e. when you click one, the other ones turns off, and vice versa.
