### PR TITLE
Rewrite how `jsdom.env` handles config vs. strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ see: [mailing list](http://groups.google.com/group/jsdom)
 
 Bootstrapping a DOM is generally a difficult process involving many error prone steps. We didn't want jsdom to fall into the same trap and that is why a new method, `jsdom.env()`, has been added in jsdom 0.2.0 which should make everyone's lives easier.
 
-with URL
+You can use it with a URL
 
 ```js
-// Count all of the links from the nodejs build page
+// Count all of the links from the Node.js build page
 var jsdom = require("jsdom");
 
 jsdom.env(
@@ -42,7 +42,7 @@ var jsdom = require("jsdom");
 jsdom.env(
   '<p><a class="the-link" href="https://github.com/tmpvar/jsdom">jsdom\'s Homepage</a></p>',
   ["http://code.jquery.com/jquery.js"],
-  function(errors, window) {
+  function (errors, window) {
     console.log("contents of a.the-link:", window.$("a.the-link").text());
   }
 );
@@ -55,7 +55,7 @@ or with a configuration object
 var jsdom = require("jsdom");
 
 jsdom.env({
-  html: "http://news.ycombinator.com/",
+  url: "http://news.ycombinator.com/",
   scripts: ["http://code.jquery.com/jquery.js"],
   done: function (errors, window) {
     var $ = window.$;
@@ -73,15 +73,15 @@ or with raw JavaScript source
 // Print all of the news items on hackernews
 var jsdom = require("jsdom");
 var fs = require("fs");
-var jquery = fs.readFileSync("./jquery.js").toString();
+var jquery = fs.readFileSync("./jquery.js", "utf-8");
 
 jsdom.env({
-  html: "http://news.ycombinator.com/",
+  url: "http://news.ycombinator.com/",
   src: [jquery],
   done: function (errors, window) {
     var $ = window.$;
     console.log("HN Links");
-    $("td.title:not(:last) a").each(function() {
+    $("td.title:not(:last) a").each(function () {
       console.log(" -", $(this).text());
     });
   }
@@ -92,17 +92,19 @@ jsdom.env({
 `jsdom.env` is built for ease of use, which is rare in the world of the DOM! Since the web has some absolutely horrible JavaScript on it, as of jsdom 0.2.0 `jsdom.env` will not process external resources (scripts, images, etc).  If you want to process the JavaScript use one of the methods below (`jsdom.jsdom` or `jsdom.jQueryify`)
 
 ```js
-jsdom.env(html, [scripts], [config], callback);
+jsdom.env(string, [scripts], [config], callback);
 ```
 
-- `html` (**required**): may be a URL, HTML fragment, or file.
-- `scripts` (**optional**): may contain files or URLs.
-- `config` (**optional**): see below.
-- `callback` (**required**): takes two arguments:
-  - `errors`: an array of errors
-  - `window`: a brand new window
+The arguments are:
 
-_example:_
+- `string`: may be a URL, file name, or HTML fragment
+- `scripts`: a string or array of strings, containing file names or URLs that will be inserted as `<script>` tags
+- `config`: see below
+- `callback`: takes two arguments
+  - `error`: either an `Error` object if something failed initializing the window, or an array of error messages from the DOM if there were script errors
+  - `window`: a brand new `window`
+
+_Example:_
 
 ```js
 jsdom.env(html, function (errors, window) {
@@ -117,15 +119,18 @@ If you would like to specify a configuration object only:
 jsdom.env(config);
 ```
 
-- `config.html`: see `html` above.
+- `config.html`: a HTML fragment
+- `config.file`: a file which jsdom will load HTML from; the resulting window's `location.href` will be a `file://` URL.
+- `config.url`: sets the resulting window's `location.href`; if `config.html` and `config.file` are not provided, jsdom will load HTML from this URL.
 - `config.scripts`: see `scripts` above.
-- `config.url`: the URL for `location.href` if `config.html` is not a file path or URL. (Relative `<a href>` and `<img src>` values are evaluated relative to this.)
 - `config.src`: an array of JavaScript strings that will be evaluated against the resulting document. Similar to `scripts`, but it accepts JavaScript instead of paths/URLs.
 - `config.done`: see `callback` above.
 - `config.document`:
   - `referer`: the new document will have this referer
   - `cookie`: manually set a cookie value, e.g. `'key=value; expires=Wed, Sep 21 2011 12:00:00 GMT; path=/'`
 - `config.features` : see `Flexibility` section below. **Note**: the default feature set for jsdom.env does _not_ include fetching remote JavaScript and executing it. This is something that you will need to **carefully** enable yourself.
+
+Note that `config.done` is required, as is one of `config.html`, `config.file`, or `config.url`.
 
 ## For the hardcore
 

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -1,14 +1,17 @@
-var dom      = exports.dom = require("./jsdom/level3/index").dom,
-    features = require('./jsdom/browser/documentfeatures'),
-    fs       = require("fs"),
-    pkg      = JSON.parse(fs.readFileSync(__dirname + "/../package.json")),
-    request  = require('request'),
-    URL      = require('url');
+var fs = require('fs');
+var path = require('path');
+var URL = require('url');
+var request = require('request');
+var pkg = require('../package.json');
 
 var style = require('./jsdom/level2/style');
+var features = require('./jsdom/browser/documentfeatures');
+var dom = exports.dom = require('./jsdom/level3/index').dom;
+var createWindow = exports.createWindow = require('./jsdom/browser/index').createWindow;
+
 exports.defaultLevel = dom.level3.html;
-exports.browserAugmentation = require("./jsdom/browser/index").browserAugmentation;
-exports.windowAugmentation = require("./jsdom/browser/index").windowAugmentation;
+exports.browserAugmentation = require('./jsdom/browser/index').browserAugmentation;
+exports.windowAugmentation = require('./jsdom/browser/index').windowAugmentation;
 
 // Proxy feature functions to features module.
 ['availableDocumentFeatures',
@@ -23,8 +26,6 @@ exports.windowAugmentation = require("./jsdom/browser/index").windowAugmentation
 });
 
 exports.debugMode = false;
-
-var createWindow = exports.createWindow = require("./jsdom/browser/index").createWindow;
 
 exports.__defineGetter__('version', function() {
   return pkg.version;
@@ -41,7 +42,7 @@ exports.level = function (level, feature) {
 exports.jsdom = function (html, level, options) {
 
   options = options || {};
-  if(typeof level == "string") {
+  if(typeof level == 'string') {
     level = exports.level(level, 'html');
   } else {
     level   = level || exports.defaultLevel;
@@ -63,7 +64,7 @@ exports.jsdom = function (html, level, options) {
                  new browser.HTMLDocument(options) :
                  new browser.Document(options);
 
-  require("./jsdom/selectors/index").applyQuerySelector(doc, level);
+  require('./jsdom/selectors/index').applyQuerySelector(doc, level);
 
   features.applyDocumentFeatures(doc, options.features);
 
@@ -116,8 +117,8 @@ exports.jQueryify = exports.jsdom.jQueryify = function (window /* path [optional
   var args = Array.prototype.slice.call(arguments),
       callback = (typeof(args[args.length - 1]) === 'function') && args.pop(),
       path,
-      jQueryTag = window.document.createElement("script");
-      jQueryTag.className = "jsdom";
+      jQueryTag = window.document.createElement('script');
+      jQueryTag.className = 'jsdom';
 
   if (args.length > 1 && typeof(args[1] === 'string')) {
     path = args[1];
@@ -127,7 +128,7 @@ exports.jQueryify = exports.jsdom.jQueryify = function (window /* path [optional
 
   window.document.implementation.addFeature('FetchExternalResources', ['script']);
   window.document.implementation.addFeature('ProcessExternalResources', ['script']);
-  window.document.implementation.addFeature('MutationEvents', ["2.0"]);
+  window.document.implementation.addFeature('MutationEvents', ['2.0']);
   jQueryTag.src = path || 'http://code.jquery.com/jquery-latest.js';
   window.document.body.appendChild(jQueryTag);
 
@@ -143,228 +144,230 @@ exports.jQueryify = exports.jsdom.jQueryify = function (window /* path [optional
 };
 
 
-exports.env = exports.jsdom.env = function() {
-  var
-  args        = Array.prototype.slice.call(arguments),
-  config      = exports.env.processArguments(args),
-  callback    = config.done,
-  processHTML = function(err, html, url) {
+exports.env = exports.jsdom.env = function () {
+  var config = getConfigFromArguments(arguments);
+  var callback = config.done;
 
-    html += '';
-    if(err) {
-      return callback(err);
-    }
-
-    config.scripts = config.scripts || [];
-    if (typeof config.scripts === 'string') {
-      config.scripts = [config.scripts];
-    }
-
-    config.src = config.src || [];
-    if (typeof config.src === 'string') {
-      config.src = [config.src];
-    }
-
-    var
-    options    = {
-      features: config.features || {
-        'FetchExternalResources' : false,
-        'ProcessExternalResources' : false,
-        'SkipExternalResources' : false
-      },
-      url: url || config.url,
-      parser: config.parser
-    },
-    window     = exports.html(html, null, options).createWindow(),
-    features   = JSON.parse(JSON.stringify(window.document.implementation._features)),
-    docsLoaded = 0,
-    totalDocs  = config.scripts.length + config.src.length,
-    readyState = null,
-    errors     = null;
-
-    if (!window || !window.document) {
-      return callback(new Error('JSDOM: a window object could not be created.'));
-    }
-
-    if( config.document ) {
-      window.document._referrer = config.document.referrer;
-      window.document._cookie = config.document.cookie;
-    }
-
-    window.document.implementation.addFeature('FetchExternalResources', ['script']);
-    window.document.implementation.addFeature('ProcessExternalResources', ['script']);
-    window.document.implementation.addFeature('MutationEvents', ['2.0']);
-
-    var scriptComplete = function() {
-      docsLoaded++;
-      if (docsLoaded >= totalDocs) {
-        window.document.implementation._features = features;
-
-        if (errors) {
-          errors = errors.concat(window.document.errors || []);
-        }
-
-        process.nextTick(function() { callback(errors, window); });
+  if (config.file) {
+    fs.readFile(config.file, 'utf-8', function (err, text) {
+      if (err) {
+        return callback(err);
       }
-    }
 
-    if (config.scripts.length > 0 || config.src.length > 0) {
-      config.scripts.forEach(function(src) {
-        var script = window.document.createElement('script');
-        script.className = "jsdom";
-        script.onload = function() {
-          scriptComplete()
-        };
-
-        script.onerror = function(e) {
-          if (!errors) {
-            errors = [];
+      config.html = text;
+      processHTML(config);
+    });
+  } else if (config.html) {
+    processHTML(config);
+  } else if (config.url) {
+    handleUrl(config);
+  } else if (config.somethingToAutodetect) {
+    var url = URL.parse(config.somethingToAutodetect);
+    if (url.protocol && url.hostname) {
+      config.url = config.somethingToAutodetect;
+      handleUrl(config.somethingToAutodetect);
+    } else {
+      fs.readFile(config.somethingToAutodetect, 'utf-8', function (err, text) {
+        if (err) {
+          if (err.code === 'ENOENT') {
+            config.html = config.somethingToAutodetect;
+            processHTML(config);
+          } else {
+            callback(err);
           }
-          errors.push(e.error);
-          scriptComplete();
-        };
-
-        script.src = src;
-        try {
-          // protect against invalid dom
-          // ex: http://www.google.com/foo#bar
-          window.document.documentElement.appendChild(script);
-        } catch(e) {
-          if(!errors) {
-            errors=[];
-          }
-          errors.push(e.error || e.message);
-          scriptComplete();
+        } else {
+          config.html = text;
+          config.url = toFileUrl(config.somethingToAutodetect);
+          processHTML(config);
         }
       });
-
-      config.src.forEach(function(src) {
-        var script = window.document.createElement('script');
-        script.onload = function() {
-          process.nextTick(scriptComplete);
-        };
-
-        script.onerror = function(e) {
-          if (!errors) {
-            errors = [];
-          }
-          errors.push(e.error || e.message);
-          // nextTick so that an exception within scriptComplete won't cause
-          // another script onerror (which would be an infinite loop)
-          process.nextTick(scriptComplete);
-        };
-
-        script.text = src;
-        window.document.documentElement.appendChild(script);
-        window.document.documentElement.removeChild(script);
-      });
-    } else {
-      scriptComplete();
     }
-  };
+  }
 
-  config.html += '';
+  function handleUrl() {
+    var options = {
+      uri: config.url,
+      encoding: config.encoding || 'utf8',
+      headers: config.headers || {},
+      proxy: config.proxy || null
+    };
 
-  var url = URL.parse(config.html);
-  if (!url.protocol) {
-    // Handle markup
-    processHTML(null, config.html);
-  } else {
-    // Handle url/file
-    config.url = config.url || url.href;
-    if (url.hostname) {
-      request({
-        uri      : url,
-        encoding : config.encoding || 'utf8',
-        headers  : config.headers || {},
-        proxy    : config.proxy || null
-      },
-      function(err, request, body) {
-        processHTML(err, body, request.request.uri.href);
-      });
-    } else {
-      fs.readFile(config.html, processHTML);
-    }
+    request(options, function (err, res, responseText) {
+      if (err) {
+        return callback(err);
+      }
+
+      // The use of `res.request.uri.href` ensures that `window.location.href`
+      // is updated when `request` follows redirects.
+      config.html = responseText;
+      config.url = res.request.uri.href;
+      processHTML(config);
+    });
   }
 };
 
-/*
-  Since jsdom.env() is a helper for quickly and easily setting up a
-  window with scripts and such already loaded into it, the arguments
-  should be fairly flexible.  Here are the requirements
+function processHTML(config) {
+  var callback = config.done;
+  var options = {
+    features: config.features,
+    url: config.url,
+    parser: config.parser
+  };
 
-  1) collect `html` (url, string, or file on disk)  (STRING)
-  2) load `code` into the window (array of scripts) (ARRAY)
-  3) callback when resources are `done`             (FUNCTION)
-  4) configuration                                  (OBJECT)
+  var window = exports.html(config.html, null, options).createWindow();
+  var features = JSON.parse(JSON.stringify(window.document.implementation._features));
 
-  Rules:
-  + if there is one argument it had better be an object with atleast
-    a `html` and `done` property (other properties are gravy)
+  var docsLoaded = 0;
+  var totalDocs = config.scripts.length + config.src.length;
+  var readyState = null;
+  var errors = null;
 
-  + arguments above are pulled out of the arguments and put into the
-    config object that is returned
-*/
-exports.env.processArguments = function(args) {
-  if (!args || !args.length || args.length < 1) {
-    throw new Error('No arguments passed to jsdom.env().');
+  if (!window || !window.document) {
+    return callback(new Error('JSDOM: a window object could not be created.'));
   }
 
-  var
-  props = {
-    'html'    : true,
-    'done'    : true,
-    'scripts' : false,
-    'config'  : false,
-    'url'     : false,  // the URL for location.href if different from html
-    'document': false,  // HTMLDocument properties
-    'features': false,  // allow for features to be specified
-    'parser'  : false
-  },
-  propKeys = Object.keys(props),
-  config = {
-    code : []
-  },
-  l    = args.length
-  ;
-  if (l === 1) {
-    config = args[0];
-  } else {
-    args.forEach(function(v) {
-      var type = typeof v;
-      if (!v) {
-        return;
+  if (config.document) {
+    window.document._referrer = config.document.referrer;
+    window.document._cookie = config.document.cookie;
+  }
+
+  window.document.implementation.addFeature('FetchExternalResources', ['script']);
+  window.document.implementation.addFeature('ProcessExternalResources', ['script']);
+  window.document.implementation.addFeature('MutationEvents', ['2.0']);
+
+  function scriptComplete() {
+    docsLoaded++;
+
+    if (docsLoaded >= totalDocs) {
+      window.document.implementation._features = features;
+
+      if (errors) {
+        errors = errors.concat(window.document.errors || []);
       }
-      if (type === 'string' || v + '' === v) {
-        config.html = v;
-      } else if (type === 'object') {
-        // Array
-        if (v.length && v[0]) {
-          config.scripts = v;
-        } else {
-          // apply missing required properties if appropriate
-          propKeys.forEach(function(req) {
 
-            if (typeof v[req] !== 'undefined' &&
-                typeof config[req] === 'undefined') {
+      process.nextTick(function() {
+        callback(errors, window);
+      });
+    }
+  }
 
-              config[req] = v[req];
-              delete v[req];
-            }
-          });
-          config.config = v;
-        }
-      } else if (type === 'function') {
-        config.done = v;
+  function handleScriptError(e) {
+    if (!errors) {
+      errors = [];
+    }
+    errors.push(e.error || e.message);
+
+    // nextTick so that an exception within scriptComplete won't cause
+    // another script onerror (which would be an infinite loop)
+    process.nextTick(scriptComplete);
+  }
+
+  if (config.scripts.length > 0 || config.src.length > 0) {
+    config.scripts.forEach(function (scriptSrc) {
+      var script = window.document.createElement('script');
+      script.className = 'jsdom';
+      script.onload = scriptComplete;
+      script.onerror = handleScriptError;
+      script.src = scriptSrc;
+
+      try {
+        // protect against invalid dom
+        // ex: http://www.google.com/foo#bar
+        window.document.documentElement.appendChild(script);
+      } catch (e) {
+        handleScriptError(e);
+      }
+    });
+
+    config.src.forEach(function (scriptText) {
+      var script = window.document.createElement('script');
+      script.onload = scriptComplete;
+      script.onerror = handleScriptError;
+      script.text = scriptText;
+
+      window.document.documentElement.appendChild(script);
+      window.document.documentElement.removeChild(script);
+    });
+  } else {
+    scriptComplete();
+  }
+}
+
+function getConfigFromArguments(args, callback) {
+  var config = {};
+  if (typeof args[0] === 'object') {
+    var configToClone = args[0];
+    Object.keys(configToClone).forEach(function (key) {
+      config[key] = configToClone[key];
+    });
+  } else {
+    var stringToAutodetect = null;
+
+    Array.prototype.forEach.call(args, function (arg) {
+      switch (typeof arg) {
+        case 'string':
+          config.somethingToAutodetect = arg;
+          break;
+        case 'function':
+          config.done = arg;
+          break;
+        case 'object':
+          if (Array.isArray(arg)) {
+            config.scripts = arg;
+          } else {
+            extend(config, arg);
+          }
+          break;
       }
     });
   }
 
-  propKeys.forEach(function(req) {
-    var required = props[req];
-    if (required && typeof config[req] === 'undefined') {
-      throw new Error("jsdom.env requires a '" + req + "' argument");
-    }
-  });
+  if (!config.done) {
+    throw new Error('Must pass a "done" option or a callback to jsdom.env.');
+  }
+
+  if (!config.somethingToAutodetect && !config.html && !config.file && !config.url) {
+    throw new Error('Must pass a "html", "file", or "url" option, or a string, to jsdom.env');
+  }
+
+  config.scripts = ensureArray(config.scripts);
+  config.src = ensureArray(config.src);
+
+  config.features = config.features || {
+    FetchExternalResources: false,
+    ProcessExternalResources: false,
+    SkipExternalResources: false
+  };
+
+  if (!config.url && config.file) {
+    config.url = toFileUrl(config.file);
+  }
+
   return config;
-};
+}
+
+function ensureArray(value) {
+  var array = value || [];
+  if (typeof array === 'string') {
+    array = [array];
+  }
+  return array;
+}
+
+function extend(config, overrides) {
+  Object.keys(overrides).forEach(function (key) {
+    config[key] = overrides[key];
+  });
+}
+
+function toFileUrl(fileName) {
+  // Beyond just the `path.resolve`, this is mostly for the benefit of Windows,
+  // where we need to convert '\' to '/' and add an extra '/' prefix before the
+  // drive letter.
+  var pathname = path.resolve(process.cwd(), fileName).replace(/\\/g, '/');
+  if (pathname[0] !== '/') {
+    pathname = '/' + pathname;
+  }
+
+  return 'file://' + pathname;
+}

--- a/test/jsdom/env.js
+++ b/test/jsdom/env.js
@@ -1,0 +1,193 @@
+"use strict";
+
+var env = require("../..").env;
+var path = require("path");
+var http = require("http");
+var fs = require("fs");
+var toFileUrl = require("../util").toFileUrl(__dirname);
+
+exports["explicit config.html, full document"] = function (t) {
+  env({
+    html: "<!DOCTYPE html><html><head><title>Hi</title></head><body>Hello</body></html>",
+    url: "http://example.com/",
+    done: function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, "<html><head><title>Hi</title></head><body>Hello</body></html>");
+      t.equal(window.location.href, "http://example.com/");
+      t.done();
+    }
+  });
+};
+
+exports["explicit config.html, just a string"] = function (t) {
+  env({
+    html: "Hello",
+    url: "http://example.com/",
+    done: function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, "<html><body>Hello</body></html>");
+      t.equal(window.location.href, "http://example.com/");
+      t.done();
+    }
+  });
+};
+
+exports["explicit config.html, a string that is also a valid URL"] = function (t) {
+  env({
+    html: "http://example.com/",
+    url: "http://example.com/",
+    done: function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, "<html><body>http://example.com/</body></html>");
+      t.equal(window.location.href, "http://example.com/");
+      t.done();
+    }
+  });
+};
+
+exports["explicit config.html, a string that is also a valid file"] = function (t) {
+  var body = path.resolve(__dirname, "files/env.html");
+  env({
+    html: body,
+    url: "http://example.com/",
+    done: function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, "<html><body>" + body + "</body></html>");
+      t.equal(window.location.href, "http://example.com/");
+      t.done();
+    }
+  });
+};
+
+exports["explicit config.url, valid"] = function (t) {
+  var html = "<html><head><title>Example URL</title></head><body>Example!</body></html>";
+  var responseText = "<!DOCTYPE html>" + html;
+
+  var server = http.createServer(function (req, res) {
+    res.writeHead(200, { "Content-Length": responseText.length });
+    res.end(responseText);
+    server.close();
+  }).listen(8976);
+
+  env({
+    url: "http://localhost:8976/",
+    done: function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, html);
+      t.equal(window.location.href, "http://localhost:8976/");
+      t.done();
+    }
+  });
+};
+
+exports["explicit config.url, invalid"] = function (t) {
+  env({
+    url: "http://localhost:8976",
+    done: function (err, window) {
+      t.ok(err, 'an error should exist');
+      t.strictEqual(window, undefined, 'window should not exist');
+      t.done();
+    }
+  });
+};
+
+exports["explicit config.file, valid"] = function (t) {
+  var fileName = path.resolve(__dirname, "files/env.html");
+
+  fs.readFile(fileName, 'utf-8', function (err, text) {
+    t.ifError(err);
+    env({
+      file: fileName,
+      done: function (err, window) {
+        t.ifError(err);
+        t.equal(window.document.doctype + window.document.innerHTML, text);
+        t.equal(window.location.href, toFileUrl(fileName));
+        t.done();
+      }
+    });
+  });
+};
+
+exports["explicit config.file, invalid"] = function (t) {
+  env({
+    file: "__DOES_NOT_EXIST__",
+    done: function (err, window) {
+      t.ok(err, 'an error should exist');
+      t.strictEqual(window, undefined, 'window should not exist');
+      t.done();
+    }
+  });
+};
+
+exports["string, parseable as a URL, valid"] = function (t) {
+  var html = "<html><head><title>Example URL</title></head><body>Example!</body></html>";
+  var responseText = "<!DOCTYPE html>" + html;
+
+  var server = http.createServer(function (req, res) {
+    res.writeHead(200, { "Content-Length": responseText.length });
+    res.end(responseText);
+    server.close();
+  }).listen(8976);
+
+  env(
+    "http://localhost:8976/",
+    function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, html);
+      t.equal(window.location.href, "http://localhost:8976/");
+      t.done();
+    }
+  );
+};
+
+exports["string, parseable as a URL, invalid"] = function (t) {
+  env(
+    "http://localhost:8976",
+    function (err, window) {
+      t.ok(err, 'an error should exist');
+      t.strictEqual(window, undefined, 'window should not exist');
+      t.done();
+    }
+  );
+};
+
+exports["string, for an existing filename"] = function (t) {
+  var fileName = path.resolve(__dirname, "files/env.html");
+
+  fs.readFile(fileName, 'utf-8', function (err, text) {
+    t.ifError(err);
+    env(
+      fileName,
+      function (err, window) {
+        t.ifError(err);
+        t.equal(window.document.doctype + window.document.innerHTML, text);
+        t.equal(window.location.href, toFileUrl(fileName));
+        t.done();
+      }
+    );
+  });
+};
+
+exports["string, does not exist as a file"] = function (t) {
+  var body = "__DOES_NOT_EXIST__";
+
+  env(
+    body,
+    function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, "<html><body>" + body + "</body></html>");
+      t.done();
+    }
+  );
+};
+
+exports["string, full HTML document"] = function (t) {
+  env(
+    "<!DOCTYPE html><html><head><title>Hi</title></head><body>Hello</body></html>",
+    function (err, window) {
+      t.ifError(err);
+      t.equal(window.document.innerHTML, "<html><head><title>Hi</title></head><body>Hello</body></html>");
+      t.done();
+    }
+  );
+};

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -195,7 +195,7 @@ exports.tests = {
 
     var cb = function() {
       jsdom.env({
-        html: "http://127.0.0.1:64000/html",
+        url: "http://127.0.0.1:64000/html",
         scripts: "http://127.0.0.1:64000/js",
         done: function(errors, window) {
           server.close();
@@ -315,60 +315,14 @@ exports.tests = {
     })
   },
 
-  env_processArguments_invalid_args: function(test) {
-    test.throws(function(){ jsdom.env.processArguments(); });
-    test.throws(function(){ jsdom.env.processArguments({}); });
-    test.throws(function(){ jsdom.env.processArguments([{html: 'abc123'}]); });
-    test.throws(function(){ jsdom.env.processArguments([{done: function(){}}]); });
+  env_invalid_args: function(test) {
+    test.throws(function(){ jsdom.env(); });
+    test.throws(function(){ jsdom.env({}); });
+    test.throws(function(){ jsdom.env({ html: 'abc123' }); });
+    test.throws(function(){ jsdom.env({ done: function () {} }); });
     test.done();
   },
 
-  env_processArguments_config_object: function(test) {
-    var config = jsdom.env.processArguments([{html: "", done: function(){}}]);
-    test.notEqual(config.done, null, 'config.done should not be null');
-    test.notEqual(config.html, null, 'config.html should not be null');
-    test.done();
-  },
-
-  env_processArguments_object_and_callback: function(test) {
-    var config = jsdom.env.processArguments([{
-      html     : "",
-      scripts  : ['path/to/some.js', 'another/path/to.js'],
-      url      : 'http://www.example.com/',
-      document : {}
-    }, function(){}]);
-
-    test.notEqual(config.done, null,     'config.done should not be null');
-    test.notEqual(config.html, null,     'config.html should not be null');
-    test.notEqual(config.url,  null,     'config.url should not be null');
-    test.notEqual(config.document, null, 'config.document should not be null');
-    test.equal(config.scripts.length, 2, 'has code');
-    test.done();
-  },
-
-  env_processArguments_all_args_no_config: function(test) {
-    var config = jsdom.env.processArguments(["<html></html>", ['script.js'], function(){}]);
-    test.notEqual(config.done, null, 'config.done should not be null');
-    test.notEqual(config.html, null, 'config.html should not be null');
-    test.equal(config.scripts.length, 1, 'script length should be 1');
-    test.done();
-  },
-
-  env_processArguments_all_args_with_config: function(test) {
-    var config = jsdom.env.processArguments(
-      ["<html></html>",
-      ['script.js'],
-      {features: {}, url : 'http://www.example.com/'},
-      function(){}
-    ]);
-
-    test.notEqual(config.done, null, 'config.done should not be null');
-    test.notEqual(config.html, null, 'config.html should not be null');
-    test.equal(config.scripts.length, 1, 'script length should be 1');
-    test.equal(config.url, 'http://www.example.com/', 'has url');
-    test.notEqual(config.features, null, 'config.features should not be null');
-    test.done();
-  },
 
   env_handle_incomplete_dom_with_script: function(test) {
     jsdom.env(
@@ -1565,7 +1519,7 @@ exports.tests = {
 
     server.listen(80001, "127.0.0.1", function() {
       jsdom.env({
-        html: "http://127.0.0.1:80001",
+        url: "http://127.0.0.1:80001",
         done: function(errors, window) {
           server.close();
           if (errors) {

--- a/test/runner
+++ b/test/runner
@@ -91,6 +91,7 @@ var files = [
   "sizzle/index.js",
   "jsdom/index.js",
   "jsdom/parsing.js",
+  "jsdom/env.js",
   "jsonp/jsonp.js",
   "browser/contextifyReplacement.js",
   "browser/index.js"


### PR DESCRIPTION
This fixes #629 and fixes #554; see also #556, #562, #622, and #623.

However, it introduces a backward-incompatible change: `config.html` is no longer auto-detected, i.e. passing a URL or file name there will not work. Instead, `config.url`, `config.html`, and `config.file` are now explicit, whereas passing a string straight to `jsdom.env` triggers the autodetection logic. The autodetection logic has itself gotten smarter, now being based on first URL parsing (checking for both protocol and hostname on the resulting parsed URL), then on trying to read the file, and then if there's an ENOENT error reading the file, it finally puts the result in as HTML.

---

@tmpvar, any thoughts on whether this is acceptable backward-compatibility breaking for a 0.7 release? Also cc @jden, @donpark, @adamstallard, and @superjoe30 who have all been involved in this issue at one time or another.
