### PR TITLE
[bugfixed]"client.abort is not a function"

### DIFF
--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -373,7 +373,7 @@ module.exports = function createXMLHttpRequest(window) {
 
       const { client } = properties;
       if (client) {
-        client.abort();
+        client.emit('abort');
         properties.client = null;
       }
 


### PR DESCRIPTION
When I use xmlHttpRequest, it throw "client.abort is not a function". It is bug! Client is a instance of eventEmitter, and we should use emit.

Here is the problem:
```
TypeError: client.abort is not a function
      
      at XMLHttpRequest.abort (node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:376:20)
      at Object.abort (node_modules/jsdom/lib/jsdom/living/xhr-utils.js:422:13)
      at RequestManager.close (node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:131:21)
      at Window.close (node_modules/jsdom/lib/jsdom/browser/Window.js:465:29)
```
