### PR TITLE
Add DocumentFragment.prototype.getElementById

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -454,6 +454,12 @@ class DocumentImpl extends NodeImpl {
     this.write(...arguments, "\n");
   }
 
+  // This is implemented separately for Document (which has a _ids cache) and DocumentFragment (which does not).
+  getElementById(id) {
+    // Return the first element with this ID.
+    return this._ids[id] && this._ids[id].length > 0 ? this._ids[id][0] : null;
+  }
+
   get referrer() {
     return this._referrer || "";
   }

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -34,6 +34,7 @@ const CDATASection = require("../generated/CDATASection");
 const Text = require("../generated/Text");
 const DocumentFragment = require("../generated/DocumentFragment");
 const DOMImplementation = require("../generated/DOMImplementation");
+const NonElementParentNodeImpl = require("./NonElementParentNode-impl").implementation;
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
 const Element = require("../generated/Element");
 const HTMLUnknownElement = require("../generated/HTMLUnknownElement");
@@ -453,11 +454,6 @@ class DocumentImpl extends NodeImpl {
     this.write(...arguments, "\n");
   }
 
-  getElementById(id) {
-    // return the first element
-    return this._ids[id] && this._ids[id].length > 0 ? this._ids[id][0] : null;
-  }
-
   get referrer() {
     return this._referrer || "";
   }
@@ -822,6 +818,7 @@ class DocumentImpl extends NodeImpl {
 
 eventAccessors.createEventAccessor(DocumentImpl.prototype, "readystatechange");
 mixin(DocumentImpl.prototype, GlobalEventHandlersImpl.prototype);
+mixin(DocumentImpl.prototype, NonElementParentNodeImpl.prototype);
 mixin(DocumentImpl.prototype, ParentNodeImpl.prototype);
 
 DocumentImpl.prototype._elementBuilders = Object.create(null);

--- a/lib/jsdom/living/nodes/DocumentFragment-impl.js
+++ b/lib/jsdom/living/nodes/DocumentFragment-impl.js
@@ -1,6 +1,7 @@
 "use strict";
 const { mixin } = require("../../utils");
 const NodeImpl = require("./Node-impl").implementation;
+const NonElementParentNodeImpl = require("./NonElementParentNode-impl").implementation;
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
 
 const NODE_TYPE = require("../node-type");
@@ -9,10 +10,12 @@ class DocumentFragmentImpl extends NodeImpl {
   constructor(args, privateData) {
     super(args, privateData);
 
+    this._ids = Object.create(null);
     this.nodeType = NODE_TYPE.DOCUMENT_FRAGMENT_NODE;
   }
 }
 
+mixin(DocumentFragmentImpl.prototype, NonElementParentNodeImpl.prototype);
 mixin(DocumentFragmentImpl.prototype, ParentNodeImpl.prototype);
 
 module.exports = {

--- a/lib/jsdom/living/nodes/DocumentFragment-impl.js
+++ b/lib/jsdom/living/nodes/DocumentFragment-impl.js
@@ -1,17 +1,31 @@
 "use strict";
 const { mixin } = require("../../utils");
+const { domSymbolTree } = require("../helpers/internal-constants");
+const NODE_TYPE = require("../node-type");
 const NodeImpl = require("./Node-impl").implementation;
 const NonElementParentNodeImpl = require("./NonElementParentNode-impl").implementation;
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
-
-const NODE_TYPE = require("../node-type");
 
 class DocumentFragmentImpl extends NodeImpl {
   constructor(args, privateData) {
     super(args, privateData);
 
-    this._ids = Object.create(null);
     this.nodeType = NODE_TYPE.DOCUMENT_FRAGMENT_NODE;
+  }
+
+  // This is implemented separately for Document (which has a _ids cache) and DocumentFragment (which does not).
+  getElementById(id) {
+    if (id === "") {
+      return null;
+    }
+
+    for (const descendant of domSymbolTree.treeIterator(this)) {
+      if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE && descendant.getAttributeNS(null, "id") === id) {
+        return descendant;
+      }
+    }
+
+    return null;
   }
 }
 

--- a/lib/jsdom/living/nodes/NonElementParentNode-impl.js
+++ b/lib/jsdom/living/nodes/NonElementParentNode-impl.js
@@ -1,7 +1,11 @@
 "use strict";
 
+// https://dom.spec.whatwg.org/#interface-nonelementparentnode
 class NonElementParentNodeImpl {
-
+  getElementById(id) {
+    // return the first element
+    return this._ids[id] && this._ids[id].length > 0 ? this._ids[id][0] : null;
+  }
 }
 
 module.exports = {

--- a/lib/jsdom/living/nodes/NonElementParentNode-impl.js
+++ b/lib/jsdom/living/nodes/NonElementParentNode-impl.js
@@ -1,11 +1,9 @@
 "use strict";
 
 // https://dom.spec.whatwg.org/#interface-nonelementparentnode
+// getElementById is implemented separately inside Document and DocumentFragment.
 class NonElementParentNodeImpl {
-  getElementById(id) {
-    // return the first element
-    return this._ids[id] && this._ids[id].length > 0 ? this._ids[id][0] : null;
-  }
+
 }
 
 module.exports = {

--- a/lib/jsdom/living/nodes/NonElementParentNode.webidl
+++ b/lib/jsdom/living/nodes/NonElementParentNode.webidl
@@ -1,7 +1,7 @@
 [NoInterfaceObject,
  Exposed=Window]
 interface NonElementParentNode {
-  Element? getElementById(DOMString elementId); // TODO implement in NonElementParentNode-impl instead of in Document-impl
+  Element? getElementById(DOMString elementId);
 };
 Document implements NonElementParentNode;
-// DocumentFragment implements NonElementParentNode;
+DocumentFragment implements NonElementParentNode;

--- a/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-getElementById.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-getElementById.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DocumentFragment.prototype.getElementById</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<template>
+  <div id="bar">
+    <span id="foo" data-yes></span>
+  </div>
+  <div id="foo">
+    <span id="foo"></span>
+    <ul id="bar">
+      <li id="foo"></li>
+    </ul>
+  </div>
+</template>
+
+<script>
+"use strict";
+
+test(() => {
+  assert_equals(typeof DocumentFragment.prototype.getElementById, "function", "It must exist on the prototype");
+  assert_equals(typeof document.createDocumentFragment().getElementById, "function", "It must exist on an instance");
+}, "The method must exist");
+
+test(() => {
+  assert_equals(document.createDocumentFragment().getElementById("foo"), null);
+  assert_equals(document.createDocumentFragment().getElementById(""), null);
+}, "It must return null when there are no matches");
+
+test(() => {
+  const frag = document.createDocumentFragment();
+  frag.appendChild(document.createElement("div"));
+  frag.appendChild(document.createElement("span"));
+  frag.childNodes[0].id = "foo";
+  frag.childNodes[1].id = "foo";
+
+  assert_equals(frag.getElementById("foo"), frag.childNodes[0]);
+}, "It must return the first element when there are matches");
+
+test(() => {
+  const frag = document.querySelector("template").content;
+
+  assert_true(frag.getElementById("foo").hasAttribute("data-yes"));
+}, "It must return the first element when there are matches, using a template");
+</script>

--- a/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-getElementById.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-getElementById.html
@@ -43,6 +43,18 @@ test(() => {
 }, "It must return the first element when there are matches");
 
 test(() => {
+  const frag = document.createDocumentFragment();
+  frag.appendChild(document.createElement("div"));
+  frag.childNodes[0].setAttribute("id", "");
+
+  assert_equals(
+    frag.getElementById(""),
+    null,
+    "Even if there is an element with an empty-string ID attribute, it must not be returned"
+  );
+});
+
+test(() => {
   const frag = document.querySelector("template").content;
 
   assert_true(frag.getElementById("foo").hasAttribute("data-yes"));


### PR DESCRIPTION
Based on a patch by @Zirro from IRC, with my own tests added. However, this does *not* work, because the functions in Element-impl.js that update the `_ids` collection do not care about DocumentFragment containers.

I'm unsure how to proceed. I guess one route is to have totally separate implementations of getElementById for Document and DocumentFragment, with the DocumentFragment version doing a whole traversal. That seems relatively easy. Alternately we could try to develop some kind of caching system, and a notation of "root" i.e. furthest ancestor.

Thoughts welcome.