### PR TITLE
Minor code and README cleanups; note Node.js version requirement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ This major release brings along our [new resource loader API](https://github.com
 
 Breaking changes:
 
+* jsdom now requires Node.js v8.
 * Removed the old jsdom API, as the new API now has all the capabilities you need.
 * Updated our [parse5](https://github.com/inikulin/parse5/) dependency to v5, which changes the format of the node locations returned by `dom.nodeLocation()`.
 * Updated our [whatwg-url](https://github.com/jsdom/whatwg-url) dependency to v7, which changes the origin of `file:` URLs to be an opaque origin (and thus `file:` URLs are no longer same origin to each other).

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ const dom = new JSDOM(``, { resources: resourceLoader });
 
 The three options to the `ResourceLoader` constructor are:
 
-- `proxy` is the address of a HTTP proxy to be used.
+- `proxy` is the address of an HTTP proxy to be used.
 - `strictSSL` can be set to false to disable the requirement that SSL certificates be valid.
 - `userAgent` affects the `User-Agent` header sent, and thus the resulting value for `navigator.userAgent`. It defaults to <code>\`Mozilla/5.0 (${process.platform || "unknown OS"}) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/${jsdomVersion}\`</code>.
 

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -47,33 +47,33 @@ class ParentNodeImpl {
     return this.children.length;
   }
 
+  prepend(...nodes) {
+    this.insertBefore(convertNodesIntoNode(this._ownerDocument, nodes), this.firstChild);
+  }
+
   append(...nodes) {
     this.appendChild(convertNodesIntoNode(this._ownerDocument, nodes));
   }
 
-  prepend(...nodes) {
-    this.insertBefore(convertNodesIntoNode(this._ownerDocument, nodes), this.firstChild);
+  querySelector(selectors) {
+    if (shouldAlwaysSelectNothing(this)) {
+      return null;
+    }
+    const matcher = addNwsapi(this);
+    return idlUtils.implForWrapper(matcher.first(selectors, idlUtils.wrapperForImpl(this)));
+  }
+
+  // Warning for internal users: this returns a NodeList containing IDL wrappers instead of impls
+  querySelectorAll(selectors) {
+    if (shouldAlwaysSelectNothing(this)) {
+      return NodeList.create([], { nodes: [] });
+    }
+    const matcher = addNwsapi(this);
+    const list = matcher.select(selectors, idlUtils.wrapperForImpl(this));
+
+    return NodeList.create([], { nodes: list.map(n => idlUtils.tryImplForWrapper(n)) });
   }
 }
-
-ParentNodeImpl.prototype.querySelector = function (selectors) {
-  if (shouldAlwaysSelectNothing(this)) {
-    return null;
-  }
-  const matcher = addNwsapi(this);
-  return idlUtils.implForWrapper(matcher.first(selectors, idlUtils.wrapperForImpl(this)));
-};
-
-// WARNING: this returns a NodeList containing IDL wrappers instead of impls
-ParentNodeImpl.prototype.querySelectorAll = function (selectors) {
-  if (shouldAlwaysSelectNothing(this)) {
-    return NodeList.create([], { nodes: [] });
-  }
-  const matcher = addNwsapi(this);
-  const list = matcher.select(selectors, idlUtils.wrapperForImpl(this));
-
-  return NodeList.create([], { nodes: list.map(n => idlUtils.tryImplForWrapper(n)) });
-};
 
 function shouldAlwaysSelectNothing(elImpl) {
   // This is true during initialization.

--- a/package.json
+++ b/package.json
@@ -101,5 +101,8 @@
     "benchmark-browser": "node ./benchmark/runner --bundle",
     "convert-idl": "node ./scripts/webidl/convert"
   },
-  "main": "./lib/api.js"
+  "main": "./lib/api.js",
+  "engines": {
+    "node": ">=8"
+  }
 }


### PR DESCRIPTION
For these selector methods, before bfb08434f540491591aace17b302816f146dd4ef they were memoized, which kept them outside the class. Now we can just put them in the class, like normal methods.

Will merge once CI is happy.