### PR TITLE
Provide `process.platform` fallback for User-Agent string

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The three options to the `ResourceLoader` constructor are:
 
 - `proxy` is the address of a HTTP proxy to be used.
 - `strictSSL` can be set to false to disable the requirement that SSL certificates be valid.
-- `userAgent` affects the `User-Agent` header sent, and thus the resulting value for `navigator.userAgent`. It defaults to <code>\`Mozilla/5.0 (${process.platform}) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/${jsdomVersion}\`</code>.
+- `userAgent` affects the `User-Agent` header sent, and thus the resulting value for `navigator.userAgent`. It defaults to <code>\`Mozilla/5.0 (${process.platform || "unknown OS"}) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/${jsdomVersion}\`</code>.
 
 You can further customize resource fetching by subclassing `ResourceLoader` and overriding the `fetch()` method. For example, here is a version that only returns results for requests to a trusted origin:
 

--- a/lib/jsdom/browser/resources/resource-loader.js
+++ b/lib/jsdom/browser/resources/resource-loader.js
@@ -11,7 +11,8 @@ module.exports = class ResourceLoader {
   constructor({
     strictSSL = true,
     proxy = undefined,
-    userAgent = `Mozilla/5.0 (${process.platform}) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/${packageVersion}`
+    userAgent = `Mozilla/5.0 (${process.platform || "unknown OS"}) AppleWebKit/537.36 ` +
+                `(KHTML, like Gecko) jsdom/${packageVersion}`
   } = {}) {
     this._strictSSL = strictSSL;
     this._proxy = proxy;

--- a/test/api/from-url.js
+++ b/test/api/from-url.js
@@ -81,7 +81,7 @@ describe("API: JSDOM.fromURL()", { skipIfBrowser: true }, () => {
 
   describe("user agent", () => {
     it("should use the default user agent as the User-Agent header when none is given", () => {
-      const expected = `Mozilla/5.0 (${process.platform}) AppleWebKit/537.36 ` +
+      const expected = `Mozilla/5.0 (${process.platform || "unknown OS"}) AppleWebKit/537.36 ` +
                        `(KHTML, like Gecko) jsdom/${packageVersion}`;
 
       let recordedHeader;

--- a/test/api/resources.js
+++ b/test/api/resources.js
@@ -552,7 +552,7 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
 
   for (const resources of [undefined, "usable"]) {
     describe(`User agent (resources set to ${resources})`, () => {
-      const expected = `Mozilla/5.0 (${process.platform}) AppleWebKit/537.36 ` +
+      const expected = `Mozilla/5.0 (${process.platform || "unknown OS"}) AppleWebKit/537.36 ` +
                        `(KHTML, like Gecko) jsdom/${packageVersion}`;
 
       it("should have a default user agent following the correct pattern", () => {


### PR DESCRIPTION
Implements the suggested solution to https://github.com/jsdom/jsdom/issues/2294 when `process.platform` is unavailable, resulting in the User-Agent string:

`Mozilla/5.0 (unknown OS) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/11.12.0`.

I'm not convinced that this is the long-term solution we want for the UA string given how different the values are from those in browsers (`win32` vs `Windows NT 10.0; Win64; x64`), but it solves the `undefined`-problem at least.

Fixes #2294.