### PR TITLE
fix css selector parsing with quoted commas

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -109,6 +109,7 @@ exports.windowAugmentation = function(dom, options) {
  */
 exports.createWindow = function(dom, options) {
   var timers = [];
+  var cssSelectorSplitRE = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
 
   function startTimer(startFn, stopFn, callback, ms) {
 	  var res = startFn(callback, ms);
@@ -251,10 +252,10 @@ exports.createWindow = function(dom, options) {
           return;
         }
 
-        var selectors = rule.selectorText.split(/\s*,\s*/);
+        var selectors = rule.selectorText.split(cssSelectorSplitRE);
         var matched = false;
         selectors.forEach(function (selectorText) {
-          if (!matched && matchesDontThrow(node, selectorText)) {
+          if (selectorText !== '' && selectorText !== ',' && !matched && matchesDontThrow(node, selectorText)) {
             matched = true;
             forEach.call(rule.style, function (property) {
               cs.setProperty(property, rule.style.getPropertyValue(property), rule.style.getPropertyPriority(property));

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -165,6 +165,27 @@ exports.tests = {
     });
   },
 
+  getComputedStyleFromEmbeddedSheet3: function(test) {
+    // use grouping with embedded quotes and commas, see https://github.com/tmpvar/jsdom/pull/541#issuecomment-18114747
+    jsdom.env(
+        '<html><head><style>#id1 .clazz, button[onclick="ga(this, event)"], #id2 .clazz { margin-left: 100px; }</style></head><body>'
+            + '<div id="id1"><p class="clazz"></p></div>'
+            + '<div id="id2"><p class="clazz"></p></div>'
+            + '<button onclick="ga(this, event)">analytics button</button>'
+            + '</body></html>',
+        jsdom.level('2', 'html'), function(err, win) {
+          var doc = win.document;
+          var p = doc.getElementsByTagName("p")[1];
+          var cs = win.getComputedStyle(p);
+          test.equal(cs.marginLeft, "100px", "computed marginLeft of p[1] is 100px");
+
+          var button = doc.getElementsByTagName("button")[0];
+          cs = win.getComputedStyle(button);
+          test.equal(cs.marginLeft, "100px", "computed marginLeft of button[0] is 100px");
+          test.done();
+    });
+  },
+
   ensureExternalStylesheetsAreLoadable : function(test) {
     var css = "body { border: 1px solid #f0f; }";
     var server = http.createServer(function(req, res) {


### PR DESCRIPTION
Used a better regular expression, also I put the regular expression outside of the getComputedStyle() function to the enclosing createWindow() so that it only gets compiled once (per window in this case). Added a test case for it using the supplied example from @espretto in #541
