### PR TITLE
Use setImmediate instead of process.nextTick.

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -203,7 +203,7 @@ exports.env = exports.jsdom.env = function() {
           errors = errors.concat(window.document.errors || []);
         }
 
-        process.nextTick(function() { callback(errors, window); });
+        setImmediate(function() { callback(errors, window); });
       }
     }
 
@@ -240,7 +240,7 @@ exports.env = exports.jsdom.env = function() {
       config.src.forEach(function(src) {
         var script = window.document.createElement('script');
         script.onload = function() {
-          process.nextTick(scriptComplete);
+          setImmediate(scriptComplete);
         };
 
         script.onerror = function(e) {
@@ -250,7 +250,7 @@ exports.env = exports.jsdom.env = function() {
           errors.push(e.error || e.message);
           // nextTick so that an exception within scriptComplete won't cause
           // another script onerror (which would be an infinite loop)
-          process.nextTick(scriptComplete);
+          setImmediate(scriptComplete);
         };
 
         script.text = src;

--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -90,7 +90,7 @@ exports.windowAugmentation = function(dom, options) {
     if (doc.readyState == 'complete') {
       var ev = doc.createEvent('HTMLEvents');
       ev.initEvent('load', false, false);
-      process.nextTick(function () {
+      setImmediate(function () {
         window.dispatchEvent(ev);
       });
     }

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -219,9 +219,9 @@ exports.tests = {
       // Mock the request object.
       var req = { setHeader : function () {}, end : function () {} };
       req.__proto__ = new EventEmitter();
-      process.nextTick(function () {
+      setImmediate(function () {
         req.emit('response', res);
-        process.nextTick(function () {
+        setImmediate(function () {
           res.emit('data', 'window.attachedHere = 123');
           res.emit('close');
         });
@@ -1139,7 +1139,7 @@ exports.tests = {
     // inline listener.  This means we have to check the value on the next
     // tick.
     window.addEventListener('load', function () {
-      process.nextTick(function () {
+      setImmediate(function () {
         test.equal(window.loader_called, true);
         test.done();
       });


### PR DESCRIPTION
This depends on caolan/nodeunit#195 to fix the errors with recursive process.nodeTick calls as of [Node v0.10.0](http://blog.nodejs.org/2013/03/11/node-v0-10-0-stable/).

Also depends on brianmcd/contextify#61 to get a working version of contextify built on 0.10.0.

But, with both of those linked to node_modules, 100% success on the tests with this change.
