### PR TITLE
Use ESLint's cache option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .svn
 .*.swp
+.eslintcache
 gmon.out
 v8.log
 node_modules

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test-browser-iframe": "karma start test/karma.conf.js",
     "test-browser-worker": "karma start test/karma-webworker.conf.js",
     "test-browser": "yarn test-browser-iframe && yarn test-browser-worker",
-    "lint": "eslint . && eslint test/web-platform-tests/to-upstream --ext .html",
+    "lint": "eslint . --cache && eslint test/web-platform-tests/to-upstream --cache --ext .html",
     "lint-is-complete": "eslint-find-rules --unused .eslintrc.json",
     "init-wpt": "git submodule update --init --recursive",
     "reset-wpt": "rimraf ./test/web-platform-tests/tests && yarn init-wpt",


### PR DESCRIPTION
This speeds up linting by ~10 seconds on my machine. The option is not enabled in ESLint by default since it interferes with plugins that require looking at dependent files to produce a result, but that's not a problem with the plugins we're using here as far as I can tell.