### PR TITLE
Add more clearity to tests run by the w3c suite

### DIFF
--- a/test/w3c/w3ctest.js
+++ b/test/w3c/w3ctest.js
@@ -29,6 +29,8 @@ function createJsdom(source, url, t) {
             t.ok(false, "Failed in \"" + test.name + "\": \n" + test.message);
           } else if (test.status === 2) {
             t.ok(false, "Timout in \"" + test.name + "\": \n" + test.message);
+          } else {
+            t.ok(true, test.name);
           }
         });
 
@@ -37,6 +39,12 @@ function createJsdom(source, url, t) {
           t.done();
         });
       };
+    },
+
+    loaded: function (err, window) {
+      t.ifError(err && err[0].data.error);
+      t.done();
+      window.close();
     }
   });
 }


### PR DESCRIPTION
Pages where script errors occur will now result in a failed test and
successful assertions will also be counted.
