### PR TITLE
Avoid leaking "arguments" in utils.intercept.

### DIFF
--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -338,8 +338,9 @@ function mutationEventsEnabled(el) {
          getDocument(el).implementation.hasFeature('MutationEvents');
 }
 
-utils.intercept(core.Node, 'insertBefore', function(_super, args, newChild, refChild) {
-  var ret = _super.apply(this, args);
+var insertBefore_super = core.Node.prototype.insertBefore;
+core.Node.prototype.insertBefore = function(newChild, refChild) {
+  var ret = insertBefore_super.apply(this, arguments);
   if (mutationEventsEnabled(this)) {
     var doc = getDocument(this),
         ev = doc.createEvent("MutationEvents");
@@ -358,9 +359,10 @@ utils.intercept(core.Node, 'insertBefore', function(_super, args, newChild, refC
     }
   }
   return ret;
-});
+};
 
-utils.intercept(core.Node, 'removeChild', function (_super, args, oldChild) {
+var removeChild_super = core.Node.prototype.removeChild;
+core.Node.prototype.removeChild = function (oldChild) {
   if (mutationEventsEnabled(this)) {
     var doc = getDocument(this),
         ev = doc.createEvent("MutationEvents");
@@ -377,8 +379,8 @@ utils.intercept(core.Node, 'removeChild', function (_super, args, oldChild) {
       }
     });
   }
-  return _super.apply(this, args);
-});
+  return removeChild_super.apply(this, arguments);
+};
 
 function dispatchAttrEvent(doc, target, prevVal, newVal, attrName, attrChange) {
   if (!newVal || newVal != prevVal) {
@@ -389,10 +391,10 @@ function dispatchAttrEvent(doc, target, prevVal, newVal, attrName, attrChange) {
   }
 }
 
-function attrNodeInterceptor(change) {
-  return function(_super, args, node) {
+function attrNodeInterceptor(_super, change) {
+  return function(node) {
     var target = this._parentNode,
-        prev = _super.apply(this, args);
+        prev = _super.apply(this, arguments);
 
     if (mutationEventsEnabled(target)) {
       dispatchAttrEvent(target._ownerDocument,
@@ -407,12 +409,13 @@ function attrNodeInterceptor(change) {
   };
 }
 
-function attrInterceptor(ns) {
-  return function(_super, args, localName, value, _name, _prefix, namespace) {
-    var target = this._parentNode;
+function attrInterceptor(_super, ns) {
+  return function(localName, value, _name, _prefix, _namespace) {
+    var target = this._parentNode,
+        namespace = _namespace; // do not reassign parameters when using "arguments" (performance)
 
     if (!mutationEventsEnabled(target)) {
-      _super.apply(this, args);
+      _super.apply(this, arguments);
       return;
     }
 
@@ -424,7 +427,7 @@ function attrInterceptor(ns) {
           ns ? this.$getNode(namespace, localName) : this.$getNoNS(localName);
     var prevVal = prev && prev.value || null;
 
-    _super.apply(this, args);
+    _super.apply(this, arguments);
 
     var node = ns ? this.$getNode(namespace, localName):
             this.$getNoNS(localName);
@@ -439,12 +442,10 @@ function attrInterceptor(ns) {
 }
 
 
-utils.intercept(core.AttributeList, '$removeNode',
-                attrNodeInterceptor('REMOVAL'));
-utils.intercept(core.AttributeList, '$setNode',
-                attrNodeInterceptor('ADDITION'));
-utils.intercept(core.AttributeList, '$set', attrInterceptor(true));
-utils.intercept(core.AttributeList, '$setNoNS', attrInterceptor(false));
+core.AttributeList.prototype.$removeNode = attrNodeInterceptor(core.AttributeList.prototype.$removeNode, 'REMOVAL');
+core.AttributeList.prototype.$setNode = attrNodeInterceptor(core.AttributeList.prototype.$setNode, 'ADDITION');
+core.AttributeList.prototype.$set = attrInterceptor(core.AttributeList.prototype.$set, true);
+core.AttributeList.prototype.$setNoNS = attrInterceptor(core.AttributeList.prototype.$setNoNS, false);
 
 defineGetter(core.CharacterData.prototype, "_nodeValue", function() {
   return this.__nodeValue;

--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -171,16 +171,17 @@ inheritFrom(core.Attr, StyleAttr, {
   }
 });
 
+var $setNode_super = core.AttributeList.prototype.$setNode;
 /**
  * Overwrite core.AttrNodeMap#setNamedItem to create a StyleAttr instance
  * instead of a core.Attr if the name equals 'style'.
  */
-utils.intercept(core.AttributeList, '$setNode', function(_super, args, attr) {
+core.AttributeList.prototype.$setNode = function(attr) {
   if (attr.name == 'style') {
     attr = new StyleAttr(this._parentNode, attr.nodeValue);
   }
-  return _super.call(this, attr);
-});
+  return $setNode_super.call(this, attr);
+};
 
 /**
  * Lazily create a CSSStyleDeclaration.

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -1,34 +1,6 @@
 "use strict";
 var path = require("path");
 
-/**
- * Intercepts a method by replacing the prototype's implementation
- * with a wrapper that invokes the given interceptor instead.
- *
- *     utils.intercept(core.Element, "insertBefore",
- *       function(_super, args, newChild, refChild) {
- *         console.log("insertBefore", newChild, refChild);
- *         return _super.apply(this, args);
- *       }
- *     );
- */
-exports.intercept = function(clazz, method, interceptor) {
-  var proto = clazz.prototype,
-      _super = proto[method],
-      unwrapArgs = interceptor.length > 2;
-
-  proto[method] = function() {
-    if (unwrapArgs) {
-      var args = Array.prototype.slice.call(arguments);
-      args.unshift(_super, arguments);
-      return interceptor.apply(this, args);
-    }
-    else {
-      return interceptor.call(this, _super, arguments);
-    }
-  };
-};
-
 exports.toFileUrl = function (fileName) {
   // Beyond just the `path.resolve`, this is mostly for the benefit of Windows,
   // where we need to convert "\" to "/" and add an extra "/" prefix before the


### PR DESCRIPTION
Also avoids a few array manipulation by speeding up the most common cases (less than 10 arguments).
These changes improve performance considerably in certain cases.
Included test case has 100% branch coverage

Fixes #948
