### PR TITLE
Get web-platform-tests dispatchEvent passing, or at least failing informatively

### DIFF
--- a/test/w3c/w3ctest.js
+++ b/test/w3c/w3ctest.js
@@ -26,9 +26,9 @@ function createJsdom(source, url, t) {
       window.shimTest = function () {
         window.add_result_callback(function (test) {
           if (test.status === 1) {
-            t.ok(false, "Failed in \"" + t.name + "\": \n" + t.message);
+            t.ok(false, "Failed in \"" + test.name + "\": \n" + test.message);
           } else if (test.status === 2) {
-            t.ok(false, "Timout in \"" + t.name + "\": \n" + t.message);
+            t.ok(false, "Timout in \"" + test.name + "\": \n" + test.message);
           }
         });
 


### PR DESCRIPTION
After seeing #893, I tried adding

``` js
w3cTest("dom/events/EventTarget-dispatchEvent.html");
```

to `test/w3c/index.js` but it failed with very unhelpful error messages.
