### PR TITLE
Implement remaining properties of the `fieldset` element

### DIFF
--- a/lib/jsdom/living/nodes/HTMLFieldSetElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFieldSetElement-impl.js
@@ -1,13 +1,27 @@
 "use strict";
+const HTMLCollection = require("../generated/HTMLCollection");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
 const { mixin } = require("../../utils");
-const { closest } = require("../helpers/traversal");
+const { closest, descendantsByHTMLLocalNames } = require("../helpers/traversal");
+
+const listedElements = new Set(["button", "fieldset", "input", "object", "output", "select", "textarea"]);
 
 class HTMLFieldSetElementImpl extends HTMLElementImpl {
+  get elements() {
+    return HTMLCollection.createImpl([], {
+      element: this,
+      query: () => descendantsByHTMLLocalNames(this, listedElements)
+    });
+  }
+
   get form() {
     return closest(this, "form");
+  }
+
+  get type() {
+    return "fieldset";
   }
 
   _barredFromConstraintValidationSpecialization() {

--- a/lib/jsdom/living/nodes/HTMLFieldSetElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLFieldSetElement.webidl
@@ -5,9 +5,9 @@ interface HTMLFieldSetElement : HTMLElement {
   readonly attribute HTMLFormElement? form;
   [CEReactions, Reflect] attribute DOMString name;
 
-//  readonly attribute DOMString type;
+  readonly attribute DOMString type;
 
-//  [SameObject] readonly attribute HTMLCollection elements;
+  [SameObject] readonly attribute HTMLCollection elements;
 
   readonly attribute boolean willValidate;
   [SameObject] readonly attribute ValidityState validity;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -498,7 +498,7 @@ button-validation.html: [fail, Expects type 'menu' to not change to 'submit']
 
 DIR: html/semantics/forms/the-fieldset-element
 
-HTMLFieldSetElement.html: [fail, Unknown]
+HTMLFieldSetElement.html: [fail, Depends on HTMLFormElement's named properties; has dont-upstream version]
 disabled-001.html: [fail, Unknown]
 fieldset-setcustomvalidity.html: [fail, Not implemented]
 

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement-dont-upstream.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: HTMLFieldSetElement interface</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-fieldset-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<form name="fm1" style="display:none">
+  <fieldset id="fs_outer">
+  <legend><input type="checkbox" name="cb"></legend>
+  <input type=text name="txt" id="ctl1">
+  <button id="ctl2" name="btn">BUTTON</button>
+    <fieldset id="fs_inner">
+      <input type="text" name="txt_inner">
+      <progress name="pg" value="0.5"></progress>
+    </fieldset>
+  </fieldset>
+</form>
+<script>
+
+var fm1,
+    fs_outer,
+    children_outer;
+
+setup(function () {
+  fm1 = document.forms.fm1;
+  fs_outer = document.getElementById("fs_outer");
+  children_outer = fs_outer.elements;
+});
+
+test(function () {
+  assert_equals(fs_outer.type, "fieldset", "The value of type attribute is incorrect.");
+}, "The type attribute must return 'fieldset'");
+
+test(function () {
+  assert_equals(fs_outer.form, fm1, "The fieldset should have a form owner.");
+}, "The form attribute must return the fieldset's form owner");
+
+test(function () {
+  assert_equals(children_outer.constructor, HTMLCollection,
+              "The elements attribute should be an HTMLCollection object");
+}, "The elements must return an HTMLCollection object");
+
+test(function () {
+  var fs_inner = document.getElementById("fs_inner");
+  var children_inner = fs_inner.elements;
+  assert_array_equals(children_inner, [fm1.querySelector("[name=txt_inner]")],
+                      "The items in the collection must be children of the inner fieldset element.");
+  assert_array_equals(children_outer, [fm1.querySelector("[name=cb]"), fm1.querySelector("[name=txt]"), fm1.querySelector("[name=btn]"), fm1.querySelector("#fs_inner"), fm1.querySelector("[name=txt_inner]")],
+                      "The items in the collection must be children of the outer fieldset element.");
+}, "The controls must root at the fieldset element");
+
+</script>


### PR DESCRIPTION
Specifically, HTMLFieldSetElement's `elements` and `type` getters. I've also added a dont-upstream test since the original version depends on HTMLFormElement's named properties, replacing them with `querySelector()` instead.