### PR TITLE
Raise error with stack trace.

### DIFF
--- a/lib/jsdom/level2/languages/javascript.js
+++ b/lib/jsdom/level2/languages/javascript.js
@@ -6,7 +6,7 @@ exports.javascript = function(element, code, filename) {
     } catch (e) {
       element.raise(
         'error', 'Running ' + filename + ' failed.',
-        {error: e, filename: filename}
+        {error: e, filename: filename, stack: e.stack}
       );
     }
   }


### PR DESCRIPTION
I changed for a detailed error want on error as JavaScript.

Example:

``` javascript
var jsdom = require("jsdom");

var window = jsdom.jsdom(
  /* Raise JavaScrpt Error */
  '<script>window.undefinedMethod();</script>',
  null, {
    features: {
      FetchExternalResources: ["script", "img", "css", "frame", "iframe", "link"],
      ProcessExternalResources: ["script"],
      SkipExternalResources: false,
      MutationEvents: '2.0',
      QuerySelector: false
    }   
}).createWindow();

var errors = window.document.errors;
if(errors && errors.length) {
  errors.forEach(function(e) {
    /* Print Stack Trace */
    console.log(e.data.stack);
  }); 
}
window.close();
```

As follows result.

```
TypeError: Object [object global] has no method 'undefinedMethod'
    at file:///dev/jsdom/test_stack_trace.js:undefined:undefined<script>:1:8
    at Contextify.sandbox.run (/dev/jsdom/node_modules/contextify/lib/contextify.js:12:24)
    at Object.exports.javascript (/dev/jsdom/lib/jsdom/level2/languages/javascript.js:5:14)
    at define.proto._eval (/dev/jsdom/lib/jsdom/level2/html.js:1543:47)
    at /dev/jsdom/lib/jsdom/level2/html.js:76:20
    at Object.item.check (/dev/jsdom/lib/jsdom/level2/html.js:345:11)
    at /dev/jsdom/lib/jsdom/level2/html.js:363:12
    at null.<anonymous> (/dev/jsdom/lib/jsdom/level2/html.js:1532:64)
    at Function.dispatch (/dev/jsdom/lib/jsdom/level2/events.js:196:42)
    at events.EventTarget.dispatchEvent (/dev/jsdom/lib/jsdom/level2/events.js:286:33)
```
