### PR TITLE
Set new options for NWSAPI

### DIFF
--- a/lib/jsdom/living/helpers/selectors.js
+++ b/lib/jsdom/living/helpers/selectors.js
@@ -14,7 +14,9 @@ exports.matchesDontThrow = (elImpl, selector) => {
     });
     document._nwsapiDontThrow.configure({
       LOGERRORS: false,
-      VERBOSITY: false
+      VERBOSITY: false,
+      IDS_DUPES: true,
+      MIXEDCASE: true
     });
   }
 
@@ -32,7 +34,9 @@ exports.addNwsapi = parentNode => {
       DOMException
     });
     document._nwsapi.configure({
-      LOGERRORS: false
+      LOGERRORS: false,
+      IDS_DUPES: true,
+      MIXEDCASE: true
     });
   }
 


### PR DESCRIPTION
NWSAPI 2.0.1 introduces two new options - one to enable the handling of duplicate IDs and another for correctly matching non-HTML elements in HTML documents. It was originally hoped that this could be handled automatically by inspecting the structure of documents, but doing so proved problematic for very large documents.

While NWSAPI remains remains plenty fast, these options do result in a small performance loss when enabled and @dperini would like to keep them disabled by default for this reason. We enable them to completely match the spec and browsers.

While they are enabled in v2.0.1 to maintain backwards compatibility, a future (potentially non-major) version of nwsapi will disable them. Releasing a version of jsdom which enables the options on our end before that should mitigate the risk of breakage in most cases.