### PR TITLE
Use NWSAPI

### DIFF
--- a/lib/jsdom/living/helpers/selectors.js
+++ b/lib/jsdom/living/helpers/selectors.js
@@ -1,28 +1,40 @@
 "use strict";
 
+const DOMException = require("domexception");
+const nwsapi = require("nwsapi");
 const idlUtils = require("../generated/utils");
-const nwmatcher = require("nwmatcher/src/nwmatcher-noqsa");
 
 exports.matchesDontThrow = (elImpl, selector) => {
   const document = elImpl._ownerDocument;
 
-  if (!document._nwmatcherDontThrow) {
-    document._nwmatcherDontThrow = nwmatcher({ document });
-    document._nwmatcherDontThrow.configure({ UNIQUE_ID: false, LOGERRORS: false, VERBOSITY: false, SVG_LCASE: true });
+  if (!document._nwsapiDontThrow) {
+    document._nwsapiDontThrow = nwsapi({
+      document,
+      DOMException
+    });
+    document._nwsapiDontThrow.configure({
+      LOGERRORS: false,
+      VERBOSITY: false
+    });
   }
 
-  return document._nwmatcherDontThrow.match(idlUtils.wrapperForImpl(elImpl), selector);
+  return document._nwsapiDontThrow.match(selector, idlUtils.wrapperForImpl(elImpl));
 };
 
-// nwmatcher gets `document.documentElement` at creation-time, so we have to initialize lazily, since in the initial
+// nwsapi gets `document.documentElement` at creation-time, so we have to initialize lazily, since in the initial
 // stages of Document initialization, there is no documentElement present yet.
-exports.addNwmatcher = parentNode => {
+exports.addNwsapi = parentNode => {
   const document = parentNode._ownerDocument;
 
-  if (!document._nwmatcher) {
-    document._nwmatcher = nwmatcher({ document });
-    document._nwmatcher.configure({ UNIQUE_ID: false, LOGERRORS: false, SVG_LCASE: true });
+  if (!document._nwsapi) {
+    document._nwsapi = nwsapi({
+      document,
+      DOMException
+    });
+    document._nwsapi.configure({
+      LOGERRORS: false
+    });
   }
 
-  return document._nwmatcher;
+  return document._nwsapi;
 };

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -1,5 +1,5 @@
 "use strict";
-const { addNwmatcher } = require("../helpers/selectors");
+const { addNwsapi } = require("../helpers/selectors");
 const { HTML_NS } = require("../helpers/namespaces");
 const { mixin, memoizeQuery } = require("../../utils");
 const idlUtils = require("../generated/utils");
@@ -427,13 +427,9 @@ ElementImpl.prototype.getElementsByClassName = memoizeQuery(function (classNames
 });
 
 ElementImpl.prototype.matches = memoizeQuery(function (selectors) {
-  const matcher = addNwmatcher(this);
+  const matcher = addNwsapi(this);
 
-  try {
-    return matcher.match(idlUtils.wrapperForImpl(this), selectors);
-  } catch (e) {
-    throw new DOMException(e.message, "SyntaxError");
-  }
+  return matcher.match(selectors, idlUtils.wrapperForImpl(this));
 });
 
 ElementImpl.prototype.webkitMatchesSelector = ElementImpl.prototype.matches;

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -1,10 +1,9 @@
 "use strict";
 
-const DOMException = require("domexception");
 const idlUtils = require("../generated/utils");
 const NodeList = require("../generated/NodeList");
 const HTMLCollection = require("../generated/HTMLCollection");
-const { addNwmatcher } = require("../helpers/selectors");
+const { addNwsapi } = require("../helpers/selectors");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const NODE_TYPE = require("../node-type");
 const { memoizeQuery } = require("../../utils");
@@ -62,13 +61,8 @@ ParentNodeImpl.prototype.querySelector = memoizeQuery(function (selectors) {
   if (shouldAlwaysSelectNothing(this)) {
     return null;
   }
-  const matcher = addNwmatcher(this);
-
-  try {
-    return idlUtils.implForWrapper(matcher.first(selectors, idlUtils.wrapperForImpl(this)));
-  } catch (e) {
-    throw new DOMException(e.message, "SyntaxError");
-  }
+  const matcher = addNwsapi(this);
+  return idlUtils.implForWrapper(matcher.first(selectors, idlUtils.wrapperForImpl(this)));
 });
 
 // WARNING: this returns a NodeList containing IDL wrappers instead of impls
@@ -76,14 +70,8 @@ ParentNodeImpl.prototype.querySelectorAll = memoizeQuery(function (selectors) {
   if (shouldAlwaysSelectNothing(this)) {
     return NodeList.create([], { nodes: [] });
   }
-  const matcher = addNwmatcher(this);
-
-  let list;
-  try {
-    list = matcher.select(selectors, idlUtils.wrapperForImpl(this));
-  } catch (e) {
-    throw new DOMException(e.message, "SyntaxError");
-  }
+  const matcher = addNwsapi(this);
+  const list = matcher.select(selectors, idlUtils.wrapperForImpl(this));
 
   return NodeList.create([], { nodes: list.map(n => idlUtils.tryImplForWrapper(n)) });
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "escodegen": "^1.9.0",
     "html-encoding-sniffer": "^1.0.2",
     "left-pad": "^1.2.0",
-    "nwmatcher": "^1.4.3",
+    "nwsapi": "^2.0.0",
     "parse5": "4.0.0",
     "pn": "^1.1.0",
     "request": "^2.83.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2620,9 +2620,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nwmatcher@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
+nwsapi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.0.tgz#7c8faf4ad501e1d17a651ebc5547f966b547c5c7"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"


### PR DESCRIPTION
This replaces nwmatcher with [nwsapi](https://github.com/dperini/nwsapi) which resolves many known issues, supports several new selectors and is significantly faster.

Although a beta version of nwsapi is currently used, all tests should pass and this pull request is ready for review. A stable version of nwsapi is expected to be published later this week.