### PR TITLE
Upgrade saxes from 3.1.2 to 3.1.3 to fix deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pn": "^1.1.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
-    "saxes": "^3.1.2",
+    "saxes": "^3.1.3",
     "symbol-tree": "^3.2.2",
     "tough-cookie": "^2.4.3",
     "w3c-hr-time": "^1.0.1",


### PR DESCRIPTION
Running saxes version 3.1.2 displays a deprecation warning related to its dependency 'xmlchars'.

Patch version 3.1.3 fixes that deprecation warning.