### PR TITLE
Added a _createElementNoTagNameValidation function

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1221,7 +1221,7 @@ core.Document.prototype = {
   get readonly() { return this._readonly;},
 
   /* returns Element */
-  _createElementNoTagNameValidation: function(/*string*/ tagName){
+  _createElementNoTagNameValidation: function(/*string*/ tagName) {
     var lower = tagName.toLowerCase();
     var element = (this._elementBuilders[lower] || this._defaultElementBuilder)(this, tagName);
 


### PR DESCRIPTION
As discussed in #617.

There is one breaking change: Passing a non-string tag name to `createElement` won't throw a TypeError with the message `"Object #<Object> has no method 'toLowerCase'"`, but rather a core.DOMException telling about an invalid character. Browsers [seem](http://jsconsole.com/?document.createElement(true\)) to convert all inputs to strings, so this just changes one faulty behavior.
