### PR TITLE
changed to requiring any 0.2.x version of cssstyle

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
        "request": "2.x",
        "xmlhttprequest": ">=1.5.0",
        "cssom": "~0.3.0",
-       "cssstyle": "~0.2.9",
+       "cssstyle": "0.2.x",
        "contextify": "~0.1.5"
     },
     "devDependencies" : {


### PR DESCRIPTION
This should pull in the newest 0.2 line of development for cssstyle, and fix issue #770 (by getting cssstyle 0.2.13)
