### PR TITLE
Do not autocreate "type" attribute on inputs

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -938,11 +938,6 @@ define('HTMLOptionElement', {
 
 define('HTMLInputElement', {
   tagName: 'INPUT',
-  init: function() {
-    if (!this.hasAttribute('type')) {
-      this.setAttribute('type', 'text');
-    }
-  },
   proto: {
     _initDefaultValue: function() {
       if (this._defaultValue === undefined) {


### PR DESCRIPTION
If we have markup `<input>`, DOM should not create any attribute itself.
