### PR TITLE
selector bug - fails when link text ends in number

### DIFF
--- a/lib/jsdom/selectors/index.js
+++ b/lib/jsdom/selectors/index.js
@@ -3,7 +3,7 @@ var nwmatcher = require("nwmatcher/src/nwmatcher-noqsa");
 function addNwmatcher(document) {
   if (!document._nwmatcher) {
     document._nwmatcher = nwmatcher({ document: document });
-    document._nwmatcher.configure({ UNIQUE_ID: false });
+    document._nwmatcher.configure({ UNIQUE_ID: false, VERBOSITY: false });
   }
   return document._nwmatcher;
 }
@@ -21,7 +21,7 @@ exports.applyQuerySelectorPrototype = function(dom) {
     return addNwmatcher(this.ownerDocument).first(selector, this);
   };
 
-  dom.DocumentFragment.prototype.querySelectorAll = function(selector) { 
+  dom.DocumentFragment.prototype.querySelectorAll = function(selector) {
     return new dom.NodeList(addNwmatcher(this.ownerDocument).select(selector, this));
   };
 


### PR DESCRIPTION
When doing a lookup on a link with text that ends in a number, you get an absolute failure. This change resolves text lookups breaking when ending in numbers.

```
Error: The string "Step 3", is not a valid CSS selector
```
