### PR TITLE
Faster lengthFromProperties implementation

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -216,8 +216,19 @@ core.NodeList = function NodeList(element, query) {
 
 function lengthFromProperties(arrayLike) {
   var max = -1;
-  for (var i in arrayLike) {
-    var asNumber = +i;
+  var keys = Object.keys(arrayLike);
+  var highestKeyIndex = keys.length - 1;
+
+  // abuses a v8 implementation detail for a very fast case
+  // (if this implementation detail changes, this method will still
+  //  return correct results)
+  if (highestKeyIndex == keys[highestKeyIndex]) { // not ===
+    return keys.length;
+  }
+
+  for (var i = highestKeyIndex; i >= 0 ; --i) {
+    var asNumber = + keys[i];
+
     if (!isNaN(asNumber) && asNumber > max) {
       max = asNumber;
     }


### PR DESCRIPTION
Because of the way NodeList is implemented in jsdom, appendChild is extremely slow. Appending nodes is something like `O(n^2)`

Here is a benchmark I ran in chrome 39 (using browserify):

``` javascript
function iteration(doc) {
  var node = doc.createElement('div');
  for (var i = 1; i < 500; ++i) {
     node.appendChild(doc.createElement('div'));
   }
}
```

Calling `iteration()` `100` times costs roughly:
`30ms` if I use `window.document`
`4500ms` If I use a jsdom document _(mutation events disabled)_

This patch improves the benchmark considerably:
`1800ms` with this commit applied.

This new lengthFromProperties implementation is faster for two reasons:
1. In v8, if you use for..in on a object that has numerical keys, the function will not be optimized. Object.keys avoids this.
2. In javascript the order of keys in an object is undefined, however v8 keeps numerical keys sorted for internal optimization reasons. The new function has a branch that checks for this behaviour and returns the correct value without looping.

More benchmarks here: http://jsperf.com/calculate-length-of-array-like-object

I have an idea on how to make appendChild even faster: Use an array to store child nodes internally, and implement the `.childNodes` IDL the same way as `.children` is implemented. 
This would also make createElement much faster  because the defineProperty is avoided (calling defineProperty is extremely slow, removing defineProperties in level1/core.js makes createElement just as fast as native!)
