### PR TITLE
Add missing window.console methods

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -212,10 +212,25 @@ exports.createWindow = function(dom, options) {
       return cs;
     },
     console: {
-      log:   function(message) { this._window.raise('log',   message) },
-      info:  function(message) { this._window.raise('info',  message) },
-      warn:  function(message) { this._window.raise('warn',  message) },
-      error: function(message) { this._window.raise('error', message) }
+      assert: function(expression, message) {
+        if (!expression) {
+          this._window.raise("error", "Assertion failed: " + message)
+        }
+      },
+      clear: function() {},
+      count: function() {},
+      debug: function() {},
+      error: function(message) { this._window.raise('error', message) },
+      group: function() {},
+      groupCollapse: function() {},
+      groupEnd: function() {},
+      info:  function(message) { this._window.raise('info', message) },
+      log:   function(message) { this._window.raise('log', message) },
+      table: function() {},
+      time: function() {},
+      timeEnd: function() {},
+      trace: function() {},
+      warn:  function(message) { this._window.raise('warn', message) }
     },
     navigator: {
       get userAgent() { return 'Node.js (' + process.platform + '; U; rv:' + process.version + ')'; },

--- a/test/window/console.js
+++ b/test/window/console.js
@@ -2,6 +2,37 @@
 
 var jsdom = require("../..").jsdom;
 
+// Tests for window.console
+// Spec: https://terinjokes.github.io/console-spec/
+
+exports["console has all methods in spec"] = function (t) {
+  var window = jsdom().parentWindow;
+
+  var methods = [
+    'assert',
+    'clear',
+    'count',
+    'debug',
+    'error',
+    'info',
+    'log',
+    'table',
+    'trace',
+    'warn',
+    'group',
+    'groupCollapse',
+    'groupEnd',
+    'time',
+    'timeEnd'
+  ];
+
+  methods.forEach(function (method) {
+    t.ok(typeof window.console[method] === "function", "console has the " + method + " method");
+  });
+
+  t.done();
+};
+
 exports["only console.error should put errors in the window.document.errors array"] = function (t) {
   var window = jsdom("<!DOCTYPE html><html><body>Hi</body></html>").parentWindow;
 


### PR DESCRIPTION
(Initially via https://github.com/tmpvar/jsdom/issues/926, while porting over https://github.com/assaf/zombie/blob/master/src/zombie/console.coffee)

Unless I'm missing something, it doesn't look like any console methods other than `console.error` output anything in jsdom ([all point to this code path](https://github.com/tmpvar/jsdom/blob/master/lib/jsdom/level1/core.js#L868)). My questions are:
- If console output isn't currently exposed anywhere, would providing stubs for all console methods be sufficient?
- Should there be a way to capture console output for better testing? (and maybe also to expose externally?)

I'll add to this PR based on feedback.
