### PR TITLE
Add "unused" parameter to all setters

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -429,12 +429,12 @@ core.Node.prototype = {
     }
     return name;
   },
-  set nodeName() { throw new core.DOMException();},
+  set nodeName(unused) { throw new core.DOMException();},
   get attributes() { return this._attributes;},
   get firstChild() {
     return this._childNodes.length > 0 ? this._childNodes[0] : null;
   },
-  set firstChild() { throw new core.DOMException();},
+  set firstChild(unused) { throw new core.DOMException();},
   get ownerDocument() { return this._ownerDocument;},
   get readonly() { return this._readonly;},
 
@@ -442,12 +442,12 @@ core.Node.prototype = {
     var len = this._childNodes.length;
     return len > 0 ? this._childNodes[len -1] : null;
   },
-  set lastChild() { throw new core.DOMException();},
+  set lastChild(unused) { throw new core.DOMException();},
 
   get childNodes() {
     return this._childNodes;
   },
-  set childNodes() { throw new core.DOMException();},
+  set childNodes(unused) { throw new core.DOMException();},
 
   _indexOf: function(/*Node*/ child) {
     if (!this._childNodes ||
@@ -484,7 +484,7 @@ core.Node.prototype = {
 
     return this._parentNode._childNodes[index+1] || null;
   },
-  set nextSibling() { throw new core.DOMException();},
+  set nextSibling(unused) { throw new core.DOMException();},
 
   get previousSibling() {
     if (!this._parentNode || !this._parentNode._indexOf) {
@@ -499,7 +499,7 @@ core.Node.prototype = {
 
     return this._parentNode._childNodes[index-1] || null;
   },
-  set previousSibling() { throw new core.DOMException();},
+  set previousSibling(unused) { throw new core.DOMException();},
 
   /* returns Node */
   insertBefore :  function(/* Node */ newChild, /* Node*/ refChild) {
@@ -1134,7 +1134,7 @@ core.DocumentFragment = function DocumentFragment(document) {
 core.DocumentFragment.prototype = {
   nodeType : DOCUMENT_FRAGMENT_NODE,
   get nodeValue() { return null;},
-  set nodeValue() { /* do nothing */ },
+  set nodeValue(unused) { /* do nothing */ },
   get attributes() { return null;}
 };
 core.DocumentFragment.prototype.__proto__ = core.Node.prototype;
@@ -1154,7 +1154,7 @@ core.ProcessingInstruction.prototype = {
   get nodeValue() { return this._nodeValue;},
   set nodeValue(value) { this._nodeValue = value},
   get data()   { return this._nodeValue;},
-  set data()   { throw new core.DOMException(NO_MODIFICATION_ALLOWED_ERR);},
+  set data(unused)   { throw new core.DOMException(NO_MODIFICATION_ALLOWED_ERR);},
   get attributes() { return null;}
 
 };
@@ -1235,7 +1235,7 @@ core.Document.prototype = {
     return null;
   },
   get nodeValue() { return null; },
-  set nodeValue() { /* noop */ },
+  set nodeValue(unused) { /* noop */ },
   get attributes() { return null;},
   get ownerDocument() { return null;},
   get readonly() { return this._readonly;},
@@ -1700,7 +1700,7 @@ core.DocumentType = function DocumentType(document, name, entities, notations, a
 core.DocumentType.prototype = {
   nodeType : DOCUMENT_TYPE_NODE,
   get nodeValue() { return null;},
-  set nodeValue() { /* do nothing */ },
+  set nodeValue(unused) { /* do nothing */ },
   get name() { return this._name;},
   get entities() { return this._entities;},
   get notations() { return this._notations;},
@@ -1723,7 +1723,7 @@ core.Notation.prototype = {
   get systemId() { return this._systemId;},
   get name() { return this._name || this._nodeName;},
   get attributes() { /* as per spec */ return null;},
-  set nodeValue() { /* intentionally left blank */ },
+  set nodeValue(unused) { /* intentionally left blank */ },
   get nodeValue() { return this._nodeValue;},
 };
 core.Notation.prototype.__proto__ = core.Node.prototype;
@@ -1742,7 +1742,7 @@ core.Entity = function Entity(document, name) {
 core.Entity.prototype = {
   nodeType : ENTITY_NODE,
   get nodeValue() { return null;},
-  set nodeValue() {
+  set nodeValue(unused) {
     // readonly
     if (this._readonly === true) {
       // TODO: is this needed?
@@ -1774,7 +1774,7 @@ core.EntityReference = function EntityReference(document, entity) {
 core.EntityReference.prototype = {
   nodeType : ENTITY_REFERENCE_NODE,
   get nodeValue() { return (this._entity) ? this._entity.nodeValue : null;},
-  set nodeValue() {
+  set nodeValue(unused) {
     // readonly
     if (this._readonly === true) {
       // TODO: is this needed?

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -500,7 +500,7 @@ core.HTMLDocument.prototype = {
     return firstChild(this.documentElement, 'HEAD');
   },
 
-  set head() { /* noop */ },
+  set head(unused) { /* noop */ },
 
   get body() {
     var body = firstChild(this.documentElement, 'BODY');


### PR DESCRIPTION
- ECMAScript ExpectedArgumentCount for a setter is always 1

Change motivated by failure of JS parser used by browserify:
Error: Parsing file /home/krose/.nave/installed/0.10.5/lib/node_modules/jsdom/lib/jsdom/level2/html.js: Line 503: Unexpected token )

I've since decided that browserify is hopeless, but it can't hurt to be standards-compliant as much as possible.
