### PR TITLE
Convert NodeLists to arrays via a loop sted slice

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -227,7 +227,14 @@ core.NodeList.prototype = {
       return this._snapshot;
     }
 
-    return Array.prototype.slice.call(this);
+    // we cannot slice here, because Firefox assigns to `length`, which is
+    // read-only for NodeLists
+    var result = new Array(this.length);
+    for (var i = 0; i < this.length; i++) {
+      result[i] = this[i];
+    }
+
+    return result;
   },
   get length() {
     this._update();


### PR DESCRIPTION
Apparently, Firefox's `Array.prototype.splice` sets `length`. This fails without
a setter. We cannot add a `length` setter, as that property is read-only for
`NodeList` instances.

So, create a new array of the required size and copy the elements of the
`NodeList` in a loop.

The tests that fail on this branch also fail on `master`.
