### PR TITLE
One line fix accounting for mocking with Jest 

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -57,10 +57,10 @@ exports.jsdom = function (html, options) {
   }
   options.parsingMode = options.parsingMode || "auto";
 
-  if (!options.url && module.parent) {
+  if (!options.url) {
     if (typeof location !== 'undefined' && location.href) {
       options.url = location.href;
-    } else {
+    } else if (module.parent) {
       options.url = module.parent.id === 'jsdom' ? module.parent.parent.filename : module.parent.filename;
       options.url = options.url.replace(/\\/g, '/');
       if (options.url[0] !== '/') {


### PR DESCRIPTION
Mocking with Jest (and possibly some other weird cases) causes the module.parent to be undefined. If this isn't checked the module breaks on require. I am not entirely sure if this is the right place to fix this, the Jest module loader might be better, but this is the only module I have encountered that does this.
