### PR TITLE
JSDOM Not Compatible with jquery.ui tabs

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1318,6 +1318,9 @@ define('HTMLAnchorElement', {
     },
     get pathname() {
       return URL.parse(this.href).pathname;
+    },
+    get hash() {
+      return URL.parse(this.href).hash;
     }
   },
   attributes: [

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -483,6 +483,19 @@ exports.tests = {
     test.done();
   },
   /**
+   * HTMLAnchorElement.hash should show part of url after hash
+   * @author Peter Culak
+   * @see https://developer.mozilla.org/en/DOM/HTMLAnchorElement
+   */
+   HTMLAnchorElement20: function(test) {
+     var doc = load("anchor5");
+     var nodeList = doc.getElementsByTagName("a");
+     test.equal(nodeList.length, 1, 'Asize');
+     test.equal(nodeList.item(0).host, 'www.github.com:3020', 'a.host');
+     test.equal(nodeList.item(0).hash, '#fragment-identifier', 'a.hash');
+     test.done();
+  },
+  /**
    *
    The align attribute specifies the alignment of the object(Vertically
    or Horizontally) with respect to its surrounding text.

--- a/test/level2/html/files/anchor5.html
+++ b/test/level2/html/files/anchor5.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+        "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+    <META HTTP-EQUIV="Content-Type" CONTENT="text/html; CHARSET=utf-8">
+    <TITLE>NIST DOM HTML Test - Anchor</TITLE>
+</HEAD>
+<BODY onload="parent.loadComplete()">
+<P>
+    <A HREF="http://www.github.com:3020/tmpvar/jsdom#fragment-identifier" TARGET="dynamic">View Submit Button</A>
+</P>
+</BODY>
+</HTML>


### PR DESCRIPTION
HTMLAnchorElement.hash support. This is the compatibility fix for jquery.ui.tabs. 
Zombie just died when running jQuery("#id").tabs()
