### PR TITLE
Use String.prototype.padStart()

### DIFF
--- a/lib/jsdom/living/helpers/dates-and-times.js
+++ b/lib/jsdom/living/helpers/dates-and-times.js
@@ -1,8 +1,5 @@
 "use strict";
 
-// TODO: use String.prototype.padStart instead when Node.js v8+ is required.
-const leftPad = require("left-pad");
-
 function isLeapYear(year) {
   return year % 400 === 0 || (year % 4 === 0 && year % 100 !== 0);
 }
@@ -40,8 +37,8 @@ function isValidMonthString(str) {
   return parseMonthString(str) !== null;
 }
 function serializeMonth({ year, month }) {
-  const yearStr = leftPad(`${year}`, 4, "0");
-  const monthStr = leftPad(`${month}`, 2, "0");
+  const yearStr = `${year}`.padStart(4, "0");
+  const monthStr = `${month}`.padStart(2, "0");
   return `${yearStr}-${monthStr}`;
 }
 
@@ -73,7 +70,7 @@ function isValidDateString(str) {
   return parseDateString(str) !== null;
 }
 function serializeDate(date) {
-  const dayStr = leftPad(`${date.day}`, 2, "0");
+  const dayStr = `${date.day}`.padStart(2, "0");
   return `${serializeMonth(date)}-${dayStr}`;
 }
 
@@ -101,8 +98,8 @@ function isValidYearlessDateString(str) {
   return parseYearlessDateString(str) !== null;
 }
 function serializeYearlessDate({ month, day }) {
-  const monthStr = leftPad(`${month}`, 2, "0");
-  const dayStr = leftPad(`${day}`, 2, "0");
+  const monthStr = `${month}`.padStart(2, "0");
+  const dayStr = `${day}`.padStart(2, "0");
   return `${monthStr}-${dayStr}`;
 }
 
@@ -136,13 +133,13 @@ function isValidTimeString(str) {
 }
 
 function serializeTime({ hour, minute, second, millisecond }) {
-  const hourStr = leftPad(`${hour}`, 2, "0");
-  const minuteStr = leftPad(`${minute}`, 2, "0");
+  const hourStr = `${hour}`.padStart(2, "0");
+  const minuteStr = `${minute}`.padStart(2, "0");
   if (millisecond === 0) {
     return `${hourStr}:${minuteStr}`;
   }
-  const secondStr = leftPad(second, 2, "0");
-  const millisecondStr = leftPad(millisecond, 3, "0");
+  const secondStr = `${second}`.padStart(2, "0");
+  const millisecondStr = `${millisecond}`.padStart(3, "0");
   return `${hourStr}:${minuteStr}:${secondStr}.${millisecondStr}`;
 }
 
@@ -210,8 +207,8 @@ function isValidWeekString(str) {
   return parseWeekString(str) !== null;
 }
 function serializeWeek({ year, week }) {
-  const yearStr = leftPad(`${year}`, 4, "0");
-  const weekStr = leftPad(`${week}`, 2, "0");
+  const yearStr = `${year}`.padStart(4, "0");
+  const weekStr = `${week}`.padStart(2, "0");
   return `${yearStr}-W${weekStr}`;
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "domexception": "^1.0.1",
     "escodegen": "^1.9.1",
     "html-encoding-sniffer": "^1.0.2",
-    "left-pad": "^1.3.0",
     "nwsapi": "^2.0.7",
     "parse5": "4.0.0",
     "pn": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,10 +2261,6 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-left-pad@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
-
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"


### PR DESCRIPTION
Since it looks like we'll require Node.js v8 with the next major release, we can use `String.prototype.padStart()` and remove a dependency.