### PR TITLE
Invalidate caches for `optionEl.selected` setter

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
@@ -90,6 +90,7 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
       this._removeOtherSelectedness();
     }
     this._askForAReset();
+    this._modified();
   }
 
   // TODO this is quite wrong


### PR DESCRIPTION
Fixes #2326.

Tests are being added in https://github.com/web-platform-tests/wpt/pull/12448.