### PR TITLE
Move addon section in order to make it PRs work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ matrix:
       node_js: "0.10"
     - env: TEST_SUITE=browser
       node_js: "0.10"
-      addons:
-        sauce_connect:
-          username: "jsdom"
-          access_key: "7d402b1d-0388-467c-8d99-edf195456eee"
+
+addons:
+  sauce_connect:
+    username: "jsdom"
+    access_key: "7d402b1d-0388-467c-8d99-edf195456eee"
 
 
 script: node test/ci.js


### PR DESCRIPTION
I'm mainly testing this out because travis complained in the linter.

Seems like travis might pay attention to it in normal pushes when in the matrix subgroup, however it doesn't work with PRs.

Travis installs a bit of unnecessary stuff in the node tests this way, which might make the tests a bit slower, but we tried...
