### PR TITLE
lazily require "request"

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 var URL = require('url');
-var request = require('request');
 var pkg = require('../package.json');
 
 var toFileUrl = require('./jsdom/utils').toFileUrl;
@@ -11,6 +10,12 @@ var style = require('./jsdom/level2/style');
 var features = require('./jsdom/browser/documentfeatures');
 var dom = exports.dom = require('./jsdom/level3/index').dom;
 var createWindow = exports.createWindow = require('./jsdom/browser/index').createWindow;
+
+
+var request = function(options, cb) {
+  request = require('request');
+  return request(options, cb);
+}
 
 exports.defaultLevel = dom.level3.html;
 exports.browserAugmentation = require('./jsdom/browser/index').browserAugmentation;


### PR DESCRIPTION
Hey, this is related to https://github.com/chad3814/CSSStyleDeclaration/pull/14

I'll give you a quick summary.

We have a tool that loads jsdom as a dependency.  We run the tool pretty often as part of our dev process so we like to keep its load time as low as possible.  

Anyway, jsdom uses `request` which is a large module that is not actually needed in all cases.  This change reduces the time to `require('jsdom')` by about 30 - 50% (depends on what version of css style you have now ;) by not loading `request` until it is actually used.

Here is a script you can use to time requiring jsdom:

``` javascript
function timeFn(fn) {
  var start = process.hrtime();

  fn();

  var elapsed = process.hrtime(start);
  var ms = elapsed[1] / 1000000
  console.log(elapsed[0] + 's ' + ms + ' ms');
}

timeFn(function() {
  var jsdom = require('jsdom');
});
```

and here is a way to run it a bunch of times and average the results:

``` bash
for i in {1..100}; do node jsdomLoad.js; done | awk -F" " '{print $2}' | awk '{T+= $NF} END { print T/NR }'
```

Thanks.
