### PR TITLE
Parser should toggle `xmlMode` depending on what kind of document is being parsed

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -59,7 +59,7 @@ function HtmlToDom(parser) {
       parser.ParseHtml = function(rawHtml) {
         var handler = new parser.DefaultHandler();
         // Check if document is XML
-        var re = /^<\?\s?xml.*version=["']1\.0["'].*\s?\?>/i; 
+        var re = /^<\?\s*xml.*version=["']1\.0["'].*\s*\?>/i; 
         var isXML = re.test(rawHtml);
         var parserInstance = new parser.Parser(handler, { xmlMode: isXML });
 


### PR DESCRIPTION
- Added regex to test if the document is xml or not
- Updated comment which describes which html parser is being used
- Removed calls to force attributes to lowercase (in XML they should remain camelCase)

Here's my first stab at a solution to #651. I'm deferring the creation of the parser so there's a chance to check if the document is xml or not. If it's xml then we need to switch the parser to `xmlMode`.

Hopefully my regex isn't too ham-fisted. I'm not a regex pro by any means :\

Running `npm test` and it looks like everything continues to pass and the test suite runs in the same amount of time as `master`.

@domenic what do you think?
