### PR TITLE
Correct the return value of EventTarget#dispatchEvent.

### DIFF
--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -302,7 +302,7 @@ events.EventTarget.prototype = {
         event._currentTarget = null;
         event._eventPhase = event.NONE;
 
-        return event._preventDefault;
+        return !event._preventDefault;
     }
 
 };

--- a/test/level2/events.js
+++ b/test/level2/events.js
@@ -320,7 +320,7 @@ exports['capture event'] = testcase({
     this.plist.firstChild.addEventListener("foo", this.monitor.handleEvent, false);
     var return_val = this.plist.firstChild.dispatchEvent(this.event);
     test.expect(4);
-    test.equal(return_val, false, 'dispatchEvent should return *false*');
+    test.equal(return_val, true, 'dispatchEvent should return *true*');
     test.equal(this.monitor.atEvents.length, 1, 'should be at 1 event');
     test.equal(this.monitor.bubbledEvents.length, 1, 'should have bubbled 1 event');
     test.equal(this.monitor.capturedEvents.length, 0, 'should not have captured any events');
@@ -359,7 +359,7 @@ exports['bubble event'] = testcase({
     this.plist.firstChild.addEventListener("foo", this.monitor.handleEvent, false);
     var return_val = this.plist.firstChild.dispatchEvent(this.event);
     test.expect(4);
-    test.equal(return_val, false, 'dispatchEvent should return *false*');
+    test.equal(return_val, true, 'dispatchEvent should return *true*');
     test.equal(this.monitor.atEvents.length, 1, 'should be at 1 event');
     test.equal(this.monitor.bubbledEvents.length, 1, 'should have 1 bubbled event');
     test.equal(this.monitor.capturedEvents.length, 1, 'should have captured 1 event');
@@ -374,7 +374,7 @@ exports['bubble event'] = testcase({
     this.event.initEvent("foo",false,false);
     var return_val = this.plist.firstChild.dispatchEvent(this.event);
     test.expect(4);
-    test.equal(return_val, false, 'dispatchEvent should return *false*');
+    test.equal(return_val, true, 'dispatchEvent should return *true*');
     test.equal(this.monitor.atEvents.length, 1, 'should be at 1 event');
     test.equal(this.monitor.bubbledEvents.length, 0, 'should not have any bubbled events');
     test.equal(this.monitor.capturedEvents.length, 1, 'should have captured 1 event');
@@ -453,7 +453,7 @@ exports['prevent default'] = testcase({
     this.plist.firstChild.addEventListener("foo", this.monitor.handleEvent, false);
     var return_val = this.plist.firstChild.dispatchEvent(this.event);
     test.expect(4);
-    test.equal(return_val, true, 'dispatchEvent should return *true*');
+    test.equal(return_val, false, 'dispatchEvent should return *false*');
     test.equal(this.monitor.atEvents.length, 1, 'should be at 1 event');
     test.equal(this.monitor.bubbledEvents.length, 1, 'should have bubbled 1 event');
     test.equal(this.monitor.capturedEvents.length, 1, 'should have captured 1 event');
@@ -467,7 +467,7 @@ exports['prevent default'] = testcase({
     this.event.initEvent("foo",true,false);
     var return_val = this.plist.firstChild.dispatchEvent(this.event);
     test.expect(4);
-    test.equal(return_val, false, 'dispatchEvent should return *false*');
+    test.equal(return_val, true, 'dispatchEvent should return *true*');
     test.equal(this.monitor.atEvents.length, 1, 'should be at 1 event');
     test.equal(this.monitor.bubbledEvents.length, 1, 'should have bubbled 1 event');
     test.equal(this.monitor.capturedEvents.length, 1, 'should have captured 1 event');

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -19921,7 +19921,7 @@ exports.tests = {
     var doc;
     var target;
     var evt;
-    var preventDefault;
+    var canceled;
     var performedDefault = false;
 
     var docRef = null;
@@ -19937,8 +19937,8 @@ exports.tests = {
     a._eventDefaults['foo'] = function(event) {
       performedDefault = true;
     };
-    preventDefault = a.dispatchEvent(evt);
-    test.equal(preventDefault, false, 'preventDefault should be *false*');
+    canceled = !a.dispatchEvent(evt);
+    test.equal(canceled, false, 'canceled should be *false*');
     test.ok(performedDefault, 'performedDefault');
     test.done();
   },


### PR DESCRIPTION
It appears that the return value of EventTarget#dispatchEvent is intended to be `true` if the default was _not_ prevented. That is, `canceled = !target.dispatchEvent(event)`. In every browser I ran the following test and got the same thing, which is the opposite of what jsdom returned before this commit.

``` js
> e = document.createEvent('UIEvents')
> e.initEvent('keydown', true, true)
> document.body.dispatchEvent(e)
true
> document.body.addEventListener('keydown', function(e){ e.preventDefault() })
> e = document.createEvent('UIEvents')
> e.initEvent('keydown', true, true)
> document.body.dispatchEvent(e)
false
```

Looking at the specs, I find evidence for this in the [spec for `dispatchEvent`](https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent), specifically 4.7.13:

> Return false if event's canceled flag is set, and true otherwise

The `canceled` flag is set by `preventDefault()` if `cancelable` is `true`.

Additionally, the web-platform-tests project has a [test for `dispatchEvent` that asserts that the return value is `true` when the event is not cancelable](https://github.com/w3c/web-platform-tests/blob/04be7dd98aa106989948ac4e5d9cb7398e6a0d4d/dom/events/EventTarget-dispatchEvent.html#L36).
