### PR TITLE
Implement logic in play and pause media element methods

### DIFF
--- a/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
@@ -108,6 +108,13 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
     }
   }
 
+  play() {
+    this.paused = false;
+  }
+  pause() {
+    this.paused = true;
+  }
+
   // Not (yet) implemented according to spec
   // Should return sane default values
   load() {
@@ -115,12 +122,6 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
   }
   canPlayType() {
     return "";
-  }
-  play() {
-    notImplemented("HTMLMediaElement.prototype.play", this._ownerDocument._defaultView);
-  }
-  pause() {
-    notImplemented("HTMLMediaElement.prototype.pause", this._ownerDocument._defaultView);
   }
   addTextTrack() {
     notImplemented("HTMLMediaElement.prototype.addNextTrack", this._ownerDocument._defaultView);


### PR DESCRIPTION
This PR aims to implement a minimal logic for the `play` and `pause` methods by setting the `paused` property.