### PR TITLE
fix: require canvas lib

### DIFF
--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -183,7 +183,19 @@ exports.treeOrderSorter = function (a, b) {
 exports.Canvas = null;
 ["canvas", "canvas-prebuilt"].some(moduleName => {
   try {
-    exports.Canvas = require(moduleName);
+    const canvasLib = require(moduleName);
+    // `canvas` and `canvas-prebuilt` export different result
+    //     for `canvas` situation,
+    //     which export an Object like this { Canvas, Image, ... }
+    //     ref: https://github.com/Automattic/node-canvas/blob/master/index.js#L51
+    if (canvasLib && canvasLib.Canvas) {
+      exports.Canvas = canvasLib.Canvas;
+      // we can assign more properties to exports.Canvas
+      // but jsdom only use `Canvas` and `Image`
+      exports.Canvas.Image = canvasLib.Image;
+    } else {
+      exports.Canvas = canvasLib;
+    }
     if (typeof exports.Canvas !== "function") {
       // In browserify, the require will succeed but return an empty object
       exports.Canvas = null;


### PR DESCRIPTION
`canvas` and `canvas-prebuilt` export different result
 for `canvas` situation,  which export an Object like this `{ Canvas, Image, ... }`, see [here](https://github.com/Automattic/node-canvas/blob/master/index.js#L51) for more details.