### PR TITLE
Implementation of Node.getRootNode

### DIFF
--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -21,7 +21,6 @@ const whatwgURL = require("whatwg-url");
 const NodeList = require("../generated/NodeList");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const NODE_TYPE = require("../node-type");
-const { getRootNode } = require("../helpers/traversal");
 const submittableLocalNames = new Set(["button", "input", "keygen", "object", "select", "textarea"]);
 
 exports.isDisabled = formControl => {
@@ -91,7 +90,7 @@ exports.getLabelsForLabelable = labelable => {
     return null;
   }
   if (!labelable._labels) {
-    const root = getRootNode(labelable);
+    const root = labelable.getRootNode();
     labelable._labels = NodeList.create([], {
       element: root,
       query: () => {

--- a/lib/jsdom/living/helpers/traversal.js
+++ b/lib/jsdom/living/helpers/traversal.js
@@ -81,11 +81,3 @@ exports.firstDescendantWithHTMLLocalName = (parent, localName) => {
   }
   return null;
 };
-
-exports.getRootNode = node => {
-  let root;
-  for (const ancestor of domSymbolTree.ancestorsIterator(node)) {
-    root = ancestor;
-  }
-  return root;
-};

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -5,7 +5,6 @@ const MouseEvent = require("../generated/MouseEvent");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const NODE_TYPE = require("../node-type");
 const { isLabelable, isDisabled } = require("../helpers/form-controls");
-const { getRootNode } = require("../helpers/traversal");
 
 function sendClickToAssociatedNode(node) {
   node.dispatchEvent(MouseEvent.createImpl([
@@ -32,7 +31,7 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
       if (forValue === "") {
         return null;
       }
-      const root = getRootNode(this);
+      const root = this.getRootNode();
       for (const descendant of domSymbolTree.treeIterator(root)) {
         if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&
           descendant.getAttribute("id") === forValue) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -86,6 +86,15 @@ class NodeImpl extends EventTargetImpl {
     return domSymbolTree.parent(this);
   }
 
+  getRootNode() {
+    // ignore option for composed, because of no Shadow DOM support
+    let root;
+    for (const ancestor of domSymbolTree.ancestorsIterator(this)) {
+      root = ancestor;
+    }
+    return root;
+  }
+
   get nodeName() {
     switch (this.nodeType) {
       case NODE_TYPE.ELEMENT_NODE:

--- a/lib/jsdom/living/nodes/Node.webidl
+++ b/lib/jsdom/living/nodes/Node.webidl
@@ -19,7 +19,7 @@ interface Node : EventTarget {
 
   readonly attribute boolean isConnected;
   readonly attribute Document? ownerDocument;
-//  Node getRootNode(optional GetRootNodeOptions options);
+  Node getRootNode(optional GetRootNodeOptions options);
   readonly attribute Node? parentNode;
   readonly attribute Element? parentElement;
   boolean hasChildNodes();

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -160,7 +160,6 @@ getElementsByClassName-11.xml: [fail, XML class attribute and localName and name
 insert-adjacent.html: [fail, Unknown]
 prepend-on-Document.html: [fail, Ensure pre-insertion validity not fully implemented, https://github.com/tmpvar/jsdom/issues/1349]
 remove-unscopable.html: [fail, Unknown]
-rootNode.html: [fail, Unknown]
 
 ---
 


### PR DESCRIPTION
Spec: https://dom.spec.whatwg.org/#dom-node-getrootnode

https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode
> composed: A Boolean that indicates whether the shadow root should be returned (false, the default), or a root node beyond shadow root (true).

Because jsdom doesn't support Shadow DOM, it should be safe to ignore the composed option.

wpt test: rootNode.html