### PR TITLE
Upgrade whatwg-url to version 6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webidl-conversions": "^4.0.2",
     "whatwg-encoding": "^1.0.3",
     "whatwg-mimetype": "^2.1.0",
-    "whatwg-url": "^6.4.0",
+    "whatwg-url": "^6.4.1",
     "ws": "^4.0.0",
     "xml-name-validator": "^3.0.0"
   },

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -810,7 +810,6 @@ a-element-xhtml.xhtml: [fail, Unknown]
 a-element.html: [fail, Unknown]
 failure.html: [fail, Depends on fetch]
 interfaces.any.html: [fail, Depends on fetch]
-url-constructor.html: [fail, href setter does not propagate to URL.searchParams, https://github.com/jsdom/whatwg-url/issues/111]
 urlencoded-parser.html: [fail, Depends on fetch]
 
 ---

--- a/yarn.lock
+++ b/yarn.lock
@@ -3684,7 +3684,7 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.
   dependencies:
     punycode "^1.4.1"
 
-tr46@^1.0.0:
+tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
@@ -3852,7 +3852,7 @@ wd@^1.4.0, wd@^1.5.0:
     underscore.string "3.3.4"
     vargs "0.1.0"
 
-webidl-conversions@^4.0.0, webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
+webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -3880,13 +3880,13 @@ whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
-whatwg-url@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+whatwg-url@^6.4.0, whatwg-url@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.1.tgz#fdb94b440fd4ad836202c16e9737d511f012fd67"
   dependencies:
     lodash.sortby "^4.7.0"
-    tr46 "^1.0.0"
-    webidl-conversions "^4.0.1"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
It includes a fix to make the href setter propagate changes to `URL.searchParams`, allowing the `url/url-constructor.html` test to pass.