### PR TITLE
Implemented a handler for htmlparser2

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -28,7 +28,7 @@ function HtmlToDom(parser) {
         },
         onattribute: function(name, value){
           try {
-            currentElement.setAttribute(name, HTMLDecode(value));
+            currentElement.setAttribute(name, value);
           } catch(e) { /* noop */ }
         },
         onclosetag: function(name){
@@ -48,9 +48,6 @@ function HtmlToDom(parser) {
         },
         ontext: function(text){
           var parent = currentElement._ownerDocument || currentElement;
-          if (!/^(?:script|style)$/i.test(currentElement.nodeName)) {
-            text = HTMLDecode(text);
-          }
           if(currentElement.lastChild && currentElement.lastChild.nodeType === 3){
             currentElement.lastChild.data += text;
           } else {
@@ -64,7 +61,7 @@ function HtmlToDom(parser) {
           currentElement.appendChild(commentNode);
           currentElement = commentNode;
         }
-      }, { lowerCaseTags: true, lowerCaseAttributeNames: true });
+      }, { lowerCaseTags: true, lowerCaseAttributeNames: true, decodeEntities: true });
       
       instance.end(html);
       


### PR DESCRIPTION
The big advantage of this change is that we'll only create a DOM tree once, with a lower memory footprint and a general performance improvement.

There is one breaking change: Previously, all children of a node that raised an error were skipped - now, the parser is `.pause()`d to avoid further events (ie. the rest of the document is skipped).

The Sizzle tests fail for some reason I haven't figured out yet. I'd appreciate any help tracking the issues down.
