### PR TITLE
Only test non-browser or non-PR commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ matrix:
           access_key: "7d402b1d-0388-467c-8d99-edf195456eee"
 
 
-script: node test/ci.js
+script:
+  - '([ "${TRAVIS_PULL_REQUEST}" = "false" ] || [ "${TEST_SUITE}" != "browser" ]) && node test/ci.js || true'


### PR DESCRIPTION
Since travis doesn't download the sauce-connect addon on pull requests we need to disable browser tests for pull requests. They'll still be executed when they're in a branch.
