### PR TITLE
Upgrade `cssstyle` dependency from ^1.0.0 to ^1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "acorn-globals": "^4.1.0",
     "array-equal": "^1.0.0",
     "cssom": ">= 0.3.2 < 0.4.0",
-    "cssstyle": "^1.0.0",
+    "cssstyle": "^1.1.1",
     "data-urls": "^1.0.1",
     "domexception": "^1.0.1",
     "escodegen": "^1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,9 +893,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 
-cssstyle@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.0.0.tgz#79b16d51ec5591faec60e688891f15d2a5705129"
+cssstyle@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
   dependencies:
     cssom "0.3.x"
 


### PR DESCRIPTION
Closes #2281 

We fixed this upstream in the `cssstyle` package in this pull request: https://github.com/jsakas/CSSStyleDeclaration/pull/61 and the fix was published in version 1.1.0, so just by upgrading the above issue should be resolved.

Here's a diff from version 1.0.0 to 1.1.1 so that the impact from the upgrade can be better evaluated: https://github.com/jsakas/CSSStyleDeclaration/compare/v1.0.0...v1.1.1

Let me know if anything else should be done in this PR to accept this change!