### PR TITLE
Fix HTMLImageElement removeAttribute for src

### DIFF
--- a/lib/jsdom/living/nodes/HTMLImageElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLImageElement-impl.js
@@ -19,17 +19,21 @@ class HTMLImageElementImpl extends HTMLElementImpl {
           };
         }
         this._currentSrc = null;
-        resourceLoader.load(this, this.src, {}, (data, url, response) => {
-          if (response && response.statusCode !== undefined && response.statusCode !== 200) {
-            throw new Error("Status code: " + response.statusCode);
-          }
-          error = null;
-          this._image.source = data;
-          if (error) {
-            throw new Error(error);
-          }
-          this._currentSrc = value;
-        });
+        if (this.hasAttribute("src")) {
+          resourceLoader.load(this, this.src, {}, (data, url, response) => {
+            if (response && response.statusCode !== undefined && response.statusCode !== 200) {
+              throw new Error("Status code: " + response.statusCode);
+            }
+            error = null;
+            this._image.source = data;
+            if (error) {
+              throw new Error(error);
+            }
+            this._currentSrc = value;
+          });
+        } else {
+          this._image.source = undefined;
+        }
       }
     }
 

--- a/test/to-port-to-wpts/htmlimageelement.js
+++ b/test/to-port-to-wpts/htmlimageelement.js
@@ -135,4 +135,35 @@ describe("htmlimageelement", { skipIfBrowser: true }, () => {
   }, {
     async: true
   });
+
+  specify("removing src attribute from image", t => {
+    if (!isCanvasInstalled(assert, t.done)) {
+      return;
+    }
+    const window = jsdom.jsdom("", { features: { FetchExternalResources: ["img"] } }).defaultView;
+    const image = new window.Image();
+    const src = fs.readFileSync(path.resolve(__dirname, "files/image.txt"), { encoding: "utf-8" }).trim();
+    const onLoadWithoutSrc = () => {
+      assert.ok(false, "onload should not be triggered when src attribute is removed");
+      t.done();
+    };
+    const onErrorWithoutSrc = () => {
+      assert.ok(false, "onerror should not be triggered when src attribute is removed");
+      t.done();
+    };
+    image.onload = () => {
+      image.onload = onLoadWithoutSrc;
+      image.onerror = onErrorWithoutSrc;
+      assert.doesNotThrow(() => image.removeAttribute("src"));
+      assert.strictEqual(image.width, 0, "after removing src, width should be 0");
+      assert.strictEqual(image.height, 0, "after removeing src, width should be 0");
+      assert.strictEqual(image.complete, false, "after removeing src, complete should be false");
+      assert.strictEqual(image.src, "", "after removeing src, src should be an empty string");
+      assert.strictEqual(image.currentSrc, "", "after removeing src, currentSrc should be an empty string");
+      t.done();
+    }
+    image.src = src;
+  }, {
+    async: true
+  });
 });

--- a/test/to-port-to-wpts/htmlimageelement.js
+++ b/test/to-port-to-wpts/htmlimageelement.js
@@ -135,35 +135,4 @@ describe("htmlimageelement", { skipIfBrowser: true }, () => {
   }, {
     async: true
   });
-
-  specify("removing src attribute from image", t => {
-    if (!isCanvasInstalled(assert, t.done)) {
-      return;
-    }
-    const window = jsdom.jsdom("", { features: { FetchExternalResources: ["img"] } }).defaultView;
-    const image = new window.Image();
-    const src = fs.readFileSync(path.resolve(__dirname, "files/image.txt"), { encoding: "utf-8" }).trim();
-    const onLoadWithoutSrc = () => {
-      assert.ok(false, "onload should not be triggered when src attribute is removed");
-      t.done();
-    };
-    const onErrorWithoutSrc = () => {
-      assert.ok(false, "onerror should not be triggered when src attribute is removed");
-      t.done();
-    };
-    image.onload = () => {
-      image.onload = onLoadWithoutSrc;
-      image.onerror = onErrorWithoutSrc;
-      assert.doesNotThrow(() => image.removeAttribute("src"));
-      assert.strictEqual(image.width, 0, "after removing src, width should be 0");
-      assert.strictEqual(image.height, 0, "after removeing src, width should be 0");
-      assert.strictEqual(image.complete, false, "after removeing src, complete should be false");
-      assert.strictEqual(image.src, "", "after removeing src, src should be an empty string");
-      assert.strictEqual(image.currentSrc, "", "after removeing src, currentSrc should be an empty string");
-      t.done();
-    }
-    image.src = src;
-  }, {
-    async: true
-  });
 });

--- a/test/web-platform-tests/run-single-wpt.js
+++ b/test/web-platform-tests/run-single-wpt.js
@@ -51,7 +51,7 @@ function createJSDOM(urlPrefix, testPath) {
       pool: globalPool,
       strictSSL: false,
       features: {
-        FetchExternalResources: ["script", "frame", "iframe", "link"],
+        FetchExternalResources: ["script", "frame", "iframe", "link", "img"],
         ProcessExternalResources: ["script"]
       },
       virtualConsole,

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
@@ -1,19 +1,18 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Removing src attribute from img</title>
+<title>Removing src attribute from img after it loads</title>
 <link rel="author" title="atsikov" href="mailto:alexey.tsikov@gmail.com">
-<link rel=help href="https://html.spec.whatwg.org/#the-img-element">
+<link rel="help" href="https://html.spec.whatwg.org/#the-img-element">
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<body>
 <script>
 "use strict";
 
 async_test(t => {
   const image = new window.Image();
-  image.onload = () => {
+  const runTest = t.step_func(() => {
     image.onload = t.unreached_func("onload should not be called with removed src");
     image.onerror = t.unreached_func("onerror should not be called with removed src");
     image.removeAttribute("src");
@@ -23,19 +22,18 @@ async_test(t => {
     assert_equals(image.complete, false);
     assert_equals(image.src, "");
     assert_equals(image.currentSrc, "");
-  };
+
+    // Give it a second to make sure onload/onerror don't fire within that time frame.
+    t.step_timeout(() => {
+      t.done();
+    }, 1000);
+  });
 
   image.src = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
 
-  t.step_timeout(() => {
-    // JSDOM specific: in case image loading is not supported (no canvas api), run checks out of onload handler
-    image.removeAttribute("src");
-    assert_equals(image.src, "");
-    assert_equals(image.currentSrc, "");
-    // end of JSDOM specific
+  img.onload = runTest;
 
-    t.done();
-  }, 1000);
+  // JSDOM specific: when image loading is not supported (i.e. when node-canvas is not installed), run the test anyway.
+  t.step_timeout(runTest, 1000);
 }, "img is cleared when src attribute is removed");
 </script>
-</body>

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Disabled checkbox event handling</title>
+<link rel="author" title="atsikov" href="mailto:alexey.tsikov@gmail.com">
+<link rel=help href="https://html.spec.whatwg.org/#the-img-element">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+async_test(t => {
+  const grayPx = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
+  const image = new window.Image();
+  image.onload = () => {
+    image.onload = () => {
+      assert_true(false, "onload should not be called with removed src");
+    };
+    image.error = () => {
+      assert_true(false, "error should not be called with removed src");
+    };
+    image.removeAttribute("src");
+    assert_equals(image.width, 0);
+    assert_equals(image.height, 0);
+    assert_equals(image.src, "");
+    assert_equals(image.currentSrc, "");
+    t.done();
+  };
+  image.src = grayPx;
+}, "img is cleared when src attribute is removed");
+</script>
+</body>

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
@@ -23,18 +23,16 @@ async_test(t => {
     assert_equals(image.complete, false);
     assert_equals(image.src, "");
     assert_equals(image.currentSrc, "");
-
-    t.done();
   };
 
   image.src = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
 
-  // JSDOM specific: in case image loading is not supported (no canvas api), run checks out of onload handler
   t.step_timeout(() => {
+    // JSDOM specific: in case image loading is not supported (no canvas api), run checks out of onload handler
     image.removeAttribute("src");
-
     assert_equals(image.src, "");
     assert_equals(image.currentSrc, "");
+    // end of JSDOM specific
 
     t.done();
   }, 1000);

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
@@ -31,7 +31,7 @@ async_test(t => {
 
   image.src = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
 
-  img.onload = runTest;
+  image.onload = runTest;
 
   // JSDOM specific: when image loading is not supported (i.e. when node-canvas is not installed), run the test anyway.
   t.step_timeout(runTest, 1000);

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
@@ -11,8 +11,17 @@
 <script>
 "use strict";
 
+function testRemoveSrc(image, t) {
+  image.removeAttribute("src");
+  assert_equals(image.width, 0);
+  assert_equals(image.height, 0);
+  assert_equals(image.complete, false);
+  assert_equals(image.src, "");
+  assert_equals(image.currentSrc, "");
+  t.done();
+}
+
 async_test(t => {
-  const grayPx = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
   const image = new window.Image();
   image.onload = () => {
     image.onload = () => {
@@ -21,14 +30,14 @@ async_test(t => {
     image.error = () => {
       assert_true(false, "error should not be called with removed src");
     };
-    image.removeAttribute("src");
-    assert_equals(image.width, 0);
-    assert_equals(image.height, 0);
-    assert_equals(image.src, "");
-    assert_equals(image.currentSrc, "");
-    t.done();
+    testRemoveSrc(image, t);
   };
-  image.src = grayPx;
+  image.src = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
+
+  t.step_timeout(() => {
+    // in case image loading is not supported, run checks out of onload handler
+    testRemoveSrc(image, t);
+  }, 1000);
 }, "img is cleared when src attribute is removed");
 </script>
 </body>

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/remove-attribute-src.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Disabled checkbox event handling</title>
+<title>Removing src attribute from img</title>
 <link rel="author" title="atsikov" href="mailto:alexey.tsikov@gmail.com">
 <link rel=help href="https://html.spec.whatwg.org/#the-img-element">
 
@@ -11,32 +11,32 @@
 <script>
 "use strict";
 
-function testRemoveSrc(image, t) {
-  image.removeAttribute("src");
-  assert_equals(image.width, 0);
-  assert_equals(image.height, 0);
-  assert_equals(image.complete, false);
-  assert_equals(image.src, "");
-  assert_equals(image.currentSrc, "");
-  t.done();
-}
-
 async_test(t => {
   const image = new window.Image();
   image.onload = () => {
-    image.onload = () => {
-      assert_true(false, "onload should not be called with removed src");
-    };
-    image.error = () => {
-      assert_true(false, "error should not be called with removed src");
-    };
-    testRemoveSrc(image, t);
+    image.onload = t.unreached_func("onload should not be called with removed src");
+    image.onerror = t.unreached_func("onerror should not be called with removed src");
+    image.removeAttribute("src");
+
+    assert_equals(image.width, 0);
+    assert_equals(image.height, 0);
+    assert_equals(image.complete, false);
+    assert_equals(image.src, "");
+    assert_equals(image.currentSrc, "");
+
+    t.done();
   };
+
   image.src = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
 
+  // JSDOM specific: in case image loading is not supported (no canvas api), run checks out of onload handler
   t.step_timeout(() => {
-    // in case image loading is not supported, run checks out of onload handler
-    testRemoveSrc(image, t);
+    image.removeAttribute("src");
+
+    assert_equals(image.src, "");
+    assert_equals(image.currentSrc, "");
+
+    t.done();
   }, 1000);
 }, "img is cleared when src attribute is removed");
 </script>


### PR DESCRIPTION
This change should fix exception raised while removing src attribute from HTMLImageElement (https://github.com/jsdom/jsdom/issues/2150)