### PR TITLE
Lint scripts in HTML and JS files during same run

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 node_modules
 
 benchmark/browser-bundle.js
+benchmark/browser-runner.html
 test/worker-bundle.js
 
 lib/jsdom/browser/default-stylesheet.js
@@ -13,12 +14,8 @@ test/*.js
 !test/karma*
 !test/util.js
 
-test/browser/files
+test/api/fixtures
 test/jquery-fixtures
-test/jsdom/files
-test/jsdom/leak.js
-test/runner
-test/sizzle
 test/to-port-to-wpts/files
 test/to-port-to-wpts/frame.js
 test/to-port-to-wpts/level1

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test-browser-iframe": "karma start test/karma.conf.js",
     "test-browser-worker": "karma start test/karma-webworker.conf.js",
     "test-browser": "yarn test-browser-iframe && yarn test-browser-worker",
-    "lint": "eslint . --cache && eslint test/web-platform-tests/to-upstream --cache --ext .html",
+    "lint": "eslint . --cache --ext .js,.html",
     "lint-is-complete": "eslint-find-rules --unused .eslintrc.json",
     "init-wpt": "git submodule update --init --recursive",
     "reset-wpt": "rimraf ./test/web-platform-tests/tests && yarn init-wpt",


### PR DESCRIPTION
I occasionally see pull requests where linting errors from `to-upstream` don't appear on the initial CI run, as the second linting command only runs if there's no error from the first.

Using `;` will ensure that errors in both locations show up right away.