### PR TITLE
window: Mention the name of the global/property that isn't implemented in the error message

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -47,11 +47,11 @@ try {
   };
 }
 
-function NOT_IMPLEMENTED(target) {
+function NOT_IMPLEMENTED(target, nameForErrorMessage) {
   return function() {
     if (!jsdom.debugMode) {
       var raise = target ? target.raise : this.raise;
-      raise.call(this, 'error', 'NOT IMPLEMENTED');
+      raise.call(this, 'error', 'NOT IMPLEMENTED' + (nameForErrorMessage ? ': ' + nameForErrorMessage : ''));
     }
   };
 }
@@ -140,8 +140,8 @@ exports.createWindow = function(dom, options) {
   function DOMWindow(options) {
     var href = (options || {}).url || 'file://' + __filename;
     this.location = URL.parse(href);
-    this.location.reload = NOT_IMPLEMENTED(this);
-    this.location.replace = NOT_IMPLEMENTED(this);
+    this.location.reload = NOT_IMPLEMENTED(this, 'location.reload');
+    this.location.replace = NOT_IMPLEMENTED(this, 'location.replace');
     this.location.toString = function() {
       return href;
     };
@@ -311,26 +311,26 @@ exports.createWindow = function(dom, options) {
     scrollY: 0,
     scrollTop: 0,
     scrollLeft: 0,
-    alert: NOT_IMPLEMENTED(),
-    blur: NOT_IMPLEMENTED(),
-    confirm: NOT_IMPLEMENTED(),
-    createPopup: NOT_IMPLEMENTED(),
-    focus: NOT_IMPLEMENTED(),
-    moveBy: NOT_IMPLEMENTED(),
-    moveTo: NOT_IMPLEMENTED(),
-    open: NOT_IMPLEMENTED(),
-    print: NOT_IMPLEMENTED(),
-    prompt: NOT_IMPLEMENTED(),
-    resizeBy: NOT_IMPLEMENTED(),
-    resizeTo: NOT_IMPLEMENTED(),
-    scroll: NOT_IMPLEMENTED(),
-    scrollBy: NOT_IMPLEMENTED(),
-    scrollTo: NOT_IMPLEMENTED(),
+    alert: NOT_IMPLEMENTED(null, 'window.alert'),
+    blur: NOT_IMPLEMENTED(null, 'window.blur'),
+    confirm: NOT_IMPLEMENTED(null, 'window.confirm'),
+    createPopup: NOT_IMPLEMENTED(null, 'window.createPopup'),
+    focus: NOT_IMPLEMENTED(null, 'window.focus'),
+    moveBy: NOT_IMPLEMENTED(null, 'window.moveBy'),
+    moveTo: NOT_IMPLEMENTED(null, 'window.moveTo'),
+    open: NOT_IMPLEMENTED(null, 'window.open'),
+    print: NOT_IMPLEMENTED(null, 'window.print'),
+    prompt: NOT_IMPLEMENTED(null, 'window.prompt'),
+    resizeBy: NOT_IMPLEMENTED(null, 'window.resizeBy'),
+    resizeTo: NOT_IMPLEMENTED(null, 'window.resizeTo'),
+    scroll: NOT_IMPLEMENTED(null, 'window.scroll'),
+    scrollBy: NOT_IMPLEMENTED(null, 'window.scrollBy'),
+    scrollTo: NOT_IMPLEMENTED(null, 'window.scrollTo'),
     screen : {
       width : 0,
       height : 0
     },
-    Image : NOT_IMPLEMENTED()
+    Image : NOT_IMPLEMENTED(null, 'window.Image')
   };
 
   var window = new DOMWindow(options);


### PR DESCRIPTION
I just had a debugging session where I couldn't figure out which `window` property wasn't implemented because I just got `NOT IMPLEMENTED` and no usable stack trace. This patch helped me track it down -- turns the culprit was `window.alert` :)
