### PR TITLE
allow overriding of the the config.url when rendering files so things like angular

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -134,7 +134,9 @@ exports.env = exports.jsdom.env = function () {
       }
 
       setParsingModeFromExtension(config, config.file);
-
+      if (config.windowLocation !== undefined) {
+        config.url = config.windowLocation;
+      }
       config.html = text;
       processHTML(config);
     });


### PR DESCRIPTION
routing can still work as expected.

this is definitely not the best place to do this but I thought I'd at least get your thoughts.

My use case is pre-executing an angular-enabled HTML page on the server and delivering it to a browser.

My node server doing this calls jsdom.env with a file option, the main index.html angular app file.

This works fine, except angular routing depends on reading the window.location, but in this case my location will always be file:///path/to/index.html instead of what I want it to be, like /cool/route/url.

When I tried manually changing the window location, jsdom reported this was not supported (I assume because in a browser, that call makes you navigate to a new resource).  I tried using history.pushState as well but I couldn't get the timing right.

Any ideas?
