### PR TITLE
Move browserify deps to `dependencies` from `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
     "nwmatcher": ">= 1.3.3 < 2.0.0",
     "parse5": ">= 1.1.4 < 2.0.0",
     "request": ">= 2.44.0 < 3.0.0",
-    "xmlhttprequest": ">= 1.6.0 < 2.0.0"
+    "xmlhttprequest": ">= 1.6.0 < 2.0.0",
+    "browser-request": "~0.3.1",
+    "cssstyle-browserify": "git://github.com/TreehouseJS/CSSStyleDeclaration.git"
   },
   "devDependencies": {
-    "browser-request": "~0.3.1",
     "browserify": "^5.9.1",
     "colors": "^0.6.2",
-    "cssstyle-browserify": "git://github.com/TreehouseJS/CSSStyleDeclaration.git",
     "http-server": "^0.6.1",
     "nodeunit": "~0.8.0",
     "optimist": "*",
@@ -88,8 +88,8 @@
   "browser": {
     "canvas": false,
     "contextify": "./lib/jsdom/contextify-shim.js",
-    "cssstyle": "./node_modules/cssstyle-browserify/lib/CSSStyleDeclaration.js",
-    "request": "./node_modules/browser-request/index.js"
+    "cssstyle": "cssstyle-browserify",
+    "request": "browser-request"
   },
   "scripts": {
     "test": "node ./test/runner"


### PR DESCRIPTION
If I `require` a module that depends on jsdom (rather than directly including jsdom in my `package.json`) and run `npm install`, jsdom's `devDependencies` are not installed. This includes a few packages that browserify depends on: I think just `cssstyle-browserify` and `browser-request`. 
