### PR TITLE
Fix for passing a blank string into jsdom.jsdom()

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ window.document.body.appendChild(scriptEl);
  window/console             2/2      100%
  window/frame             16/16      100%
  sizzle/index             14/14      100%
- jsdom/index              83/83      100%
+ jsdom/index              84/84      100%
  jsdom/parsing            11/11      100%
  jsdom/env                25/25      100%
  jsdom/utils              11/11      100%
@@ -296,7 +296,7 @@ window.document.body.appendChild(scriptEl);
  browser/css                1/1      100%
  browser/index            34/34      100%
 ------------------------------------------
-TOTALS: 0/2666 failed; 100% success
+TOTALS: 0/2667 failed; 100% success
 ```
 
 ### Running the tests

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -71,7 +71,8 @@ exports.jsdom = function (html, level, options) {
 
   features.applyDocumentFeatures(doc, options.features);
 
-  if (typeof html === 'undefined' || html === null) {
+  if (typeof html === 'undefined' || html === null ||
+      (html.trim && !html.trim())) {
     doc.write('<html><head></head><body></body></html>');
   } else {
     doc.write(html + '');

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -21,6 +21,13 @@ exports.tests = {
     test.done();
   },
 
+  jsdom_empty_html: function(test) {
+    var emptyDoc = jsdom.jsdom('');
+    var blankDoc = jsdom.jsdom(' ');
+    test.equal(emptyDoc.innerHTML, blankDoc.innerHTML, 'Passing blank and empty strings into jsdom() result in the same html');
+    test.done();
+  },
+
   jsdom_method_creates_default_document: function(test) {
     var doc = jsdom.jsdom();
     test.equal(doc.documentElement.nodeName, 'HTML', 'Calling jsdom.jsdom() should automatically populate the doc');


### PR DESCRIPTION
Follow-up for discussion on #772.

Fixes a bug where calling `jsdom.jsdom(' ')` resulted in a document with
no html, while `jsdom.jsdom('')` yields the default `<html>...</html>`.

I'm using `trim()` to strip whitespace from the parameter and check if it's falsy.
