### PR TITLE
Fix for changing id's on attached html <option> elements

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -873,7 +873,7 @@ define('HTMLOptionElement', {
       if (name === 'selected') {
         this.selected = this.defaultSelected;
       }
-      core.HTMLElement.prototype._attrModified.call(this, arguments);
+      core.HTMLElement.prototype._attrModified.apply(this, arguments);
     },
     get form() {
       return closest(this, 'FORM');

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -20151,5 +20151,17 @@ exports.tests = {
     });
 
     test.done();
+  },
+
+  option_element_id_attaching_on_id_change: function(test) {
+    var doc = jsdom.jsdom('<html><head></head><body></body></html>');
+    var option = doc.createElement('option');
+    option.setAttribute('id', 'foo');
+    doc.body.appendChild(option);
+    option.setAttribute('id', 'bar');
+
+    test.ok(!doc.getElementById('foo'), 'getElementById("foo") should not match after the id has been changed from foo to bar');
+    test.ok(doc.getElementById('bar') === option, 'getElementById("bar") should match after the id has been changed from foo to bar');
+    test.done();
   }
 }


### PR DESCRIPTION
document.getElementById would return results as if the id was never changed.

I stumbled upon this while trying to fix a different issue ;)
