### PR TITLE
README.md: add missing `config.headers` desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ jsdom.env(config);
   - `referrer`: the new document will have this referrer.
   - `cookie`: manually set a cookie value, e.g. `'key=value; expires=Wed, Sep 21 2011 12:00:00 GMT; path=/'`.
   - `cookieDomain`: a cookie domain for the manually set cookie; defaults to `127.0.0.1`.
-- `config.headers`: a custom header which will be passed to `request` options.
+- `config.headers`: an object giving any headers that will be used while loading the HTML from `config.url`, if applicable
 - `config.features`: see Flexibility section below. **Note**: the default feature set for `jsdom.env` does _not_ include fetching remote JavaScript and executing it. This is something that you will need to _carefully_ enable yourself.
 - `config.done`, `config.loaded`, `config.created`: see below.
 


### PR DESCRIPTION
This option was added in 2011 but not documented. commit is here: tmpvar/jsdom@0fe4
