### PR TITLE
Add window.status

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -582,9 +582,7 @@ function Window(options) {
 
   define(this, {
     name: "",
-    // Node v6 has issues (presumably in the vm module)
-    // which this property exposes through an XHR test
-    // status: "",
+    status: "",
     devicePixelRatio: 1,
     innerWidth: 1024,
     innerHeight: 768,

--- a/test/web-platform-tests/to-upstream/html/browsers/the-window-object/window-properties-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/browsers/the-window-object/window-properties-dont-upstream.html
@@ -115,15 +115,15 @@ var readonlyAttributes = [
   // "applicationCache", // not yet implemented
 
   // WindowSessionStorage
-  // "sessionStorage", // not yet implemented
+  "sessionStorage",
 
   // WindowLocalStorage
-  // "localStorage", // not yet implemented
+  "localStorage",
 ];
 
 var writableAttributes = [
   "name",
-//  "status", // looks like there is an issue with Node v6 and XHR, see Window.js
+  "status",
 //  "opener", // not yet implemented
   "onabort",
   "onafterprint",


### PR DESCRIPTION
This property was previously missing because it exposed a bug in the `vm` module on Node.js v6 which appeared in a few XHR tests. The bug has been fixed in later versions.

Spec: https://html.spec.whatwg.org/multipage/#dom-window-status