### PR TITLE
Don't override/change Error.prototype globally

### DIFF
--- a/lib/jsdom/level3/xpath.js
+++ b/lib/jsdom/level3/xpath.js
@@ -1679,7 +1679,7 @@
     this.name = 'XPathException';
     this.code = code;
   }
-  XPathException.prototype = Error.prototype;
+  XPathException.prototype = Object.create(Error.prototype);
   XPathException.prototype.__proto__ = XPathException;
   XPathException.INVALID_EXPRESSION_ERR = 51;
   XPathException.TYPE_ERR = 52;


### PR DESCRIPTION
Currently, `Error.prototype` is changed globally. This breaks other parts of our app which which relay on prototype properties. jsdom should not do such changes. This pull request addresses this.

Related issue:

https://github.com/meteor/meteor/issues/849
