### PR TITLE
remove cssstyle-browserify and require cssstyle-0.2.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "browser": {
     "canvas": false,
     "contextify": "./lib/jsdom/contextify-shim.js",
-    "cssstyle": "cssstyle-browserify",
     "request": "browser-request"
   },
   "scripts": {


### PR DESCRIPTION
should fix #910 and since jsdom-1.0.4 wasn't published, no need to bump?
