### PR TITLE
Restore QuerySelector functions onto prototype.

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -65,7 +65,7 @@ exports.jsdom = function (html, level, options) {
                  new browser.HTMLDocument(options) :
                  new browser.Document(options);
 
-  require('./jsdom/selectors/index').applyQuerySelector(doc, level);
+  require('./jsdom/selectors/index').applyQuerySelectorPrototype(level);
 
   features.applyDocumentFeatures(doc, options.features);
 

--- a/lib/jsdom/selectors/index.js
+++ b/lib/jsdom/selectors/index.js
@@ -8,31 +8,24 @@ function addNwmatcher(document) {
   return document._nwmatcher;
 }
 
-exports.applyQuerySelector = function(doc, dom) {
-  doc.querySelector = function(selector) {
+exports.applyQuerySelectorPrototype = function(dom) {
+  dom.Document.prototype.querySelector = function(selector) {
     return addNwmatcher(this).first(selector, this);
   };
 
-  doc.querySelectorAll = function(selector) {
+  dom.Document.prototype.querySelectorAll = function(selector) {
     return new dom.NodeList(addNwmatcher(this).select(selector, this));
   };
 
-  var _createElement = doc.createElement;
-  doc.createElement = function() {
-      var element = _createElement.apply(this, arguments);
+  dom.Element.prototype.querySelector = function(selector) {
+    return addNwmatcher(this.ownerDocument).first(selector, this);
+  };
 
-      element.querySelector = function(selector) {
-        return addNwmatcher(this.ownerDocument).first(selector, this);
-      };
+  dom.Element.prototype.querySelectorAll = function(selector) {
+    return new dom.NodeList(addNwmatcher(this.ownerDocument).select(selector, this));
+  };
 
-      element.querySelectorAll = function(selector) {
-        return new dom.NodeList(addNwmatcher(this.ownerDocument).select(selector, this));
-      };
-
-      element.matchesSelector = function(selector) {
-        return addNwmatcher(this.ownerDocument).match(this, selector);
-      };
-
-      return element;
+  dom.Element.prototype.matchesSelector = function(selector) {
+    return addNwmatcher(this.ownerDocument).match(this, selector);
   };
 };


### PR DESCRIPTION
This largely reverts dc263d62e63038a947f633169d0c9d6c3aa69175, and is necessary so that when a custom parser is used (such as an HTML5-compliant parser), the returned elements still expose querySelector and querySelectorAll methods.
