### PR TITLE
Fix the --verbose option in the test runner

### DIFF
--- a/test/runner
+++ b/test/runner
@@ -103,7 +103,7 @@ files.map(function (p) {
   }
 });
 
-var reporter = nodeunit.reporters.minimal;
+var reporter = argv.verbose ? nodeunit.reporters.default : nodeunit.reporters.minimal;
 reporter.run(modulesToRun, null, function(err) {
   process.exit(err ? 1 : 0);
 });


### PR DESCRIPTION
The verbose option got broken when redesigning the test runner.

This should give enough info to debug hangups for example.
