### PR TITLE
Do not discard contents of TEMPLATE element

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -97,7 +97,7 @@ exports.makeHtmlGenerator = function makeHtmlGenerator(indentUnit, eol) {
   eol = eol || "";
 
   return function generateHtmlRecursive(node, rawText, curIndent) {
-    var ret = "", parent, current, i;
+    var ret = "", parent, current, i, childNodes;
     curIndent = curIndent || "";
     if (node) {
       if (node.nodeType &&
@@ -110,19 +110,25 @@ exports.makeHtmlGenerator = function makeHtmlGenerator(indentUnit, eol) {
       switch (node.nodeType) {
         case node.ELEMENT_NODE:
           current = exports.stringifyElement(node);
+          if (node.tagName === "TEMPLATE") {
+            childNodes = node.content._childNodes;
+            childNodesRawText = true;
+          } else {
+            childNodes = node._childNodes;
+          }
           if (childNodesRawText) {
             ret += curIndent + current.start;
           } else {
             ret += curIndent + current.start;
           }
-          if (node._childNodes.length > 0) {
-            if (node._childNodes[0].nodeType !== node.TEXT_NODE) {
+          if (childNodes.length > 0) {
+            if (childNodes[0].nodeType !== node.TEXT_NODE) {
               ret += eol;
             }
-            for (i=0; i<node._childNodes.length; i++) {
-              ret += generateHtmlRecursive(node._childNodes[i], childNodesRawText, curIndent + indentUnit);
+            for (i=0; i<childNodes.length; i++) {
+              ret += generateHtmlRecursive(childNodes[i], childNodesRawText, curIndent + indentUnit);
             }
-            if (node._childNodes[node._childNodes.length - 1].nodeType !== node.TEXT_NODE) {
+            if (childNodes[childNodes.length - 1].nodeType !== node.TEXT_NODE) {
               ret += curIndent;
             }
             ret += current.end + eol;


### PR DESCRIPTION
The current serialization approach will silently discard the contents of the `<template>` tag.

The contents of an `<template>` node should be considered _raw text_ in that their contents should remain untouched. However, the real children of a `<template>` are in the `content` attribute of the node and traversal should continue within that tree.
