### PR TITLE
canvas/canvas-prebuilt: show error when module is available but fails to load

### DIFF
--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -169,6 +169,13 @@ exports.Canvas = null;
       exports.Canvas = null;
     }
   } catch (e) {
+    try {
+      require.resolve(moduleName);
+      // the module is installed, but loading it failed
+      console.error("Failed loading " + moduleName, e);
+    } catch(_) {
+      // module is not installed
+    }
     exports.Canvas = null;
   }
   return exports.Canvas !== null;

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -163,20 +163,15 @@ exports.treeOrderSorter = function (a, b) {
 exports.Canvas = null;
 ["canvas", "canvas-prebuilt"].some(moduleName => {
   try {
-    exports.Canvas = require(moduleName);
-    if (typeof exports.Canvas !== "function") {
-      // In browserify, the require will succeed but return an empty object
-      exports.Canvas = null;
-    }
+    require.resolve(moduleName);
   } catch (e) {
-    try {
-      require.resolve(moduleName);
-      // the module is installed, but loading it failed
-      // eslint-disable-next-line no-console
-      console.error("Failed loading " + moduleName, e);
-    } catch (_) {
-      // module is not installed
-    }
+    // ${moduleName} is not installed
+    exports.Canvas = null;
+    return false;
+  }
+  exports.Canvas = require(moduleName);
+  if (typeof exports.Canvas !== "function") {
+    // In browserify, the require will succeed but return an empty object
     exports.Canvas = null;
   }
   return exports.Canvas !== null;

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -172,8 +172,9 @@ exports.Canvas = null;
     try {
       require.resolve(moduleName);
       // the module is installed, but loading it failed
+      // eslint-disable-next-line no-console
       console.error("Failed loading " + moduleName, e);
-    } catch(_) {
+    } catch (_) {
       // module is not installed
     }
     exports.Canvas = null;


### PR DESCRIPTION
In some environments, neither `canvas`, nor `canvas-prebuilt` will be installed - as it is an optional dependency, we will just ignore their absence, however when one or both of them are installed, there is a chance that loading them fails, as they are depending on native bindings.

For example when building a docker image that runs `sid`, `libpng12-0` is not available, which means that loading (requiring) canvas-prebuilt fails, due to:

> `error while loading shared libraries: libpng12.so.0: cannot open shared object file: No such file or directory`

It took me quite a while to figure out why canvas-prebuilt worked outside the docker container, but not inside, even though both systems were linux.
The way the try/catch is currently set up means that loading errors are swallowed. The change in this PR makes loading changes at least visible in a similar manner to how they would show up when just doing `require('canvas-prebuilt')` anywhere in the bootstrap code.

references https://github.com/jsdom/jsdom/pull/1754, https://github.com/jsdom/jsdom/issues/1365, https://github.com/tcoopman/image-webpack-loader/issues/95