### PR TITLE
Remove unused form-data-symbols.js file

### DIFF
--- a/lib/jsdom/living/form-data-symbols.js
+++ b/lib/jsdom/living/form-data-symbols.js
@@ -1,3 +1,0 @@
-"use strict";
-
-exports.formData = Symbol("entries");


### PR DESCRIPTION
It seems like this file no longer is required as of https://github.com/jsdom/jsdom/commit/63f8010cba0a3ac4be9355e5a190aada9da97d2e.