### PR TITLE
Add support for HTMLLabelElement.control

### DIFF
--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -72,7 +72,6 @@ exports.isLabelable = node => {
 
   switch (node.tagName) {
     case "BUTTON":
-    case "KEYGEN":
     case "METER":
     case "OUTPUT":
     case "PROGRESS":

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -18,6 +18,10 @@ const {
 } = require("./dates-and-times");
 const whatwgURL = require("whatwg-url");
 
+const NodeList = require("../generated/NodeList");
+const { domSymbolTree } = require("../helpers/internal-constants");
+const NODE_TYPE = require("../node-type");
+const { getRootNode } = require("../helpers/traversal");
 const submittableLocalNames = new Set(["button", "input", "keygen", "object", "select", "textarea"]);
 
 exports.isDisabled = formControl => {
@@ -58,6 +62,51 @@ exports.normalizeToCRLF = string => {
     .replace(/\r$/, "\r\n")
     .replace(/([^\r])\n/g, "$1\r\n")
     .replace(/^\n/, "\r\n");
+};
+
+exports.isLabelable = node => {
+  // labelable logic defined at: https://html.spec.whatwg.org/multipage/forms.html#category-label
+  if (node.nodeType !== NODE_TYPE.ELEMENT_NODE) {
+    return false;
+  }
+
+  switch (node.tagName) {
+    case "BUTTON":
+    case "KEYGEN":
+    case "METER":
+    case "OUTPUT":
+    case "PROGRESS":
+    case "SELECT":
+    case "TEXTAREA":
+      return true;
+
+    case "INPUT":
+      return node.type !== "hidden";
+  }
+
+  return false;
+};
+
+exports.getLabelsForLabelable = labelable => {
+  if (!exports.isLabelable(labelable)) {
+    return null;
+  }
+  if (!labelable._labels) {
+    const root = getRootNode(labelable);
+    labelable._labels = NodeList.create([], {
+      element: root,
+      query: () => {
+        const nodes = [];
+        for (const descendant of domSymbolTree.treeIterator(root)) {
+          if (descendant.control === labelable) {
+            nodes.push(descendant);
+          }
+        }
+        return nodes;
+      }
+    });
+  }
+  return labelable._labels;
 };
 
 // https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address

--- a/lib/jsdom/living/helpers/traversal.js
+++ b/lib/jsdom/living/helpers/traversal.js
@@ -82,3 +82,10 @@ exports.firstDescendantWithHTMLLocalName = (parent, localName) => {
   return null;
 };
 
+exports.getRootNode = node => {
+  let root;
+  for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
+    root = ancestor;
+  }
+  return root;
+};

--- a/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
@@ -12,6 +12,7 @@ class HTMLButtonElementImpl extends HTMLElementImpl {
     super(args, privateData);
 
     this._customValidityErrorMessage = "";
+    this._labels = null;
   }
 
   _activationBehavior() {

--- a/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
@@ -5,6 +5,7 @@ const { isDisabled } = require("../helpers/form-controls");
 const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
 const { mixin } = require("../../utils");
+const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLButtonElementImpl extends HTMLElementImpl {
   constructor(args, privateData) {
@@ -25,6 +26,10 @@ class HTMLButtonElementImpl extends HTMLElementImpl {
   _getValue() {
     const valueAttr = this.getAttribute("value");
     return valueAttr === null ? "" : valueAttr;
+  }
+
+  get labels() {
+    return getLabelsForLabelable(this);
   }
 
   get form() {

--- a/lib/jsdom/living/nodes/HTMLButtonElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLButtonElement.webidl
@@ -20,5 +20,5 @@ interface HTMLButtonElement : HTMLElement {
   boolean reportValidity();
   void setCustomValidity(DOMString error);
 
-//  readonly attribute NodeList labels;
+  readonly attribute NodeList labels;
 };

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -4,6 +4,7 @@ const DOMException = require("domexception");
 const Event = require("../generated/Event");
 const FileList = require("../generated/FileList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+const NodeList = require("../generated/NodeList");
 const idlUtils = require("../generated/utils");
 const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
@@ -59,6 +60,7 @@ function allowVariableLengthSelection(type) {
 
 const valueAttributeDefaultMode = new Set(["hidden", "submit", "image", "reset", "button"]);
 const valueAttributeDefaultOnMode = new Set(["checkbox", "radio"]);
+
 function valueAttributeMode(type) {
   if (valueAttributeDefaultMode.has(type)) {
     return "default";
@@ -240,6 +242,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
     super._attrModified.apply(this, arguments);
   }
+
   _formReset() {
     const wrapper = idlUtils.wrapperForImpl(this);
     this._value = sanitizeValueByType(this, wrapper.defaultValue);
@@ -250,6 +253,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
       this._removeOtherRadioCheckedness();
     }
   }
+
   _changedFormOwner() {
     if (this._checkedness) {
       this._removeOtherRadioCheckedness();
@@ -316,6 +320,16 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     return this._otherRadioGroupElements.some(radioGroupElement => radioGroupElement.checked);
   }
 
+  get labels() {
+    const root = this.ownerDocument;
+    return NodeList.create([], {
+      element: root,
+      query: () => domSymbolTree.treeToArray(root, {
+        filter: node => node.tagName === "LABEL" && node.control === this
+      })
+    });
+  }
+
   get form() {
     return closest(this, "form");
   }
@@ -354,6 +368,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
         throw new Error("jsdom internal error: unknown value attribute mode");
     }
   }
+
   set value(val) {
     switch (valueAttributeMode(this.type)) {
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-value
@@ -387,7 +402,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
           this.files.length = 0;
         } else {
           throw new DOMException("This input element accepts a filename, which may only be programmatically set to " +
-                                 "the empty string.", "InvalidStateError");
+            "the empty string.", "InvalidStateError");
         }
         break;
 
@@ -404,6 +419,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     }
     return this[filesSymbol];
   }
+
   set files(value) {
     if (this.type === "file" && value !== null) {
       this[filesSymbol] = value;
@@ -414,6 +430,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     const type = this.getAttribute("type");
     return type ? type.toLowerCase() : "text";
   }
+
   set type(type) {
     this.setAttribute("type", type);
   }
@@ -423,6 +440,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     event.initEvent("select", true, true);
     this.dispatchEvent(event);
   }
+
   _getValueLength() {
     return typeof this.value === "string" ? this.value.length : 0;
   }

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -153,6 +153,14 @@ const convertStringToNumberByTypeMap = new Map([
   ["range", parseFloatingPointNumber]
 ]);
 
+function getRootNode(node) {
+  let root;
+  for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
+    root = ancestor;
+  }
+  return root;
+}
+
 class HTMLInputElementImpl extends HTMLElementImpl {
   constructor(args, privateData) {
     super(args, privateData);
@@ -320,14 +328,30 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     return this._otherRadioGroupElements.some(radioGroupElement => radioGroupElement.checked);
   }
 
+  _isHiddenInput() {
+    return this.tagName === "INPUT" && this.type === "hidden";
+  }
+
   get labels() {
-    const root = this.ownerDocument;
-    return NodeList.create([], {
-      element: root,
-      query: () => domSymbolTree.treeToArray(root, {
-        filter: node => node.tagName === "LABEL" && node.control === this
-      })
-    });
+    if (this._isHiddenInput()) {
+      return null;
+    }
+    if (!this._labels) {
+      const root = getRootNode(this);
+      this._labels = NodeList.create([], {
+        element: root,
+        query: () => {
+          const nodes = [];
+          for (const descendant of domSymbolTree.treeIterator(root)) {
+            if (descendant.control === this) {
+              nodes.push(descendant);
+            }
+          }
+          return nodes;
+        }
+      });
+    }
+    return this._labels;
   }
 
   get form() {

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -172,6 +172,8 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     this.indeterminate = false;
 
     this._customValidityErrorMessage = "";
+
+    this._labels = null;
   }
 
   // https://html.spec.whatwg.org/multipage/input.html#concept-input-value-string-number

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -4,7 +4,6 @@ const DOMException = require("domexception");
 const Event = require("../generated/Event");
 const FileList = require("../generated/FileList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
-const NodeList = require("../generated/NodeList");
 const idlUtils = require("../generated/utils");
 const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
@@ -12,6 +11,7 @@ const ValidityState = require("../generated/ValidityState");
 const { mixin } = require("../../utils");
 const { domSymbolTree, cloningSteps } = require("../helpers/internal-constants");
 const { closest } = require("../helpers/traversal");
+const { getLabelsForLabelable } = require("../helpers/form-controls");
 const {
   isDisabled,
   isValidEmailAddress,
@@ -152,14 +152,6 @@ const convertStringToNumberByTypeMap = new Map([
   // https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range):concept-input-value-string-number
   ["range", parseFloatingPointNumber]
 ]);
-
-function getRootNode(node) {
-  let root;
-  for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
-    root = ancestor;
-  }
-  return root;
-}
 
 class HTMLInputElementImpl extends HTMLElementImpl {
   constructor(args, privateData) {
@@ -328,30 +320,8 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     return this._otherRadioGroupElements.some(radioGroupElement => radioGroupElement.checked);
   }
 
-  _isHiddenInput() {
-    return this.tagName === "INPUT" && this.type === "hidden";
-  }
-
   get labels() {
-    if (this._isHiddenInput()) {
-      return null;
-    }
-    if (!this._labels) {
-      const root = getRootNode(this);
-      this._labels = NodeList.create([], {
-        element: root,
-        query: () => {
-          const nodes = [];
-          for (const descendant of domSymbolTree.treeIterator(root)) {
-            if (descendant.control === this) {
-              nodes.push(descendant);
-            }
-          }
-          return nodes;
-        }
-      });
-    }
-    return this._labels;
+    return getLabelsForLabelable(this);
   }
 
   get form() {

--- a/lib/jsdom/living/nodes/HTMLInputElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLInputElement.webidl
@@ -50,7 +50,7 @@ interface HTMLInputElement : HTMLElement {
   boolean reportValidity();
   void setCustomValidity(DOMString error);
 
-//  readonly attribute NodeList? labels;
+  readonly attribute NodeList? labels;
 
   void select();
   attribute unsigned long? selectionStart;

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -2,7 +2,6 @@
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
-const { closest } = require("../helpers/traversal");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const { isDisabled } = require("../helpers/form-controls");
 
@@ -65,7 +64,11 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
   }
 
   get form() {
-    return closest(this, "form");
+    const node = this.control;
+    if (node) {
+      return node.form;
+    }
+    return null;
   }
 
   _activationBehavior() {

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -5,14 +5,7 @@ const MouseEvent = require("../generated/MouseEvent");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const NODE_TYPE = require("../node-type");
 const { isLabelable, isDisabled } = require("../helpers/form-controls");
-
-function getRootNode(node) {
-  let root;
-  for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
-    root = ancestor;
-  }
-  return root;
-}
+const { getRootNode } = require("../helpers/traversal");
 
 function sendClickToAssociatedNode(node) {
   node.dispatchEvent(MouseEvent.createImpl([

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -28,6 +28,11 @@ function isLabelable(node) {
   return false;
 }
 
+function hasCommonAncestor(a, b) {
+  const ancestors = new Set(domSymbolTree.ancestorsIterator(a));
+  return domSymbolTree.ancestorsToArray(b).some(ancestor => ancestors.has(ancestor));
+}
+
 function sendClickToAssociatedNode(node) {
   node.dispatchEvent(MouseEvent.createImpl([
     "click",
@@ -50,7 +55,7 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
   get control() {
     if (this.hasAttribute("for")) {
       const node = this.ownerDocument.getElementById(this.getAttribute("for"));
-      if (node && isLabelable(node)) {
+      if (node && isLabelable(node) && hasCommonAncestor(this, node)) {
         return node;
       }
       return null;

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -3,11 +3,12 @@
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
 const { domSymbolTree } = require("../helpers/internal-constants");
+const NODE_TYPE = require("../node-type");
 const { isDisabled } = require("../helpers/form-controls");
 
 function isLabelable(node) {
   // labelable logic defined at: https://html.spec.whatwg.org/multipage/forms.html#category-label
-  if (node.nodeType !== 1) {
+  if (node.nodeType !== NODE_TYPE.ELEMENT_NODE) {
     return false;
   }
 
@@ -28,9 +29,12 @@ function isLabelable(node) {
   return false;
 }
 
-function hasCommonAncestor(a, b) {
-  const ancestors = new Set(domSymbolTree.ancestorsIterator(a));
-  return domSymbolTree.ancestorsToArray(b).some(ancestor => ancestors.has(ancestor));
+function getRootNode(node) {
+  let root;
+  for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
+    root = ancestor;
+  }
+  return root;
 }
 
 function sendClickToAssociatedNode(node) {
@@ -54,9 +58,16 @@ function sendClickToAssociatedNode(node) {
 class HTMLLabelElementImpl extends HTMLElementImpl {
   get control() {
     if (this.hasAttribute("for")) {
-      const node = this.ownerDocument.getElementById(this.getAttribute("for"));
-      if (node && isLabelable(node) && hasCommonAncestor(this, node)) {
-        return node;
+      const forValue = this.getAttribute("for");
+      if (forValue === "") {
+        return null;
+      }
+      const root = getRootNode(this);
+      for (const descendant of domSymbolTree.treeIterator(root)) {
+        if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&
+          descendant.getAttribute("id") === forValue) {
+          return isLabelable(descendant) ? descendant : null;
+        }
       }
       return null;
     }

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -48,6 +48,26 @@ function sendClickToAssociatedNode(node) {
 }
 
 class HTMLLabelElementImpl extends HTMLElementImpl {
+  get control() {
+    if (this.hasAttribute("for")) {
+      const node = this.ownerDocument.getElementById(this.getAttribute("for"));
+      if (node && isLabelable(node)) {
+        return node;
+      }
+      return undefined;
+    }
+    for (const descendant of domSymbolTree.treeIterator(this)) {
+      if (isLabelable(descendant)) {
+        return descendant;
+      }
+    }
+    return undefined;
+  }
+
+  get form() {
+    return closest(this, "form");
+  }
+
   _activationBehavior() {
     if (this.hasAttribute("for")) {
       const node = this.ownerDocument.getElementById(this.getAttribute("for"));
@@ -65,10 +85,6 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
         }
       }
     }
-  }
-
-  get form() {
-    return closest(this, "form");
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -4,30 +4,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const NODE_TYPE = require("../node-type");
-const { isDisabled } = require("../helpers/form-controls");
-
-function isLabelable(node) {
-  // labelable logic defined at: https://html.spec.whatwg.org/multipage/forms.html#category-label
-  if (node.nodeType !== NODE_TYPE.ELEMENT_NODE) {
-    return false;
-  }
-
-  switch (node.tagName) {
-    case "BUTTON":
-    case "KEYGEN":
-    case "METER":
-    case "OUTPUT":
-    case "PROGRESS":
-    case "SELECT":
-    case "TEXTAREA":
-      return true;
-
-    case "INPUT":
-      return node.type !== "hidden";
-  }
-
-  return false;
-}
+const { isLabelable, isDisabled } = require("../helpers/form-controls");
 
 function getRootNode(node) {
   let root;

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -54,14 +54,14 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
       if (node && isLabelable(node)) {
         return node;
       }
-      return undefined;
+      return null;
     }
     for (const descendant of domSymbolTree.treeIterator(this)) {
       if (isLabelable(descendant)) {
         return descendant;
       }
     }
-    return undefined;
+    return null;
   }
 
   get form() {
@@ -69,21 +69,9 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
   }
 
   _activationBehavior() {
-    if (this.hasAttribute("for")) {
-      const node = this.ownerDocument.getElementById(this.getAttribute("for"));
-      if (node && isLabelable(node) && !isDisabled(node)) {
-        sendClickToAssociatedNode(node);
-      }
-    } else {
-      for (const descendant of domSymbolTree.treeIterator(this)) {
-        if (isLabelable(descendant)) {
-          if (!isDisabled(descendant)) {
-            sendClickToAssociatedNode(descendant);
-          }
-
-          break;
-        }
-      }
+    const node = this.control;
+    if (node && !isDisabled(node)) {
+      sendClickToAssociatedNode(node);
     }
   }
 }

--- a/lib/jsdom/living/nodes/HTMLLabelElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLLabelElement.webidl
@@ -3,5 +3,5 @@
 interface HTMLLabelElement : HTMLElement {
   readonly attribute HTMLFormElement? form;
   [CEReactions, Reflect=for] attribute DOMString htmlFor;
-//  readonly attribute HTMLElement? control;
+  readonly attribute HTMLElement? control;
 };

--- a/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
@@ -5,6 +5,12 @@ const { parseFloatingPointNumber } = require("../helpers/strings");
 const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLMeterElementImpl extends HTMLElementImpl {
+
+  constructor(args, privateData) {
+    super(args, privateData);
+    this._labels = null;
+  }
+
   // https://html.spec.whatwg.org/multipage/form-elements.html#concept-meter-minimum
   get _minimumValue() {
     const min = this.getAttribute("min");

--- a/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
@@ -5,7 +5,6 @@ const { parseFloatingPointNumber } = require("../helpers/strings");
 const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLMeterElementImpl extends HTMLElementImpl {
-
   constructor(args, privateData) {
     super(args, privateData);
     this._labels = null;

--- a/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
@@ -2,6 +2,7 @@
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const { parseFloatingPointNumber } = require("../helpers/strings");
+const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLMeterElementImpl extends HTMLElementImpl {
   // https://html.spec.whatwg.org/multipage/form-elements.html#concept-meter-minimum
@@ -115,6 +116,10 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
     }
 
     return candidate > maximumValue ? maximumValue : candidate;
+  }
+
+  get labels() {
+    return getLabelsForLabelable(this);
   }
 
   get value() {

--- a/lib/jsdom/living/nodes/HTMLMeterElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLMeterElement.webidl
@@ -7,5 +7,5 @@ interface HTMLMeterElement : HTMLElement {
   [CEReactions] attribute double low;
   [CEReactions] attribute double high;
   [CEReactions] attribute double optimum;
-  // readonly attribute NodeList labels;
+  readonly attribute NodeList labels;
 };

--- a/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
@@ -4,10 +4,15 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
 const { mixin } = require("../../utils");
+const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLOutputElementImpl extends HTMLElementImpl {
   _barredFromConstraintValidationSpecialization() {
     return true;
+  }
+
+  get labels() {
+    return getLabelsForLabelable(this);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
@@ -7,7 +7,6 @@ const { mixin } = require("../../utils");
 const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLOutputElementImpl extends HTMLElementImpl {
-
   constructor(args, privateData) {
     super(args, privateData);
     this._labels = null;

--- a/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
@@ -7,6 +7,12 @@ const { mixin } = require("../../utils");
 const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLOutputElementImpl extends HTMLElementImpl {
+
+  constructor(args, privateData) {
+    super(args, privateData);
+    this._labels = null;
+  }
+
   _barredFromConstraintValidationSpecialization() {
     return true;
   }

--- a/lib/jsdom/living/nodes/HTMLOutputElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLOutputElement.webidl
@@ -16,5 +16,5 @@ interface HTMLOutputElement : HTMLElement {
   boolean reportValidity();
   void setCustomValidity(DOMString error);
 
-//  readonly attribute NodeList labels;
+  readonly attribute NodeList labels;
 };

--- a/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
@@ -4,7 +4,6 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLProgressElementImpl extends HTMLElementImpl {
-
   constructor(args, privateData) {
     super(args, privateData);
     this._labels = null;

--- a/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
@@ -4,6 +4,12 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLProgressElementImpl extends HTMLElementImpl {
+
+  constructor(args, privateData) {
+    super(args, privateData);
+    this._labels = null;
+  }
+
   get labels() {
     return getLabelsForLabelable(this);
   }

--- a/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
@@ -1,8 +1,13 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+const { getLabelsForLabelable } = require("../helpers/form-controls");
 
-class HTMLProgressElementImpl extends HTMLElementImpl { }
+class HTMLProgressElementImpl extends HTMLElementImpl {
+  get labels() {
+    return getLabelsForLabelable(this);
+  }
+}
 
 module.exports = {
   implementation: HTMLProgressElementImpl

--- a/lib/jsdom/living/nodes/HTMLProgressElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLProgressElement.webidl
@@ -4,5 +4,5 @@ interface HTMLProgressElement : HTMLElement {
 //  [CEReactions] attribute double value;
 //  [CEReactions] attribute double max;
 //  readonly attribute double position;
-//  readonly attribute NodeList labels;
+  readonly attribute NodeList labels;
 };

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -40,6 +40,8 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     this._selectedOptions = null; // lazy
 
     this._customValidityErrorMessage = "";
+
+    this._labels = null;
   }
 
   _formReset() {

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -13,6 +13,7 @@ const HTMLCollection = require("../generated/HTMLCollection");
 const HTMLOptionsCollection = require("../generated/HTMLOptionsCollection");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const { closest } = require("../helpers/traversal");
+const { getLabelsForLabelable } = require("../helpers/form-controls");
 
 class HTMLSelectElementImpl extends HTMLElementImpl {
   constructor(args, privateData) {
@@ -63,8 +64,8 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
         let disabled = option.hasAttribute("disabled");
         const parentNode = domSymbolTree.parent(option);
         if (parentNode &&
-            parentNode.nodeName.toUpperCase() === "OPTGROUP" &&
-            parentNode.hasAttribute("disabled")) {
+          parentNode.nodeName.toUpperCase() === "OPTGROUP" &&
+          parentNode.hasAttribute("disabled")) {
           disabled = true;
         }
 
@@ -144,6 +145,10 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     for (let i = 0; i < this.options.length; i++) {
       this.options.item(i).selected = i === index;
     }
+  }
+
+  get labels() {
+    return getLabelsForLabelable(this);
   }
 
   get value() {

--- a/lib/jsdom/living/nodes/HTMLSelectElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLSelectElement.webidl
@@ -32,5 +32,5 @@ interface HTMLSelectElement : HTMLElement {
   boolean reportValidity();
   void setCustomValidity(DOMString error);
 
-//  readonly attribute NodeList labels;
+  readonly attribute NodeList labels;
 };

--- a/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
@@ -20,6 +20,8 @@ class HTMLTextAreaElementImpl extends HTMLElementImpl {
     this._dirtyValue = false;
 
     this._customValidityErrorMessage = "";
+
+    this._labels = null;
   }
 
   _formReset() {

--- a/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
@@ -9,7 +9,7 @@ const { mixin } = require("../../utils");
 
 const DOMException = require("domexception");
 const { closest } = require("../helpers/traversal");
-const { normalizeToCRLF } = require("../helpers/form-controls");
+const { normalizeToCRLF, getLabelsForLabelable } = require("../helpers/form-controls");
 const { childTextContent } = require("../helpers/text");
 
 class HTMLTextAreaElementImpl extends HTMLElementImpl {
@@ -42,6 +42,10 @@ class HTMLTextAreaElementImpl extends HTMLElementImpl {
     }
   }
 
+  get labels() {
+    return getLabelsForLabelable(this);
+  }
+
   get form() {
     return closest(this, "form");
   }
@@ -70,6 +74,7 @@ class HTMLTextAreaElementImpl extends HTMLElementImpl {
   get textLength() {
     return this.value.length; // code unit length (16 bit)
   }
+
   get type() {
     return "textarea";
   }
@@ -79,39 +84,49 @@ class HTMLTextAreaElementImpl extends HTMLElementImpl {
     event.initEvent("select", true, true);
     this.dispatchEvent(event);
   }
+
   _getValueLength() {
     return typeof this.value === "string" ? this.value.length : 0;
   }
+
   select() {
     this._selectionStart = 0;
     this._selectionEnd = this._getValueLength();
     this._selectionDirection = "none";
     this._dispatchSelectEvent();
   }
+
   get selectionStart() {
     return this._selectionStart;
   }
+
   set selectionStart(start) {
     this.setSelectionRange(start, Math.max(start, this._selectionEnd), this._selectionDirection);
   }
+
   get selectionEnd() {
     return this._selectionEnd;
   }
+
   set selectionEnd(end) {
     this.setSelectionRange(this._selectionStart, end, this._selectionDirection);
   }
+
   get selectionDirection() {
     return this._selectionDirection;
   }
+
   set selectionDirection(dir) {
     this.setSelectionRange(this._selectionStart, this._selectionEnd, dir);
   }
+
   setSelectionRange(start, end, dir) {
     this._selectionEnd = Math.min(end, this._getValueLength());
     this._selectionStart = Math.min(start, this._selectionEnd);
     this._selectionDirection = dir === "forward" || dir === "backward" ? dir : "none";
     this._dispatchSelectEvent();
   }
+
   setRangeText(repl, start, end, selectionMode = "preserve") {
     if (arguments.length < 2) {
       start = this._selectionStart;

--- a/lib/jsdom/living/nodes/HTMLTextAreaElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLTextAreaElement.webidl
@@ -29,7 +29,7 @@ interface HTMLTextAreaElement : HTMLElement {
   boolean reportValidity();
   void setCustomValidity(DOMString error);
 
-//  readonly attribute NodeList labels;
+  readonly attribute NodeList labels;
 
   void select();
   attribute unsigned long selectionStart;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -519,8 +519,6 @@ type-change-state.html: [fail, type attribute state switching not yet implemente
 
 DIR: html/semantics/forms/the-label-element
 
-labelable-elements.html: [fail, Unknown]
-
 ---
 
 DIR: html/semantics/forms/the-meter-element

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -519,6 +519,8 @@ type-change-state.html: [fail, type attribute state switching not yet implemente
 
 DIR: html/semantics/forms/the-label-element
 
+label-attributes.html: [fail, Shadow DOM, copied working tests to upstream]
+
 ---
 
 DIR: html/semantics/forms/the-meter-element

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -466,7 +466,6 @@ DIR: html/semantics/forms/the-button-element
 
 button-activate.html: [fail, Unknown]
 button-events.html: [fail, Unknown]
-button-labels.html: [fail, labels attribute is not implemented]
 button-validation.html: [fail, Expects type 'menu' to not change to 'submit']
 
 ---

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -499,7 +499,6 @@ datetime-local.html: [fail, min/max constraints not implemented]
 datetime.html: [fail, step is not implemented]
 hidden.html: [fail, list/step/valueAsDate/valueAsNumber not implemented]
 image-click-form-data.html: [timeout, Unknown]
-input-labels.html: [fail, labels attribute is not implemented]
 input-stepdown.html: [fail, stepDown()-method is not implemented]
 input-stepup.html: [fail, stepUp()-method is not implemented]
 input-type-button.html: [fail, Unknown]
@@ -521,7 +520,6 @@ type-change-state.html: [fail, type attribute state switching not yet implemente
 
 DIR: html/semantics/forms/the-label-element
 
-label-attributes.html: [fail, Unknown]
 labelable-elements.html: [fail, Unknown]
 
 ---

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: The label element</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<form id="fm" style="display:none">
+  <label id="lbl0" for="test0"></label>
+  <b id="test0"></b>
+
+  <input id="test1"></input>
+
+  <label id="lbl1">
+    <a id="test2"></a>
+    <div><input id="test3"></div>
+    <input id="test4">
+  </label>
+
+  <label id="lbl2" for="testx">
+    <input id="test5">
+  </label>
+
+  <label id="lbl3" for="test6">
+    <b id="test6"></b>
+    <input id="test6" class="class1">
+  </label>
+
+  <label id="lbl4" for="">
+    <input id="" class="class2">
+  </label>
+
+  <label id="lbl5" for="test7"></label>
+  <input id="test7">
+
+  <label id="lbl7">
+    <label id="lbl8">
+      <div id="div1">
+        <input id="test8">
+      </div>
+    </label>
+  </label>
+  <div id="div2"></div>
+
+  <label id="lbl9">
+    <label id="lbl10" for="test10">
+      <div id="div3">
+        <input id="test9">
+      </div>
+    </label>
+  </label>
+  <div id="div4"><input id="test10"></div>
+
+  <label id="lbl11">
+    <object id="obj">
+      <input id="test11">
+      <input id="test12">
+    </object>
+  </label>
+  <label id="lbl12" for="test12"><div id="div5"></div></label>
+
+  <label id="lbl13">
+    <p id="p1">
+      <input id="test13">
+    </p>
+  </label>
+
+  <div id="div6">
+    <div id="div7">
+      <label id="lbl14">
+        <label id="lbl15" for="test15">
+          <input id="test14">
+        </label>
+      </label>
+    </div>
+  </div>
+  <input id="test15">
+</form>
+
+<label id="lbl6" for="test7"></label>
+<div id="content" style="display: none">
+  <script>
+
+    //control attribute
+    test(function () {
+      assert_not_equals(document.getElementById("lbl0").control, document.getElementById("test0"),
+        "An element that's not a labelable element can't be a label element's labeled control.");
+      assert_equals(document.getElementById("lbl0").control, null,
+        "A label element whose 'for' attribute doesn't reference any labelable element shouldn't have any labeled control.");
+    }, "A label element with a 'for' attribute should only be associated with a labelable element.");
+
+    test(function () {
+      var label = document.createElement("label");
+      label.htmlFor = "test1";
+      assert_not_equals(label.control, document.getElementById("test1"),
+        "A label element not in a document should not label an element in a document.");
+      document.body.appendChild(label);
+      assert_equals(label.control, document.getElementById("test1"));
+      label.remove();
+    }, "A label element not in a document can not label any element in the document.");
+
+    test(function () {
+      var labels = document.getElementById("test3").labels;
+      assert_equals(document.getElementById("lbl1").control, document.getElementById("test3"),
+        "The first labelable descendant of a label element should be its labeled control.");
+
+      var input = document.createElement("input");
+      document.getElementById("lbl1").insertBefore(input, document.getElementById("test2"));
+      assert_equals(document.getElementById("lbl1").control, input,
+        "The first labelable descendant of a label element in tree order should be its labeled control.");
+      assert_equals(input.labels.length, 1,
+        "The form control has an ancestor with no explicit associated label, and is the first labelable descendant.");
+      assert_equals(labels.length, 0,
+        "The number of labels should be 0 if it's not the first labelable descendant of a label element.");
+      input.remove();
+    }, "The labeled control for a label element that has no 'for' attribute is the first labelable element which is a descendant of that label element.");
+
+    test(function () {
+      assert_equals(document.getElementById("lbl2").control, null,
+        "The label's 'control' property should return null if its 'for' attribute points to an inexistent element.");
+    }, "The 'for' attribute points to an inexistent id.");
+
+    test(function () {
+      assert_equals(document.getElementById("lbl3").control, null, "The label should have no control associated.");
+      assert_equals(document.querySelector(".class1").labels.length, 0);
+    }, "A non-control follows by a control with same ID.");
+
+    test(function () {
+      assert_equals(document.getElementById("lbl4").control, null,
+        "A label element with an empty 'for' attribute should not associate with anything.");
+    }, "The 'for' attribute is an empty string.");
+
+    //labels attribute
+    test(function () {
+      var labels = document.getElementById("test7").labels;
+      assert_true(labels instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels.length, 2,
+        "The number of labels associated with a form control should be the number of label elements for which it is a labeled control.");
+      assert_array_equals(labels, [document.getElementById("lbl5"), document.getElementById("lbl6")],
+        "The labels for a form control should be returned in tree order.");
+
+      var newLabel = document.createElement("label");
+      newLabel.htmlFor = "test7";
+      document.getElementById("fm").insertBefore(newLabel, document.getElementById("lbl0"));
+      assert_array_equals(document.getElementById("test7").labels, [newLabel, document.getElementById("lbl5"), document.getElementById("lbl6")],
+        "The labels for a form control should be returned in tree order.");
+      newLabel.remove();
+    }, "A form control has multiple labels.");
+
+    test(function () {
+      var labels = document.getElementById("test8").labels;
+      assert_true(labels instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels.length, 2,
+        "The form control has two ancestors with no explicit associated label, and is the first labelable descendant.");
+      assert_array_equals(labels, [document.getElementById("lbl7"), document.getElementById("lbl8")],
+        "The labels for a form control should be returned in tree order.");
+
+      document.getElementById('div2').insertBefore(document.getElementById('div1'), document.getElementById('div2').firstChild);
+      assert_equals(labels.length, 0,
+        "The number of labels should be 0 after the labelable element is moved to outside of nested associated labels.");
+    }, "A labelable element is moved to outside of nested associated labels.");
+
+    test(function () {
+      var labels1 = document.getElementById("test9").labels;
+      var labels2 = document.getElementById("test10").labels;
+      assert_true(labels1 instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_true(labels2 instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels1.length, 1,
+        "The form control has an ancestor with no explicit associated label, and is the first labelable descendant.");
+      assert_equals(labels2.length, 1,
+        "The number of labels associated with a form control should be the number of label elements for which it is a labeled control.");
+      assert_array_equals(labels1, [document.getElementById("lbl9")],
+        "The labels for a form control should be returned in tree order.");
+      assert_array_equals(labels2, [document.getElementById("lbl10")],
+        "The labels for a form control should be returned in tree order.");
+      document.getElementById('div3').insertBefore(document.getElementById('div4'), document.getElementById('div3').firstChild);
+      assert_equals(labels1.length, 0,
+        "The number of labels should be 0 if it's not the first labelable descendant of a label element.");
+      assert_equals(labels2.length, 2,
+        "The form control has an ancestor with an explicit associated label, and is the first labelable descendant.");
+    }, "A labelable element is moved to inside of nested associated labels.");
+
+    test(function () {
+      var labels1 = document.getElementById("test11").labels;
+      var labels2 = document.getElementById("test12").labels;
+      assert_true(labels1 instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_true(labels2 instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels1.length, 1,
+        "The form control has an ancestor with no explicit associated label, and it is the first labelable descendant.");
+      assert_equals(labels2.length, 1,
+        "The number of labels should be 1 since there is a label with a 'for' attribute associated with this labelable element.");
+      assert_array_equals(labels1, [document.getElementById("lbl11")],
+        "The labels for a form control should be returned in tree order.");
+      assert_array_equals(labels2, [document.getElementById("lbl12")],
+        "The labels for a form control should be returned in tree order.");
+      document.getElementById('div5').appendChild(document.getElementById('obj'));
+      assert_equals(labels1.length, 0,
+        "The number of labels should be 0 after the labelable element is moved to outside of associated label.");
+      assert_equals(labels2.length, 1,
+        "The number of labels should be 1 after the labelable element is moved to outside of associated label.");
+    }, "A labelable element which is a descendant of non-labelable element is moved to outside of associated label.");
+
+    test(function () {
+      var labels1 = document.getElementById("test14").labels;
+      var labels2 = document.getElementById("test15").labels;
+      assert_true(labels1 instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels1.length, 1,
+        "The form control has an ancestor with no explicit associated label, and is the first labelable descendant.");
+      assert_equals(labels2.length, 1,
+        "The number of labels associated with a form control should be the number of label elements for which it is a labeled control.");
+      assert_array_equals(labels1, [document.getElementById("lbl14")],
+        "The labels for a form control should be returned in tree order.");
+
+      document.getElementById('div6').removeChild(document.getElementById('div7'));
+      assert_equals(labels1.length, 0,
+        "The number of labels should be 0 after the labelable element is removed.");
+      assert_equals(labels2.length, 0,
+        "The number of labels should be 0 since there is no label with a 'for' attribute associated with this labelable element.");
+    }, "A div element which contains labelable element is removed.");
+
+    test(function () {
+      // <label><input id="test16"><label for="test16"></label></label>
+      var label1 = document.createElement('label');
+      label1.innerHTML = "<input id='test16'>";
+      var label2 = document.createElement('label');
+      label2.htmlFor = "test16";
+      label1.appendChild(label2);
+
+      var input = label1.firstChild;
+      var labels = input.labels;
+
+      assert_equals(labels.length, 2,
+        "The number of labels associated with a form control should be the number of label elements for which it is a labeled control.");
+      assert_true(labels instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(label1.control, input, "The first labelable descendant of a label element should be its labeled control.");
+      assert_equals(label2.control, input, "The labeled cotrol should be associated with the control whose ID is equal to the value of the 'for' attribute.");
+    }, "A labelable element not in a document can label element in the same tree.");
+
+    test(function () {
+      var labels = document.getElementById("test3").labels;
+      assert_true(labels instanceof NodeList, "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels.length, 1, "The form control has an ancestor with no explicit associated label, and is the first labelable descendant.");
+    }, "A form control has an implicit label.");
+
+    test(function () {
+      var labels = document.getElementById("test4").labels;
+      assert_true(labels instanceof NodeList, "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels.length, 0, "The form control has an ancestor with no explicit associated label, but is *not* the first labelable descendant");
+    }, "A form control has no label 1.");
+
+    test(function () {
+      assert_equals(document.getElementById("test5").labels.length, 0,
+        "The number of labels should be 0 if the form control has an ancestor label element that the for attribute points to another control.");
+      assert_equals(document.getElementById("lbl2").control, null,
+        "The labeled cotrol should be associated with the control whose ID is equal to the value of the 'for' attribute.");
+    }, "A form control has no label 2.");
+
+    // form attribute
+    test(function () {
+      assert_equals(document.getElementById("lbl0").form, null,
+        "The 'form' property for a label should return null if label.control is null.");
+    }, "A label in a form without a control");
+
+    test(function () {
+      assert_equals(document.getElementById("lbl6").form, document.getElementById("fm"),
+        "The 'form' property for a label should return label.control.form.");
+    }, "A label outside a form with a control inside the form");
+
+    // htmlFor attribute
+    test(function () {
+      assert_equals(document.getElementById("lbl2").htmlFor, "testx");
+    }, "A label's htmlFor attribute must reflect the for content attribute");
+  </script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
@@ -205,7 +205,27 @@
       assert_equals(labels2.length, 1,
         "The number of labels should be 1 after the labelable element is moved to outside of associated label.");
     }, "A labelable element which is a descendant of non-labelable element is moved to outside of associated label.");
+    /*
+    async_test(function () {
+      var labels = document.getElementById("test13").labels;
+      assert_true(labels instanceof NodeList,
+        "A form control's 'labels' property should be an instance of a NodeList.");
+      assert_equals(labels.length, 1,
+        "The form control has an ancestor with no explicit associated label, and is the first labelable descendant.");
+      assert_array_equals(labels, [document.getElementById("lbl13")],
+        "The labels for a form control should be returned in tree order.");
+      let iframe = document.createElement('iframe');
 
+      iframe.onload = this.step_func_done(() => {
+        iframe.contentWindow.document.getElementById("div1").appendChild(document.getElementById("p1"));
+        assert_equals(labels.length, 2,
+          "The number of labels should be 2 after the labelable element is moved to iframe.");
+      });
+
+      iframe.setAttribute('src', 'http://web-platform.test:9000/html/semantics/forms/the-label-element/iframe-label-attributes.html');
+      document.body.appendChild(iframe);
+    }, "A labelable element is moved to iframe.");
+    */
     test(function () {
       var labels1 = document.getElementById("test14").labels;
       var labels2 = document.getElementById("test15").labels;
@@ -243,7 +263,53 @@
       assert_equals(label1.control, input, "The first labelable descendant of a label element should be its labeled control.");
       assert_equals(label2.control, input, "The labeled cotrol should be associated with the control whose ID is equal to the value of the 'for' attribute.");
     }, "A labelable element not in a document can label element in the same tree.");
+    /*
+    test(function () {
+      var isShadowDOMV0;
+      if ("createShadowRoot" in document.getElementById('content')) {
+        isShadowDOMV0 = true;
+      }
+      var root1;
+      if (isShadowDOMV0) {
+        root1 = document.getElementById('content').createShadowRoot();
+      } else {
+        root1 = document.getElementById('content').attachShadow({mode: 'open'});
+      }
+      assert_true(root1 instanceof DocumentFragment,
+        "ShadowRoot should be an instance of DocumentFragment.");
+      // <label><input id="shadow1"/></label><div id="div1"></div>
+      var label1 = document.createElement('label');
+      var input1 = document.createElement('input');
+      input1.setAttribute("id", "shadow1");
+      label1.appendChild(input1);
+      root1.appendChild(label1);
 
+      var div1 = document.createElement('div');
+      label1.appendChild(div1);
+      // <label for="shadow2"></label><input id="shadow2"/>
+      var root2;
+      if (isShadowDOMV0) {
+        root2 = div1.createShadowRoot();
+      } else {
+        root2 = div1.attachShadow({mode: 'open'});
+      }
+
+      assert_true(root2 instanceof DocumentFragment,
+        "ShadowRoot should be an instance of DocumentFragment.");
+      var label2 = document.createElement('label');
+      label2.setAttribute("for", "shadow2");
+
+      var input2 = document.createElement('input');
+      input2.setAttribute("id", "shadow2");
+      root2.appendChild(label2);
+      root2.appendChild(input2);
+
+      assert_equals(root1.getElementById("shadow1").labels.length, 1,
+        "The form control has an ancestor with no explicit associated label, and it is the first labelable descendant.");
+      assert_equals(root2.getElementById("shadow2").labels.length, 1,
+        "The number of labels should be 1 since there is a label with a 'for' attribute associated with this labelable element.");
+    }, "A labelable element inside the shadow DOM.");
+    */
     test(function () {
       var labels = document.getElementById("test3").labels;
       assert_true(labels instanceof NodeList, "A form control's 'labels' property should be an instance of a NodeList.");

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-control-attribute.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-control-attribute.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Label event handling with disabled labeled control</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<label id="label1">
+  <input id="input1" type="text" disabled>
+</label>
+
+<label id="label2" for="input2"></label>
+<input id="input2" type="text">
+
+<label id="label3" for="notfoundid">
+  <input id="input3" type="checkbox">
+</label>
+
+<script>
+  "use strict";
+
+  test(() => {
+    const label = document.getElementById("label1");
+    const input = document.getElementById("input1");
+
+    assert_equals(label.control, input);
+  }, "get descendant controlled element");
+
+  test(() => {
+    const label = document.getElementById("label2");
+    const input = document.getElementById("input2");
+
+    assert_equals(label.control, input);
+  }, "get control by for attribute");
+
+  test(() => {
+    const label = document.getElementById("label3");
+
+    assert_equals(label.control, undefined);
+
+  }, "label with invalid for attribute, don't have a control");
+</script>
+</body>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-control-attribute.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-control-attribute.html
@@ -8,13 +8,15 @@
 <body>
 
 <label id="label1">
+  Label-Text
   <input id="input1" type="text" disabled>
 </label>
 
-<label id="label2" for="input2"></label>
+<label id="label2" for="input2">Label-Text</label>
 <input id="input2" type="text">
 
 <label id="label3" for="notfoundid">
+  Label-Text
   <input id="input3" type="checkbox">
 </label>
 
@@ -38,7 +40,7 @@
   test(() => {
     const label = document.getElementById("label3");
 
-    assert_equals(label.control, undefined);
+    assert_equals(label.control, null);
 
   }, "label with invalid for attribute, don't have a control");
 </script>


### PR DESCRIPTION
Adds support for the HTMLLabelElement.control and *.labels properties. (jsdom/jsdom#2175)

Adds labels property support for:

- button
- input (if the type attribute is not in the Hidden state)
- meter
- output
- progress
- select
- textarea

Activated tests:
- button-labels.html
- input-labels.html
- labelable-elements.html

Added tests:
- label-attributes-dont-upstream.html (copy from wpt without 2 failing tests.)