### PR TITLE
Wrap dispose in setTimeout to prevent segfault

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -169,7 +169,7 @@ exports.createWindow = function(dom, options) {
       stopAllTimers();
       // Clean up the window's execution context.
       // dispose() is added by Contextify.
-      this.dispose();
+      setTimeout(this.dispose.bind(this), 0);
     },
     getComputedStyle: function(node) {
       var s = node.style,


### PR DESCRIPTION
I was consistently getting a segfault after creating 50-100 environments in series, but deferring the Contextify .dispose() fixed the problem.

This should fix #806.

Segfault ([full stack trace](http://pastey.org/view/raw/704fa2ca))

```
#
# Fatal error in ../deps/v8/src/api.h, line 297
# CHECK(allow_empty_handle || that != __null) failed
#
```

The underlying issue seems to be in Contextify. Possibly related: https://github.com/brianmcd/contextify/issues/89#issuecomment-24720569

> If client code to Contextify calls .dispose on a sandbox, the context will get pulled out from under it. Asynchronous operations set up within the sandbox may then fire at a later time, causing the null handle derefs.
