### PR TITLE
Text Selection API for Input and TextArea

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1078,7 +1078,7 @@ define('HTMLInputElement', {
       }
       return this._selectionEnd;
     },
-    set selectionEnd(e) {
+    set selectionEnd(end) {
       this.setSelectionRange(this._selectionStart, end, this._selectionDirection);
     },
     get selectionDirection() {
@@ -1109,18 +1109,18 @@ define('HTMLInputElement', {
       start = Math.min(start, this._getValueLength());
       end = Math.min(end, this._getValueLength());
       var val = this.value;
-      val = val.slice(0, start) + repl + val.slice(end);
+      var selStart = this._selectionStart;
+      var selEnd = this._selectionEnd;
+      this.value = val.slice(0, start) + repl + val.slice(end);
       var newEnd = start+repl.length;
       if(selectionMode == "select") {
-        setSelectionRange(start, newEnd); 
+        this.setSelectionRange(start, newEnd); 
       } else if(selectionMode == "start") {
-        setSelectionRange(start, start); 
+        this.setSelectionRange(start, start); 
       } else if(selectionMode == "end") {
-        setSelectionRange(newEnd, newEnd); 
+        this.setSelectionRange(newEnd, newEnd); 
       } else {//preserve
         var delta = repl.length - (end-start);
-        var selStart = this._selectionStart;
-        var selEnd = this._selectionEnd;
         if(selStart > end) {
           selStart += delta;
         } else if(selStart > start) {
@@ -1131,7 +1131,7 @@ define('HTMLInputElement', {
         } else if(selEnd > start) {
           selEnd = newEnd;
         }
-        setSelectionRange(newEnd, newEnd); 
+        this.setSelectionRange(selStart, selEnd); 
       }
     },
 
@@ -1237,7 +1237,7 @@ define('HTMLTextAreaElement', {
     get selectionEnd() {
       return this._selectionEnd;
     },
-    set selectionEnd(e) {
+    set selectionEnd(end) {
       this.setSelectionRange(this._selectionStart, end, this._selectionDirection);
     },
     get selectionDirection() {
@@ -1262,18 +1262,18 @@ define('HTMLTextAreaElement', {
       start = Math.min(start, this._getValueLength());
       end = Math.min(end, this._getValueLength());
       var val = this.value;
-      val = val.slice(0, start) + repl + val.slice(end);
+      var selStart = this._selectionStart;
+      var selEnd = this._selectionEnd;
+      this.value = val.slice(0, start) + repl + val.slice(end);
       var newEnd = start+repl.length;
       if(selectionMode == "select") {
-        setSelectionRange(start, newEnd); 
+        this.setSelectionRange(start, newEnd); 
       } else if(selectionMode == "start") {
-        setSelectionRange(start, start); 
+        this.setSelectionRange(start, start); 
       } else if(selectionMode == "end") {
-        setSelectionRange(newEnd, newEnd); 
+        this.setSelectionRange(newEnd, newEnd); 
       } else {//preserve
         var delta = repl.length - (end-start);
-        var selStart = this._selectionStart;
-        var selEnd = this._selectionEnd;
         if(selStart > end) {
           selStart += delta;
         } else if(selStart > start) {
@@ -1284,7 +1284,7 @@ define('HTMLTextAreaElement', {
         } else if(selEnd > start) {
           selEnd = newEnd;
         }
-        setSelectionRange(newEnd, newEnd); 
+        this.setSelectionRange(selStart, selEnd);
       }
     }
   },


### PR DESCRIPTION
See #799.  Followed documentation at http://www.whatwg.org/specs/web-apps/current-work/#textFieldSelection

Pretty straight forward addition.  A few concerns:
1. I ended up duplicating the code in order to put it into both Input and Text Area
2. When the content of the text box changes, presumably the selection is also supposed to change.  Consider, for example, if the content of the box is empties, and the selection is supposed to be of characters 4 through 10.  Clearly that selection is now impossible.  However, I couldn't really find any documentation on this point (though it's possible I don't know where to look).  Chrome moves the cursor to the end of the text box, which seems reasonable, but since I couldn't find it actually documented anywhere I just did some basic sanitizing to make sure the selection is always within the bounds of the actual text.
3.  Sometimes `input` tags don't support the selection API (e.g. `type=radio`).  In these cases I throw `throw new core.DOMException(core.INVALID_STATE_ERR)`, because chrome throws an `InvalidStateError` and this was the most similar thing I could find.  No idea if that's the correct thing to throw though.  Would appreciate someone who knows more taking a look.
4.  On my machine, the automated tests stall at `running jsdom/index.js jsdom/index`.  They did this before I made my changes, so I'm pretty sure it's not my fault, but at the same time I feel kind of queasy sending a pull request without having the tests finish.
5.  On that note, I haven't written any tests.  I did some manual testing, so I know it everything works.  I don't know if that's enough for you guys.
