### PR TITLE
Fixed a line in toBlob() where quality was always taken to be 0

### DIFF
--- a/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
@@ -68,7 +68,7 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
         case "image/jpg":
         case "image/jpeg":
           stream = canvas.createJPEGStream({
-            quality: Math.min(0, Math.max(1, qualityArgument)) * 100
+            quality: Math.max(0, Math.min(1, qualityArgument)) * 100
           });
           break;
         default:


### PR DESCRIPTION
Just a single line change replacing 
`Math.min(0, Math.max(1, qualityArgument)) * 100 
`
with
`Math.max(0, Math.min(1, qualityArgument)) * 100`