### PR TITLE
potential runaway promise fix

### DIFF
--- a/lib/jsdom/browser/resources/resource-queue.js
+++ b/lib/jsdom/browser/resources/resource-queue.js
@@ -116,7 +116,7 @@ module.exports = class ResourceQueue {
       .then(data => {
         item.fired = 1;
         item.data = data;
-        item.check();
+        return item.check();
       })
       .catch(err => {
         item.fired = true;


### PR DESCRIPTION
I am getting a warning from Bluebird which seems to match a runaway promise in the code above

http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it

Adding a return statement fixes the warning and "seems" logic.

Not sure if one should do the same for the catch statement

If the sensible thing is not to chain the return promise of item.check() please consider adding a "return null;" statement for Bluebird users. This silences the warning too and confirms the intention to not chain promises