### PR TITLE
Implement `insertAdjacentElement()` and `insertAdjacentText()`

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -451,7 +451,7 @@ class ElementImpl extends NodeImpl {
 
   // https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml
   insertAdjacentHTML(position, text) {
-    position = position.toLowerCase();
+    position = asciiLowercase(position);
 
     let context;
     switch (position) {
@@ -470,8 +470,8 @@ class ElementImpl extends NodeImpl {
         break;
       }
       default: {
-        throw new DOMException("Must provide one of \"beforebegin\", \"afterend\", " +
-          "\"afterbegin\", or \"beforeend\".", "SyntaxError");
+        throw new DOMException('Must provide one of "beforebegin", "afterbegin", ' +
+      '"beforeend", or "afterend".', "SyntaxError");
       }
     }
 

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -23,6 +23,7 @@ const { clone, listOfElementsWithQualifiedName, listOfElementsWithNamespaceAndLo
 const SlotableMixinImpl = require("./Slotable-impl").implementation;
 const NonDocumentTypeChildNode = require("./NonDocumentTypeChildNode-impl").implementation;
 const ShadowRoot = require("../generated/ShadowRoot");
+const Text = require("../generated/Text");
 const { isValidHostElementName } = require("../helpers/shadow-dom");
 const { isValidCustomElementName } = require("../helpers/custom-elements");
 
@@ -409,6 +410,43 @@ class ElementImpl extends NodeImpl {
     }
 
     return shadow;
+  }
+
+  // https://dom.spec.whatwg.org/#insert-adjacent
+  _insertAdjacent(element, where, node) {
+    where = asciiLowercase(where);
+
+    if (where === "beforebegin") {
+      if (element.parentNode === null) {
+        return null;
+      }
+      return element.parentNode._preInsert(node, element);
+    }
+    if (where === "afterbegin") {
+      return element._preInsert(node, element.firstChild);
+    }
+    if (where === "beforeend") {
+      return element._preInsert(node, null);
+    }
+    if (where === "afterend") {
+      if (element.parentNode === null) {
+        return null;
+      }
+      return element.parentNode._preInsert(node, element.nextSibling);
+    }
+
+    throw new DOMException('Must provide one of "beforebegin", "afterbegin", ' +
+      '"beforeend", or "afterend".', "SyntaxError");
+  }
+
+  insertAdjacentElement(where, element) {
+    return this._insertAdjacent(this, where, element);
+  }
+
+  insertAdjacentText(where, data) {
+    const text = Text.createImpl([], { data, ownerDocument: this._ownerDocument });
+
+    this._insertAdjacent(this, where, text);
   }
 
   // https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml

--- a/lib/jsdom/living/nodes/Element.webidl
+++ b/lib/jsdom/living/nodes/Element.webidl
@@ -40,8 +40,8 @@ interface Element : Node {
   HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
   HTMLCollection getElementsByClassName(DOMString classNames);
 
-//  [CEReactions] Element? insertAdjacentElement(DOMString where, Element element); // historical
-//  void insertAdjacentText(DOMString where, DOMString data); // historical
+  [CEReactions] Element? insertAdjacentElement(DOMString where, Element element); // historical
+  void insertAdjacentText(DOMString where, DOMString data); // historical
 };
 
 dictionary ShadowRootInit {

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -131,8 +131,6 @@ Document-importNode.html: [fail, Attr should be a Node, https://github.com/jsdom
 Element-closest.html: [fail, :has is not supported (by all major browsers as well)]
 Element-firstElementChild-entity-xhtml.xhtml: [fail, Unknown]
 Element-getElementsByTagName-change-document-HTMLNess.html: [fail, Unknown]
-Element-insertAdjacentElement.html: [fail, Not implemented]
-Element-insertAdjacentText.html: [fail, Not implemented]
 Element-matches.html: [fail, Whitespace in pseudo-class parameter]
 Element-webkitMatchesSelector.html: [fail, Whitespace in pseudo-class parameter]
 MutationObserver-**: [fail, Not implemented]
@@ -144,7 +142,6 @@ ParentNode-querySelector-All-xht.xht: [timeout, Unknown]
 ProcessingInstruction-escapes-1.xhtml: [fail, Unknown]
 ProcessingInstruction-literal-1.xhtml: [fail, Unknown]
 Text-constructor.html: [fail, Unknown]
-insert-adjacent.html: [fail, Unknown]
 remove-unscopable.html: [fail, Unknown]
 
 ---


### PR DESCRIPTION
This builds on the code in https://github.com/jsdom/jsdom/pull/2395, and implements the `insertAdjacentElement()` and `insertAdjacentText()` methods on `Element`.

It also includes a fix to use ASCII lowercase for the `position` argument in `insertAdjacentHTML()`.

Fixes https://github.com/jsdom/jsdom/issues/1890.