### PR TITLE
Fix cloning of Documents

### DIFF
--- a/lib/jsdom/living/node.js
+++ b/lib/jsdom/living/node.js
@@ -14,14 +14,13 @@ module.exports.clone = function (node, document, cloneChildren) {
   let copy;
   switch (node.nodeType) {
     case NODE_TYPE.DOCUMENT_NODE:
-      // TODO: just use Document when we eliminate the difference between Document and HTMLDocument.
-      if (node.contentType === "text/html") { // need to differentiate due to parsing mode
-        copy = document.implementation.createHTMLDocument();
-        copy.removeChild(copy.documentElement); // ;_;
-      } else {
-        copy = document.implementation.createDocument("", "", null);
-      }
-      document = copy;
+      // Can't use a simple Document.createImpl because of circular dependency issues :-/
+      copy = document.implementation.createDocument(null, "", null);
+      copy._encoding = node._encoding;
+      copy._contentType = node._contentType;
+      copy._URL = node._URL;
+      copy._origin = node._origin;
+      copy._parsingMode = node._parsingMode;
       break;
 
     case NODE_TYPE.DOCUMENT_TYPE_NODE:

--- a/lib/jsdom/living/nodes/DOMImplementation-impl.js
+++ b/lib/jsdom/living/nodes/DOMImplementation-impl.js
@@ -26,12 +26,6 @@ class DOMImplementationImpl {
   }
 
   createDocument(namespace, qualifiedName, doctype) {
-    namespace = namespace !== null ? String(namespace) : namespace;
-    qualifiedName = qualifiedName === null ? "" : String(qualifiedName);
-    if (doctype === undefined) {
-      doctype = null;
-    }
-
     const document = Document.createImpl([], {
       options: { parsingMode: "xml", encoding: "UTF-8" }
     });

--- a/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-document-with-doctype.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-document-with-doctype.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cloning of a document with a doctype</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-clonenode">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const doctype = document.implementation.createDocumentType("name", "publicId", "systemId");
+  const doc = document.implementation.createDocument("namespace", "", doctype);
+
+  const clone = doc.cloneNode(true);
+
+  assert_equals(clone.childNodes.length, 1, "Only one child node");
+  assert_equals(clone.childNodes[0].nodeType, Node.DOCUMENT_TYPE_NODE, "Is a document fragment");
+  assert_equals(clone.childNodes[0].name, "name");
+  assert_equals(clone.childNodes[0].publicId, "publicId");
+  assert_equals(clone.childNodes[0].systemId, "systemId");
+}, "Created with the createDocument/createDocumentType");
+
+test(() => {
+  const doc = document.implementation.createHTMLDocument();
+
+  const clone = doc.cloneNode(true);
+
+  assert_equals(clone.childNodes.length, 2, "Two child nodes");
+  assert_equals(clone.childNodes[0].nodeType, Node.DOCUMENT_TYPE_NODE, "Is a document fragment");
+  assert_equals(clone.childNodes[0].name, "html");
+  assert_equals(clone.childNodes[0].publicId, "");
+  assert_equals(clone.childNodes[0].systemId, "");
+}, "Created with the createHTMLDocument");
+
+test(() => {
+  const parser = new window.DOMParser();
+  const doc = parser.parseFromString("<!DOCTYPE html><html></html>", "text/html");
+
+  const clone = doc.cloneNode(true);
+
+  assert_equals(clone.childNodes.length, 2, "Two child nodes");
+  assert_equals(clone.childNodes[0].nodeType, Node.DOCUMENT_TYPE_NODE, "Is a document fragment");
+  assert_equals(clone.childNodes[0].name, "html");
+  assert_equals(clone.childNodes[0].publicId, "");
+  assert_equals(clone.childNodes[0].systemId, "");
+}, "Created with DOMParser");
+
+</script>


### PR DESCRIPTION
Previously it would not clone all pieces of state, and sometimes would add an extra doctype.

Also removes some unnecessary-in-a-webidl2js-world argument conversion code from DOMImplementation's createDocument().

Closes #2191.