### PR TITLE
Use parse5 v5.0.0

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -65,11 +65,11 @@ class JSDOM {
   }
 
   nodeLocation(node) {
-    if (!idlUtils.implForWrapper(this[window]._document)._parseOptions.locationInfo) {
+    if (!idlUtils.implForWrapper(this[window]._document)._parseOptions.sourceCodeLocationInfo) {
       throw new Error("Location information was not saved for this jsdom. Use includeNodeLocations during creation.");
     }
 
-    return idlUtils.implForWrapper(node).__location;
+    return idlUtils.implForWrapper(node).sourceCodeLocation;
   }
 
   runVMScript(script) {
@@ -210,7 +210,7 @@ function transformOptions(options, encoding) {
       referrer: "",
       contentType: "text/html",
       parsingMode: "html",
-      parseOptions: { locationInfo: false },
+      parseOptions: { sourceCodeLocationInfo: false },
       runScripts: undefined,
       encoding,
       pretendToBeVisual: false,
@@ -254,7 +254,7 @@ function transformOptions(options, encoding) {
       throw new TypeError("Cannot set includeNodeLocations to true with an XML content type");
     }
 
-    transformed.windowOptions.parseOptions = { locationInfo: true };
+    transformed.windowOptions.parseOptions = { sourceCodeLocationInfo: true };
   }
 
   transformed.windowOptions.cookieJar = options.cookieJar === undefined ?

--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -8,7 +8,7 @@ const JSDOMParse5Adapter = require("./parse5-adapter-parsing");
 const { HTML_NS } = require("../living/helpers/namespaces");
 
 // Horrible monkey-patch to implement https://github.com/inikulin/parse5/issues/237
-const OpenElementStack = require("parse5/lib/parser/open_element_stack");
+const OpenElementStack = require("parse5/lib/parser/open-element-stack");
 const originalPop = OpenElementStack.prototype.pop;
 OpenElementStack.prototype.pop = function (...args) {
   const before = this.items[this.stackTop];

--- a/lib/jsdom/browser/parse5-adapter-serialization.js
+++ b/lib/jsdom/browser/parse5-adapter-serialization.js
@@ -31,7 +31,6 @@ exports.getTemplateContent = templateElement => templateElement._templateContent
 exports.getDocumentMode = document => document._mode;
 
 // Node types
-
 exports.isTextNode = node => node.nodeType === nodeTypes.TEXT_NODE;
 
 exports.isCommentNode = node => node.nodeType === nodeTypes.COMMENT_NODE;
@@ -39,3 +38,10 @@ exports.isCommentNode = node => node.nodeType === nodeTypes.COMMENT_NODE;
 exports.isDocumentTypeNode = node => node.nodeType === nodeTypes.DOCUMENT_TYPE_NODE;
 
 exports.isElementNode = node => node.nodeType === nodeTypes.ELEMENT_NODE;
+
+// Source code location
+exports.setNodeSourceCodeLocation = (node, location) => {
+  node.sourceCodeLocation = location;
+};
+
+exports.getNodeSourceCodeLocation = node => node.sourceCodeLocation;

--- a/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
@@ -230,8 +230,8 @@ function processJavaScript(element, code, filename) {
     if (!element.src) {
       for (const child of domSymbolTree.childrenIterator(element)) {
         if (child.nodeType === nodeTypes.TEXT_NODE) {
-          if (child.__location) {
-            lineOffset = child.__location.line - 1;
+          if (child.sourceCodeLocation) {
+            lineOffset = child.sourceCodeLocation.startLine - 1;
           }
           break;
         }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "html-encoding-sniffer": "^1.0.2",
     "left-pad": "^1.3.0",
     "nwsapi": "^2.0.7",
-    "parse5": "4.0.0",
+    "parse5": "^5.0.0",
     "pn": "^1.1.0",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5",

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -65,12 +65,14 @@ describe("API: JSDOM class's methods", () => {
       const node = dom.window.document.querySelector("p");
 
       assert.deepEqual(dom.nodeLocation(node), {
-        line: 1,
-        col: 1,
+        endCol: 13,
+        endLine: 1,
+        startLine: 1,
+        startCol: 1,
         startOffset: 0,
         endOffset: 12,
-        startTag: { line: 1, col: 1, startOffset: 0, endOffset: 3 },
-        endTag: { line: 1, col: 9, startOffset: 8, endOffset: 12 }
+        startTag: { endCol: 4, endLine: 1, startLine: 1, startCol: 1, startOffset: 0, endOffset: 3 },
+        endTag: { endCol: 13, endLine: 1, startLine: 1, startCol: 9, startOffset: 8, endOffset: 12 }
       });
     });
 
@@ -79,8 +81,10 @@ describe("API: JSDOM class's methods", () => {
       const node = dom.window.document.querySelector("p").firstChild;
 
       assert.deepEqual(dom.nodeLocation(node), {
-        line: 1,
-        col: 4,
+        endCol: 9,
+        endLine: 1,
+        startLine: 1,
+        startCol: 4,
         startOffset: 3,
         endOffset: 8
       });
@@ -96,27 +100,35 @@ describe("API: JSDOM class's methods", () => {
         startTag: {
           attrs: {
             src: {
-              line: 2,
-              col: 14,
+              endCol: 27,
+              endLine: 2,
+              startLine: 2,
+              startCol: 14,
               startOffset: 22,
               endOffset: 35
             }
           },
-          line: 2,
-          col: 9,
+          endCol: 28,
+          endLine: 2,
+          startLine: 2,
+          startCol: 9,
           startOffset: 17,
           endOffset: 36
         },
         attrs: {
           src: {
-            line: 2,
-            col: 14,
+            endCol: 27,
+            endLine: 2,
+            startLine: 2,
+            startCol: 14,
             startOffset: 22,
             endOffset: 35
           }
         },
-        line: 2,
-        col: 9,
+        endCol: 28,
+        endLine: 2,
+        startLine: 2,
+        startCol: 9,
         startOffset: 17,
         endOffset: 36
       });

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -46,7 +46,7 @@ describe("API: runScripts constructor option", () => {
         virtualConsole.on("jsdomError", err => {
           try {
             assert.strictEqual(err.type, "unhandled exception");
-            assert(err.detail.stack.includes("at about:blank:2"));
+            assert.isTrue(err.detail.stack.includes("at about:blank:2"));
             resolve();
           } catch (actualErr) {
             reject(actualErr);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,9 +2817,9 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse5@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+parse5@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.0.0.tgz#4d02710d44f3c3846197a11e205d4ef17842b81a"
 
 parsejson@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
[Version 5.0.0](https://github.com/inikulin/parse5/blob/master/docs/version-history.md) of parse5 was just released and it implements the `scriptingEnabled` flag which may allow us to fix issues https://github.com/jsdom/jsdom/issues/1611 and https://github.com/jsdom/jsdom/issues/1802. This pull request only includes the changes necessary for the upgrade at the moment, though.

It also includes some breaking changes to the location info, but I'm happy to report that the only fix required because of the temporary monkey-patch was the replacement of underscores with dashes in a filename.