### PR TITLE
Detect url or html based on URL.parse #622

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -265,13 +265,12 @@ exports.env = exports.jsdom.env = function() {
 
   config.html += '';
 
-  // Handle markup
-  if (config.html.indexOf("\n") > 0 || config.html.match(/^\W*</)) {
+  var url = URL.parse(config.html);
+  if (!url.protocol) {
+    // Handle markup
     processHTML(null, config.html);
-
-  // Handle url/file
   } else {
-    var url = URL.parse(config.html);
+    // Handle url/file
     config.url = config.url || url.href;
     if (url.hostname) {
       request({

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -105,6 +105,18 @@ exports.tests = {
     });
   },
 
+  env_with_bad_html: function (test) {
+    var html = "some poorly<div>formed<b>html</div> fragment";
+    jsdom.env({
+      html: html,
+      done: function (errors, window) {
+        test.equal(errors, null, 'errors should be null');
+        test.notEqual(window && window.location || null, null, 'window.location should not be null');
+        test.done()
+      }
+    })
+  },
+
   env_with_overridden_url : function(test) {
     var html = "<html><body><p>hello world!</p></body></html>";
     jsdom.env({


### PR DESCRIPTION
Address edge cases in URL vs HTML detection in  config.html parameter.
Added test case showing html fragment which was previously incorrectly
detected as a URL, which was throwing errors.
