### PR TITLE
canvas behaves like div w/o node-canvas installed

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1163,6 +1163,13 @@ define('HTMLLIElement', {
   ]
 });
 
+define('HTMLCanvasElement', {
+  tagName: 'CANVAS',
+  attributes: [
+    'align'
+  ]
+});
+
 define('HTMLDivElement', {
   tagName: 'DIV',
   attributes: [

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -31,6 +31,20 @@ exports.tests = {
     });
   },
 
+  HTMLCanvasStyleAttribute01 : function (test) {
+    jsdom.env(
+        '<html><body><canvas style="background-color: blue; z-index:1">',
+        jsdom.level('2', 'html'), function(err, win) {
+      var c = win.document.body.lastChild;
+      test.equal(2, c.style.length);
+      test.equal('background-color', c.style[0]);
+      test.equal('blue', c.style.backgroundColor);
+      test.equal('z-index', c.style[1]);
+      test.equal(1, c.style.zIndex);
+      test.done();
+    });
+  },
+
   StylePropertyReflectsStyleAttribute : function (test) {
     jsdom.env(
         '<html>',


### PR DESCRIPTION
Now canvas behaves like a div w/o node-canvas installed (as described in readme)

Previously running code which accessed the style attribute
on a canvas element threw an error.
