### PR TITLE
Feature/document.hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ dom.reconfigure({ windowTop: myFakeTopForTesting, url: "https://example.com/", d
 
 dom.window.top === myFakeTopForTesting;
 dom.window.location.href === "https://example.com/";
-dom.hidden === false;
+dom.window.document.hidden === false;
 ```
 
 Note that changing the jsdom's URL will impact all APIs that return the current document URL, such as `window.location`, `document.URL`, and `document.documentURI`, as well as resolution of relative URLs within the document, and the same-origin checks and referrer used while fetching subresources. It will not, however, perform a navigation to the contents of that URL; the contents of the DOM will remain unchanged, and no new instances of `Window`, `Document`, etc. will be created.

--- a/lib/api.js
+++ b/lib/api.js
@@ -99,6 +99,11 @@ class JSDOM {
     }
 
     if ("documentHidden" in settings) {
+      // verbose check due to eslint rule no-eq-null
+      if (settings.documentHidden === null || settings.documentHidden === undefined) {
+        return;
+      }
+
       const document = idlUtils.implForWrapper(this[window]._document);
 
       const hidden = Boolean(settings.documentHidden);

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -291,37 +291,40 @@ describe("API: JSDOM class's methods", () => {
     describe("documentHidden", () => {
       it("should reconfigure the document.hidden property (tested from the outside)", () => {
         const dom = new JSDOM();
-        const expected = false;
 
         dom.reconfigure({ documentHidden: false });
+        assert.strictEqual(dom.window.document.hidden, false);
 
-        assert.strictEqual(dom.document.hidden, expected);
+        dom.reconfigure({ documentHidden: true });
+        assert.strictEqual(dom.window.document.hidden, true);
       });
 
-      // it("should reconfigure the window.top property (tested from the inside)", () => {
-      //   const dom = new JSDOM(`<script>window.getTopResult = () => top.is;</script>`, { runScripts: "dangerously" });
-      //   const newTop = { is: "top" };
+      it("should reconfigure the document.hidden property (tested from the inside)", () => {
+        const dom = new JSDOM(`<script>window.getHidden = () => document.hidden;</script>`, { runScripts: "dangerously" });
 
-      //   dom.reconfigure({ windowTop: newTop });
+        dom.reconfigure({ documentHidden: false });
+        assert.strictEqual(dom.window.getHidden(), false);
 
-      //   assert.strictEqual(dom.window.getTopResult(), "top");
-      // });
+        dom.reconfigure({ documentHidden: true });
+        assert.strictEqual(dom.window.getHidden(), true);
+      });
 
-      // it("should do nothing when no options are passed", () => {
-      //   const dom = new JSDOM();
+      it("should do nothing when no options are passed", () => {
+        const dom = new JSDOM();
+        const expected = true;
 
-      //   dom.reconfigure({ });
+        dom.reconfigure({ });
 
-      //   assert.strictEqual(dom.window.top, dom.window);
-      // });
+        assert.strictEqual(dom.window.document.hidden, expected);
+      });
 
-      // it("should change window.top to undefined if passing undefined", () => {
-      //   const dom = new JSDOM();
+      it("should do nothing if passing undefined", () => {
+        const dom = new JSDOM();
 
-      //   dom.reconfigure({ windowTop: undefined });
+        dom.reconfigure({ documentHidden: undefined });
 
-      //   assert.strictEqual(dom.window.top, undefined);
-      // });
+        assert.strictEqual(dom.window.document.hidden, true);
+      });
     });
   });
 });


### PR DESCRIPTION
This patch is my initial attempt to enable jsdom to test the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API)

I am very open to suggestions as it is not a very thought thorough patch but it gets the job done and allow me to have confident in my production code. I need this ASAP.

However, it might only cover my use-case and as I have noted in #2391:

>It would perhaps make more sense if the setting was called `pretendToBeVisual` but then it would not make so much sense that it alters `document.hidden`.

I also added documentation in the README. But English is not my first language, so please review that as well.

There is 4 new tests in _test/api/methods.js_.

## Full Explanation

I need to test code that set a timestamp value depending on `document.hidden`.
jsdom toggles the value depending on `pretendToBeVisual` as [documented in the jsdom README](https://github.com/jsdom/jsdom#pretending-to-be-a-visual-browser).

I am using [jest](https://github.com/facebook/jest/) which uses jsdom.

### Minimal reproduction case

I need a way to toggle `document.hidden` in jsdom in order to test code that has different code paths depending on the value.

To test the following function `getTimeDuration`:
```js
/**
 * First call starts a timer and returns a function
 * that when called will give the elapsed time in
 * milisecond, while subtracting "hidden" time.
 * @returns {function} Calling this function will return the elapsed time.
 */
export default function getTimeDuration () {
  const startTimestamp = Date.now()
  let hiddenTimeDelta = 0
  let hiddenTimeStart = 0

  document.addEventListener('visibilitychange', trackHiddenTime)

  function trackHiddenTime () {
    if (document.hidden) {
      hiddenTimeStart = Date.now()
    } else {
      hiddenTimeDelta += (Date.now() - hiddenTimeStart)
    }
  }

  return () => {
    document.removeEventListener('visibilitychange', trackHiddenTime)

    return (Date.now() - hiddenTimeDelta) - startTimestamp
  }
}
```
And with [jest-environment-jsdom-global](https://www.npmjs.com/package/jest-environment-jsdom-global) you can use it in jest like so:

```js
test.only('visibilitychange duration used by PayloadTiming', () => {
  // jestDateMock.advanceTo(0) is
  // needed due to issue: https://github.com/hustcc/jest-date-mock/issues/15
  jestDateMock.advanceTo(0)

  const timer = getTimeDuration()

  jestDateMock.advanceBy(10) // visible state

  jsdom.reconfigure({ documentHidden: true }) // hidden state
  document.dispatchEvent(new Event('visibilitychange'))
  jestDateMock.advanceBy(10)

  jsdom.reconfigure({ documentHidden: false }) // visible state
  document.dispatchEvent(new Event('visibilitychange'))
  jestDateMock.advanceBy(10)

  const expected = 20
  const actual = timer()

  expect(actual).toBe(expected)
  jestDateMock.clear()
})
```

More background info in #2391  and https://github.com/facebook/jest/issues/7142