### PR TITLE
Make onevent handlers more spec-compatible

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -587,25 +587,33 @@ core.Node.prototype = {
     // dispatchEvent() because that would create 2 'traditional' event handlers
     // in the case where there's an inline event handler attribute, plus one
     // set using element.on* in a script.
+    //
+    // @see http://www.w3.org/TR/2011/WD-html5-20110405/webappapis.html#event-handler-content-attributes
     if ((name.length > 2) && (name[0] == 'o') && (name[1] == 'n')) {
         if (value) {
           var self = this;
-          self[name] = function () {
+          // Check whether we're the window. This can happen because inline
+          // handlers on the body are proxied to the window.
+          var w = (typeof self.run !== 'undefined') ? self : self._ownerDocument.parentWindow;
+          self[name] = function (event) {
               // The handler code probably refers to functions declared in the
               // window context, so we need to call run().
-              if (self.run != undefined) {
-                  // We're the window. This can happen because inline handlers
-                  // on the body are proxied to the window.
-                  self.run(value);
-              } else {
-                  // We're an element. Use awesome hacks to get the correct `this` context for the inline event handler.
-                  self._ownerDocument.parentWindow.__tempContextForInlineEventHandler = self;
-                  self._ownerDocument.parentWindow.run("(function () {" + value + "}).call(window.__tempContextForInlineEventHandler);");
-                  delete self.ownerDocument.parentWindow.__tempContextForInlineEventHandler;
-              }
+
+              // Use awesome hacks to get the correct `this` context for the
+              // inline event handler. This would only be necessary if we're an
+              // element, but for the sake of simplicity we also do it on window.
+
+              // Also set event variable and support `return false`.
+              w.__tempContextForInlineEventHandler = self;
+              w.__tempEvent = event;
+              w.run("if ((function (event) {" + value + "}).call(" +
+                "window.__tempContextForInlineEventHandler, window.__tempEvent) === false) {" +
+                "window.__tempEvent.preventDefault()}");
+              delete w.__tempContextForInlineEventHandler;
+              delete w.__tempEvent;
           };
         } else {
-          delete this[name];
+          this[name] = null;
         }
     }
   },


### PR DESCRIPTION
Support `return false;`, add `event` argument, set property to `null` on unset.
