### PR TITLE
fix: pass vm scrip options through

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ console.log(dom.nodeLocation(imgEl));    // { startOffset: 13, endOffset: 32 }
 
 Note that this feature only works if you have set the `includeNodeLocations` option; node locations are off by default for performance reasons.
 
-### Running vm-created scripts with `runVMScript(script)`
+### Running vm-created scripts with `runVMScript(script[, options])`
 
 The built-in `vm` module of Node.js allows you to create `Script` instances, which can be compiled ahead of time and then run multiple times on a given "VM context". Behind the scenes, a jsdom `Window` is indeed a VM context. To get access to this ability, use the `runVMScript()` method:
 
@@ -332,7 +332,7 @@ dom.window.ran === 3;
 
 This is somewhat-advanced functionality, and we advise sticking to normal DOM APIs (such as `window.eval()` or `document.createElement("script")`) unless you have very specific needs.
 
-`runVMScript` also takes an `options` object as its second argument. See the [Node docs](https://nodejs.org/api/vm.html#vm_script_runincontext_contextifiedsandbox_options) for details.
+`runVMScript()` also takes an `options` object as its second argument. See the [Node.js docs](https://nodejs.org/api/vm.html#vm_script_runincontext_contextifiedsandbox_options) for details.
 
 ### Reconfiguring the jsdom with `reconfigure(settings)`
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ dom.window.ran === 3;
 
 This is somewhat-advanced functionality, and we advise sticking to normal DOM APIs (such as `window.eval()` or `document.createElement("script")`) unless you have very specific needs.
 
+`runVMScript` also takes an `options` object as its second argument. See the [Node docs](https://nodejs.org/api/vm.html#vm_script_runincontext_contextifiedsandbox_options) for details.
+
 ### Reconfiguring the jsdom with `reconfigure(settings)`
 
 The `top` property on `window` is marked `[Unforgeable]` in the spec, meaning it is a non-configurable own property and thus cannot be overridden or shadowed by normal code running inside the jsdom, even using `Object.defineProperty`.

--- a/lib/api.js
+++ b/lib/api.js
@@ -72,13 +72,13 @@ class JSDOM {
     return idlUtils.implForWrapper(node).sourceCodeLocation;
   }
 
-  runVMScript(script) {
+  runVMScript(script, options) {
     if (!vm.isContext(this[window])) {
       throw new TypeError("This jsdom was not configured to allow script running. " +
         "Use the runScripts option during creation.");
     }
 
-    return script.runInContext(this[window]);
+    return script.runInContext(this[window], options);
   }
 
   reconfigure(settings) {

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -182,6 +182,13 @@ describe("API: JSDOM class's methods", () => {
 
       assert.strictEqual(dom.window.ran, 3);
     });
+
+    it("should allow passing through options", () => {
+      const dom = new JSDOM(``, { runScripts: "outside-only" });
+      const script = new vm.Script("while(true) {}");
+
+      assert.throws(() => dom.runVMScript(script, { timeout: 50 }), "Script execution timed out.");
+    });
   });
 
   describe("reconfigure", () => {


### PR DESCRIPTION
In order to prevent scripts from potentially running forever, it'd be great to be able to pass a `timeout` to it.

Docs: https://nodejs.org/api/vm.html#vm_script_runincontext_contextifiedsandbox_options