### PR TITLE
Upgrades cssstyle dependency to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "acorn-globals": "^4.1.0",
     "array-equal": "^1.0.0",
     "cssom": ">= 0.3.2 < 0.4.0",
-    "cssstyle": ">= 0.3.1 < 0.4.0",
+    "cssstyle": "^1.0.0",
     "data-urls": "^1.0.0",
     "domexception": "^1.0.1",
     "escodegen": "^1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,9 +956,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.3.1 < 0.4.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
+cssstyle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.0.0.tgz#79b16d51ec5591faec60e688891f15d2a5705129"
   dependencies:
     cssom "0.3.x"
 


### PR DESCRIPTION
This release includes jsakas/CSSStyleDeclaration#52, which at long last fixes the `v.toLowerCase is not a function` error when setting `border-spacing` to `0` or `'0'`.

Also, as of this release, cssstyle will follow semver: jsakas/CSSStyleDeclaration#59