### PR TITLE
Fix serialization of void elements

### DIFF
--- a/lib/jsdom/browser/domtohtml.js
+++ b/lib/jsdom/browser/domtohtml.js
@@ -60,7 +60,7 @@ exports.stringifyElement = function stringifyElement(element) {
   ret.start += attributes.join(" ");
 
   if (voidElements[tagName]) {
-    ret.start += " />";
+    ret.start += ">";
     ret.end = '';
   } else {
     ret.start += ">";

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -783,6 +783,13 @@ exports.tests = {
     test.done();
   },
 
+  serialization_of_void_elements : function(test){
+    var html = '<html><body><div><br><hr><audio><source></audio></div></body></html>',
+        doc = jsdom.html(html);
+    test.strictEqual(doc.outerHTML, html)
+    test.done();
+  },
+
   children_should_be_available_right_after_document_creation : function(test) {
     var doc = jsdom.jsdom("<html><body><div></div></body></html>");
     test.ok((doc.body.children[0] !== undefined), "there should be a body, and it should have a child");

--- a/test/window/index.js
+++ b/test/window/index.js
@@ -8,7 +8,7 @@ exports.tests = {
     window.document.getElementsByTagName("head").item(0).appendChild(meta);
     var elements = window.document.getElementsByTagName("head").item(0).childNodes;
     test.strictEqual(elements.item(elements.length-1), meta, 'last element should be the new meta tag');
-    test.ok(window.document.innerHTML.indexOf("<meta />") > -1, 'meta should have open tag');
+    test.ok(window.document.innerHTML.indexOf("<meta>") > -1, 'meta should have open tag');
     test.strictEqual(window.document.innerHTML.indexOf("</meta>"), -1, 'meta should not be stringified with a closing tag');
     test.done();
   },


### PR DESCRIPTION
Don't close void elements with `/>`, it's an XHTML-ism that was introduced years ago (77ff1e3a) when the explicit `isXHTML` mode was removed for some reason. It's causing me trouble when checking HTML back into version control after a round trip through jsdom.

This PR makes jsdom behave like a browser in this respect.
