### PR TITLE
add failing test for jsdom.jsdom('')

### DIFF
--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -21,6 +21,14 @@ exports.tests = {
     test.done();
   },
 
+  jsdom_empty_html: function(test) {
+    var document = jsdom.jsdom('');
+    test.equal(document.innerHTML, '', 'Passing an empty string into jsdom() results in an empty doc');
+    document = jsdom.jsdom(' ');
+    test.equal(document.innerHTML, '', 'Passing a blank string into jsdom() results in an empty doc');
+    test.done();
+  },
+
   jsdom_method_creates_default_document: function(test) {
     var doc = jsdom.jsdom();
     test.equal(doc.documentElement.nodeName, 'HTML', 'Calling jsdom.jsdom() should automatically populate the doc');


### PR DESCRIPTION
I've added a failing test for some strange behavior I'm seeing:

`jsdom.jsdom('')` doesn't initialize an empty dom as expected, it uses the default string - `<html><head></head><body></body></html>`.

The logic here looks fine: https://github.com/tmpvar/jsdom/blob/master/lib/jsdom.js#L74

I'll update this PR if I'm able to get to the bottom of this.
