### PR TITLE
Fix old-api tests missing html property

### DIFF
--- a/test/old-api/env.js
+++ b/test/old-api/env.js
@@ -133,9 +133,9 @@ describe("jsdom/env", () => {
   });
 
   specify("string, full HTML document", { async: true }, t => {
-    env(
-      "<!DOCTYPE html><html><head><title>Hi</title></head><body>Hello</body></html>",
-      (err, window) => {
+    env({
+      html: "<!DOCTYPE html><html><head><title>Hi</title></head><body>Hello</body></html>",
+      done(err, window) {
         assert.ifError(err);
         assert.equal(
           serializeDocument(window.document),
@@ -143,18 +143,18 @@ describe("jsdom/env", () => {
         );
         t.done();
       }
-    );
+    });
   });
 
   specify("string, HTML content with a null byte", { async: true }, t => {
-    env(
-      "<div>\0</div>",
-      (err, window) => {
+    env({
+      html: "<div>\0</div>",
+      done(err, window) {
         assert.ifError(err);
         assert.ok(window.document.querySelector("div") !== null, "div was parsed");
         t.done();
       }
-    );
+    });
   });
 
   specify("with src", { async: true }, t => {


### PR DESCRIPTION
Two of the old-api tests were missing their `html` property, apparently resulting in the HTML getting passed to `fs.readFile` as a filename through resource-loader instead.

This issue was revealed by changes in Node.js v10 - likely https://github.com/nodejs/node/commit/d8f73385e2 where the null byte included in one of the tests now causes a synchronous error to be thrown.

There could potentially be more tests with missing `html` properties. I only had a quick look through `env.js`.