### PR TITLE
Implement requestAnimationFrame using performance.now

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -30,10 +30,6 @@ const { matchesDontThrow } = require("../living/helpers/selectors");
 const SessionHistory = require("../living/window/SessionHistory");
 const { contextifyWindow } = require("./documentfeatures.js");
 
-// Browserify's process implementation doesn't have hrtime, and this package is small so not much of a burden for
-// Node.js users.
-const hrtime = require("browser-process-hrtime");
-
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
 
@@ -56,8 +52,7 @@ function Window(options) {
   EventTarget.setup(this);
 
   const rawPerformance = new RawPerformance();
-  const windowInitialized = hrtime();
-
+  const windowInitialized = rawPerformance.now();
 
   const window = this;
 
@@ -255,8 +250,7 @@ function Window(options) {
 
   if (this._pretendToBeVisual) {
     this.requestAnimationFrame = fn => {
-      const hr = hrtime(windowInitialized);
-      const hrInMicro = hr[0] * 1e3 + hr[1] / 1e6;
+      const timestamp = rawPerformance.now() - windowInitialized;
       const fps = 1000 / 60;
 
       return startTimer(
@@ -267,7 +261,7 @@ function Window(options) {
         fn,
         fps,
         animationFrameCallbacks,
-        [hrInMicro]
+        [timestamp]
       );
     };
     this.cancelAnimationFrame = stopTimer.bind(this, animationFrameCallbacks);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "acorn": "^5.3.0",
     "acorn-globals": "^4.1.0",
     "array-equal": "^1.0.0",
-    "browser-process-hrtime": "^0.1.2",
     "cssom": ">= 0.3.2 < 0.4.0",
     "cssstyle": ">= 0.2.37 < 0.3.0",
     "data-urls": "^1.0.0",


### PR DESCRIPTION
Shouldn't make a practical difference as `w3c-hr-time` uses `browser-process-hrtime` (thus no change in lockfile), but it simplifies things a tiny bit.