### PR TITLE
Fix for elements with no style attribute

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -243,7 +243,7 @@ exports.createWindow = function(dom, options) {
       this.dispose();
     },
     getComputedStyle: function(node) {
-      var s = node.style,
+      var s = node.style || {},
           cs = new CSSStyleDeclaration(),
           forEach = Array.prototype.forEach;
 


### PR DESCRIPTION
I've got the following error:

```
TypeError: Array.prototype.forEach called on null or undefined
    at forEach (native)
    at exports.createWindow.DOMWindow.getComputedStyle (/Users/Stefan/Developer/Projects/Github/fabric.js/node_modules/jsdom/lib/jsdom/browser/index.js:279:15)
```

This is the code to initialize document and window elements under node:

```
fabric.document = require("jsdom").jsdom("<!DOCTYPE html><html><head></head><body></body></html>");
fabric.window = fabric.document.createWindow();
```

If i run this code i've got the above error:

```
var element = fabric.document.createElement('canvas');
var style = fabric.document.defaultView.getComputedStyle(element, null);
```

In the browser does this work.
