### PR TITLE
add a location change handler to catch requests to change location

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -238,6 +238,7 @@ function transformOptions(options, encoding) {
       parseOptions: { locationInfo: false },
       runScripts: undefined,
       encoding,
+      onLocationChange: undefined,
 
       // Defaults filled in later
       virtualConsole: undefined,
@@ -282,6 +283,8 @@ function transformOptions(options, encoding) {
 
     transformed.windowOptions.parseOptions = { locationInfo: true };
   }
+
+  transformed.windowOptions.onLocationChange = options.onLocationChange;
 
   transformed.windowOptions.cookieJar = options.cookieJar === undefined ?
                                        new CookieJar() :

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -100,6 +100,8 @@ function Window(options) {
   }];
   this._currentSessionHistoryEntryIndex = 0;
 
+  this._onLocationChange = options.onLocationChange;
+
   // TODO NEWAPI can remove this
   if (options.virtualConsole) {
     if (options.virtualConsole instanceof VirtualConsole) {

--- a/lib/jsdom/living/window/Location-impl.js
+++ b/lib/jsdom/living/window/Location-impl.js
@@ -10,15 +10,19 @@ const navigate = require("./navigation.js").navigate;
 
 exports.implementation = class LocationImpl {
   constructor(args, privateData) {
+    this._basicURL = args.basicURL;
     this._relevantDocument = privateData.relevantDocument;
     this.url = null;
   }
 
   get _url() {
-    return this._relevantDocument._URL;
+    return this._basicURL || this._relevantDocument._URL;
   }
 
   _locationObjectSetterNavigate(url) {
+    if (this._basicURL) {
+      return undefined;
+    }
     // Not implemented: extra steps here to determine replacement flag.
 
     return this._locationObjectNavigate(url);

--- a/lib/jsdom/living/window/navigation.js
+++ b/lib/jsdom/living/window/navigation.js
@@ -109,7 +109,9 @@ exports.navigate = (window, newURL, flags) => {
     }, 0);
     return;
   }
-  navigateFetch(window);
+
+  // currentURL passed to save some cpu cycles, if true navigation gets implemented probably don't do this.
+  navigateFetch(window, newURL, currentURL);
 };
 
 // https://html.spec.whatwg.org/#scroll-to-fragid
@@ -141,9 +143,18 @@ function navigateToFragment(window, newURL, flags) {
 }
 
 // https://html.spec.whatwg.org/#process-a-navigate-fetch
-function navigateFetch(window) {
-  // TODO:
-  notImplemented("navigation (except hash changes)", window);
+function navigateFetch(window, newURL, currentURL) {
+  if (window._onLocationChange) {
+    // require not at global because of circulars
+    const Location = require("../generated/Location"); // eslint-disable-line global-require
+    window._onLocationChange(
+      Location.create({ basicURL: newURL }, window),
+      Location.create({ basicURL: currentURL }, window)
+    );
+  } else {
+    // TODO:
+    notImplemented("navigation (except hash changes)", window);
+  }
 }
 
 function urlEquals(a, b, flags) {


### PR DESCRIPTION
allows a setup like
```js
new jsdom.JSDOM(
  '<script>document.location.href = "https://google.com";</script>', {
  runScripts: 'dangerously',
  onLocationChange: (newURL /*, currentURL */) => console.log(newURL.href),
});
```
Regardless of full navigation being added, we will need a handler, and this is that handler.