### PR TITLE
Allow empty strings for HTML

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -335,7 +335,8 @@ function getConfigFromArguments(args, callback) {
     throw new Error('Must pass a "created", "loaded", "done" option or a callback to jsdom.env.');
   }
 
-  if (config.somethingToAutodetect === undefined && !config.html && !config.file && !config.url) {
+  if (config.somethingToAutodetect === undefined &&
+      config.html === undefined && !config.file && !config.url) {
     throw new Error('Must pass a "html", "file", or "url" option, or a string, to jsdom.env');
   }
 


### PR DESCRIPTION
Completely empty HTML is completely valid. This is a simple alteration to the
config test which allows it.
