### PR TITLE
rowIndex getter crashes on detached table rows

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1614,7 +1614,8 @@ define('HTMLTableRowElement', {
       return this._cells;
     },
     get rowIndex() {
-      return closest(this, 'TABLE').rows._toArray().indexOf(this);
+      var table = closest(this, 'TABLE');
+      return table ? table.rows._toArray().indexOf(this) : -1;
     },
 
     get sectionRowIndex() {

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -19937,5 +19937,13 @@ exports.tests = {
         test.done();
       }
     );
+  },
+
+  rowIndex_on_detached_table_row_should_return_minus_one: function(test) {
+    var doc = jsdom.jsdom();
+    var row = doc.createElement('tr');
+
+    test.strictEqual(row.rowIndex, -1, "rowIndex should equal -1");
+    test.done();
   }
 }


### PR DESCRIPTION
Currently jsdom crashes whenever I try to access `rowIndex` on detached table row element, it should return `-1` instead.

This pull request fixes that.
