### PR TITLE
Upgrade cssstyle >= 0.3.1 < 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "acorn-globals": "^4.1.0",
     "array-equal": "^1.0.0",
     "cssom": ">= 0.3.2 < 0.4.0",
-    "cssstyle": ">= 0.2.37 < 0.3.0",
+    "cssstyle": ">= 0.3.1 < 0.4.0",
     "data-urls": "^1.0.0",
     "domexception": "^1.0.0",
     "escodegen": "^1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,9 +917,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+"cssstyle@>= 0.3.1 < 0.4.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
   dependencies:
     cssom "0.3.x"
 


### PR DESCRIPTION
Greetings. I use jsdom a lot in testing applications with jest. We have run into issues when our application code cannot get style values that are not implemented in cssstyle. Like the css3 unit `rem`, for example.

```js
const jsdom = require('jsdom');
const assert = require('assert');

const { JSDOM } = jsdom;
const doc = new JSDOM(`
  <p style="width:10px" id="px">Hello world</p>
  <p style="width:10rem" id="rem">Hello world</p>
`).window.document;

assert.strictEqual(doc.querySelector('#px').style.width, '10px'); // ok

assert.strictEqual(doc.querySelector('#rem').style.width, '10rem');
// AssertionError [ERR_ASSERTION]: '' === '10rem'
```

I have taken ownership of the cssstyle github project and bumped it to 0.3.1 with a few PRs that had been open for awhile: https://github.com/jsakas/CSSStyleDeclaration/releases/tag/0.3.1

Ultimately the goal would be to upgrade cssstyle to use information gathered from csswg, and then release 1.0.0.

If the owners of jsdom are willing to continue upgrading this package we can have a better implementation of `CSSStyleDeclaration` for testing!

Thanks.

