### PR TITLE
avoid repeated NodeList.length calculation [refs #694]

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -115,14 +115,15 @@ exports.makeHtmlGenerator = function makeHtmlGenerator(indentUnit, eol) {
           } else {
             ret += curIndent + current.start;
           }
-          if (node._childNodes.length > 0) {
+          var len = node._childNodes.length;
+          if (len > 0) {
             if (node._childNodes[0].nodeType !== node.TEXT_NODE) {
               ret += eol;
             }
-            for (i=0; i<node._childNodes.length; i++) {
+            for (i=0; i<len; i++) {
               ret += generateHtmlRecursive(node._childNodes[i], childNodesRawText, curIndent + indentUnit);
             }
-            if (node._childNodes[node._childNodes.length - 1].nodeType !== node.TEXT_NODE) {
+            if (node._childNodes[len - 1].nodeType !== node.TEXT_NODE) {
               ret += curIndent;
             }
             ret += current.end + eol;

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -529,8 +529,8 @@ core.Node.prototype = {
 
     // fragments are merged into the element
     if (newChild.nodeType === DOCUMENT_FRAGMENT_NODE) {
-      var tmpNode;
-      while (newChild._childNodes.length > 0) {
+      var tmpNode, i = newChild._childNodes.length;
+      while (i-- > 0) {
         tmpNode = newChild.removeChild(newChild.firstChild);
         this.insertBefore(tmpNode, refChild);
       }
@@ -630,7 +630,7 @@ core.Node.prototype = {
     if (this.id) {
       attachId(this.id,this,this._ownerDocument);
     }
-    for (var i=0;i<this._childNodes.length;i++) {
+    for (var i=0,len=this._childNodes.length;i<len;i++) {
       if (this._childNodes[i]._attach) {
         this._childNodes[i]._attach();
       }
@@ -643,7 +643,7 @@ core.Node.prototype = {
     if (this.id) {
       detachId(this.id,this,this._ownerDocument);
     }
-    for (var i=0;i<this._childNodes.length;i++) {
+    for (var i=0,len=this._childNodes.length;i<len;i++) {
       this._childNodes[i]._detach();
     }
   },


### PR DESCRIPTION
Calculating outside the loop saves me about 50% calls to `lengthFromProperties`.  It still might be worth looking at ways of avoiding `_update` for calls like `get length()` which do not mutate the list.
