### PR TITLE
bumped version of cssstyle to 0.2.8 and jsdom to 0.8.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsdom",
-    "version": "0.8.10",
+    "version": "0.8.11",
     "description": "A JavaScript implementation of the W3C DOM",
     "keywords": ["dom", "w3c", "html"],
     "maintainers": [
@@ -65,7 +65,7 @@
        "request": "2.x",
        "xmlhttprequest": ">=1.5.0",
        "cssom": "~0.3.0",
-       "cssstyle": "~0.2.6",
+       "cssstyle": "~0.2.8",
        "contextify": "~0.1.5"
     },
     "devDependencies" : {


### PR DESCRIPTION
cssstyle 0.2.8 fixes some big problems with color parsing, see chad3814/CSSStyleDeclaration#9

@davidaurelio
