### PR TITLE
added failing test on form.elements

### DIFF
--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -20022,5 +20022,59 @@ exports.tests = {
     });
 
     test.done();
+  },
+
+  /**
+   * The form.elements[name] getter should provide an element
+   * @author Pavel Vanecek
+   * @see http://www.w3.org/TR/html5/forms.html#dom-form-elements
+   */
+  form_elements_namedItem_should_return_element: function(test) {
+    var doc;
+    var nodeList;
+    var formNode;
+    var formElementsList;
+    var inputsList;
+
+    doc = load("form4");
+    nodeList = doc.getElementsByTagName("form");
+    test.equal(nodeList.length, 1, "one form node should be found");
+
+    formNode = nodeList[0];
+    test.equal(formNode.nodeName, "FORM", "form node should be found");
+
+    formElementsList = formNode.elements;
+    inputsList = formElementsList.namedItem("submit1");
+    test.ok("object" == typeof inputsList, "namedItem should return object");
+    test.equal(inputsList.nodeName, "INPUT", "returned element should be of type input")
+
+    test.done();
+  },
+
+  /**
+   * The form.elements[name] getter should provide an array of elements, if inputs of that name are more than one (e. g. radio inputs)
+   * @author Pavel Vanecek
+   * @see http://www.w3.org/TR/html5/forms.html#dom-form-elements
+   */
+  form_elements_radio_buttons_should_be_an_array: function(test) {
+    var doc;
+    var nodeList;
+    var formNode;
+    var formElementsList;
+    var radioInputsList;
+
+    doc = load("form4");
+    nodeList = doc.getElementsByTagName("form");
+    test.equal(nodeList.length, 1, "one form node should be found");
+
+    formNode = nodeList[0];
+    test.equal(formNode.nodeName, "FORM", "form node should be found");
+
+    formElementsList = formNode.elements;
+    radioInputsList = formElementsList.namedItem("radioInput");
+    test.ok(Array.isArray(radioInputsList), "namedItem should return array");
+    test.equal(radioInputsList.length, 2, "there should be two radio input nodes found");
+
+    test.done();
   }
 }

--- a/test/level2/html/files/form4.html
+++ b/test/level2/html/files/form4.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; CHARSET=utf-8">
+<TITLE>FORM3</TITLE>
+</HEAD>
+<BODY onload="parent.loadComplete()">
+<FORM ID="form4" ACTION="about:blank">
+<P>
+<INPUT TYPE="radio" NAME="radioInput" VALUE="optionA" />
+<INPUT TYPE="radio" NAME="radioInput" VALUE="optionB" />
+<INPUT TYPE="submit" NAME="submit1" VALUE="Submit" />
+<INPUT TYPE="reset" NAME="submit2" VALUE="Reset" />
+</P>
+</FORM>
+</BODY>
+</HTML>


### PR DESCRIPTION
form.elements[name] property should return array (or array-like list), if the name is provided by more elements (e. g. radio buttons). However, it does not.
Test case that exposes this behaviour has been added.

I used a simple script to test the implementation across browsers, it works the same as far back as IE 5 compatibility mode:
http://jsfiddle.net/nP3SB/1/

I wasn't able to find the code that handles this, so I couldn't fix it myself.

The DOM 2 HTML document states that the namedItem method should return either Node or null: http://www.w3.org/TR/2003/REC-DOM-Level-2-HTML-20030109/html.html#ID-75708506, however all the browsers I could find and test do return array if there are duplicate names.

W3C document that handles the elements property with duplicate names behaviour can be found under html5 namespace: http://www.w3.org/TR/html5/forms.html#dom-form-elements
