### PR TITLE
History: Initial length should be 1, not 0, and pushState() / replaceState() shouldn't fire popstate events

### DIFF
--- a/lib/jsdom/browser/history.js
+++ b/lib/jsdom/browser/history.js
@@ -50,7 +50,11 @@ History.prototype = {
     }
 
     this._index = newIndex;
-    this._applyState(this._states[this._index]);
+
+    var state = this._states[newIndex];
+
+    this._applyState(state);
+    this._signalPopstate(state);
   },
 
   pushState: function (data, title, url) {
@@ -71,8 +75,6 @@ History.prototype = {
 
   _applyState: function(state) {
     this._location._url = URL.parse(URL.resolve(this._location._url.href, state.url));
-
-    this._signalPopstate(state);
   },
 
   _signalPopstate: function(state) {

--- a/test/window/history.js
+++ b/test/window/history.js
@@ -15,6 +15,10 @@ exports["a default window should have a history object with correct default valu
 exports["the history object should update correctly when calling pushState/replaceState"] = function (t) {
   var window = jsdom().parentWindow;
 
+  window.addEventListener("popstate", function () {
+    t.fail("popstate should not fire as a result of a pushState() or replaceState() call");
+  });
+
   // Absolute path
   window.history.pushState({ foo: "one" }, "unused title", "/bar/baz#fuzz");
   t.strictEqual(window.history.length, 2);
@@ -139,6 +143,8 @@ exports["the history object should fire popstate on the window while navigating 
   });
 
   window.history.pushState(state, "title", "bar");
+  window.history.pushState(null, "", "baz");
+  window.history.back();
 
   setTimeout(function () {
     t.ok(eventFired, "popstate event should be fired.");


### PR DESCRIPTION
Two `window.history` bug fixes, the first of which was necessary to properly test the second:
## Initial history.length should be 1, not 0

This brings jsdom in line with both the spec and with browsers, and fixes an issue where calling `history.pushState()` and then `history.back()` would fail to trigger a `popstate` event for the `back()` call, since there was no initial history entry to navigate back to.

From https://html.spec.whatwg.org/multipage/browsers.html#browsing-context:

> When a browsing context is first created, it must be created with a single Document in its session history [...]
## pushState() and replaceState() shouldn't fire popstate events

The spec doesn't say that `pushState()` or `replaceState()` should trigger a `popstate` event, and browsers don't fire a `popstate` event after a `pushState()` or `replaceState()` call. `popstate` should only be fired during traversal.

See https://html.spec.whatwg.org/multipage/browsers.html#history-1
