### PR TITLE
Fix env test to check for proper exception

### DIFF
--- a/test/jsdom/env.js
+++ b/test/jsdom/env.js
@@ -9,10 +9,10 @@ var toFileUrl = require("../util").toFileUrl(__dirname);
 var serializeDocument = require('../../lib/jsdom').serializeDocument;
 
 exports["with invalid arguments"] = function (t) {
-  t.throws(function () { jsdom.env(); });
-  t.throws(function () { jsdom.env({}); });
-  t.throws(function () { jsdom.env({ html: "abc123" }); });
-  t.throws(function () { jsdom.env({ done: function () {} }); });
+  t.throws(function () { env(); });
+  t.throws(function () { env({}); });
+  t.throws(function () { env({ html: "abc123" }); });
+  t.throws(function () { env({ done: function () {} }); });
   t.done();
 };
 


### PR DESCRIPTION
The test didn't check for what it actually wanted to test. The contained code did actually throw, however that was only the case, because jsdom was undefined, instead of a thrown error by jsdom.env.

Noticed this through some selective enabling of jshint.
