### PR TITLE
Parser can now be set via jsdom.env config object.

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -172,7 +172,8 @@ exports.env = exports.jsdom.env = function() {
         'ProcessExternalResources' : false,
         'SkipExternalResources' : false
       },
-      url: config.url
+      url: config.url,
+      parser: config.parser
     },
     window     = exports.html(html, null, options).createWindow(),
     features   = JSON.parse(JSON.stringify(window.document.implementation._features)),
@@ -318,7 +319,8 @@ exports.env.processArguments = function(args) {
     'config'  : false,
     'url'     : false,  // the URL for location.href if different from html
     'document': false,  // HTMLDocument properties
-    'features': false   // allow for features to be specified
+    'features': false,  // allow for features to be specified
+    'parser'  : false
   },
   propKeys = Object.keys(props),
   config = {

--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -393,16 +393,19 @@ exports.setDefaultParser = function (parser) {
  */
 var browserAugmentation = exports.browserAugmentation = function(dom, options) {
 
-  if (dom._augmented) {
-    return dom;
-  }
-
   if(!options) {
     options = {};
   }
 
   // set up html parser - use a provided one or try and load from library
-  var htmltodom = new HtmlToDom(options.parser || getDefaultParser());
+  var parser = options.parser || getDefaultParser();
+
+  if (dom._augmented && dom._parser === parser) {
+    return dom;
+  }
+
+  dom._parser = parser
+  var htmltodom = new HtmlToDom(parser);
 
   if (!dom.HTMLDocument) {
     dom.HTMLDocument = dom.Document;


### PR DESCRIPTION
Made it possible to set the htmltodom parser via the config object passed to `jsdom.env`.  Example:

``` javascript
var jsdom = require("jsdom");
var html5 = require("html5");
jsdom.env(
    url,
    [ "http://code.jquery.com/jquery-1.9.1.min.js" ],
    { parser: html5 },
    callback
);
```
