### PR TITLE
Removing false error when parsing XML.

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -71,9 +71,6 @@ function HtmlToDom(parser) {
       };
     } else if (parser.Parser && parser.TreeAdapters) {
       parser.ParseHtml = function (rawHtml) {
-        if (rawHtml.match(/^<\?\s*xml.*version=["']1\.0["'].*\s*\?>/i)) {
-          throw new Error('Can\'t parse XML with parse5, please use htmlparser2 instead.');
-        }
         var instance = new parser.Parser(parser.TreeAdapters.htmlparser2);
         var dom = instance.parse(rawHtml);
         return dom.children;


### PR DESCRIPTION
There seems to be a bug when parsing XML. It throws about using parse5 with XML, then it uses htmlparser2 anyway.
