### PR TITLE
Fix 'WebIDL2 is not defined'-error in tests

### DIFF
--- a/test/web-platform-tests/run-single-wpt.js
+++ b/test/web-platform-tests/run-single-wpt.js
@@ -61,7 +61,11 @@ function createJSDOM(urlPrefix, testPath) {
         } else if (resource.url.pathname.startsWith("/resources/")) {
           // When running to-upstream tests, the server doesn't have a /resources/ directory.
           // So, always go to the one in ./tests.
-          const filePath = path.resolve(__dirname, "tests" + resource.url.pathname);
+          // The path replacement accounts for a rewrite performed by the WPT server:
+          // https://github.com/w3c/web-platform-tests/blob/master/tools/serve/serve.py#L271
+          const filePath = path.resolve(__dirname, "tests" + resource.url.pathname)
+            .replace("/resources/WebIDLParser.js", "/resources/webidl2/lib/webidl2.js");
+
           fs.readFile(filePath, { encoding: "utf-8" }, callback);
         } else {
           resource.defaultFetch(callback);

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -188,7 +188,7 @@ xml-serialization.xhtml: [fail, Unknown]
 
 DIR: hr-time
 
-idlharness.html: [fail, ReferenceError - WebIDL2 is not defined]
+idlharness.html: [fail, Depends on fetch]
 performance-tojson.html: [fail, PerformanceTiming and PerformanceNavigation are not implemented]
 test_cross_frame_start.html: [fail, Not implemented]
 timeOrigin.html: [fail, Needs Worker implementation]
@@ -780,7 +780,7 @@ serializing.html: [fail, Unknown]
 
 DIR: html/webappapis/animation-frames
 
-idlharness.html: [fail, "Unknown ('ReferenceError: WebIDL2 is not defined', but why?)"]
+idlharness.html: [fail, The methods do not always throw when expected to]
 same-dispatch-time.html: [fail, Probably https://github.com/tmpvar/jsdom/pull/1994#discussion_r147567274]
 
 ---


### PR DESCRIPTION
Figured I'd finally see if I could find the cause of this issue. Turns out that a path that was meant to be rewritten by the WPT server got overridden and used by the `/resources/`-condition here before that happened. The fix performs the same replacement as the [WPT server](https://github.com/w3c/web-platform-tests/blob/master/tools/serve/serve.py#L271).

This change alone hasn't made any tests pass since most of them also depend on `fetch()`, but I suppose it'll come in handy when we eventually do support it - assuming the rewrite is still in use at that point.