### PR TITLE
Fixed an issue with the testharness detection regex

### DIFF
--- a/test/w3c/w3ctest.js
+++ b/test/w3c/w3ctest.js
@@ -7,7 +7,7 @@ var jsdom = require("../..");
 
 function createJsdom(source, url, t) {
   var input = source.replace(
-      /<script src="?(.*?)\/resources\/testharnessreport.js"?><\/script>/,
+      /<script src=["']?([^"']*?)\/resources\/testharnessreport.js["']?><\/script>/,
       "<script>window.shimTest();</script>");
 
   if (input === source) {


### PR DESCRIPTION
If testharness + testharness report script tags were on the same line, the regex would greedily capture both, which would lead to a document without the testharness loaded.

This is to start working with document.write tests. Currently however, they all fail because we are not correctly handling document.write, especially if the script tag is in a <head> tag.
