### PR TITLE
Support `relList` attribute on <a>, <area> and <link> elements

### DIFF
--- a/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
@@ -1,5 +1,6 @@
 "use strict";
 const { mixin } = require("../../utils");
+const DOMTokenList = require("../generated/DOMTokenList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const HTMLHyperlinkElementUtilsImpl = require("./HTMLHyperlinkElementUtils-impl").implementation;
 
@@ -10,11 +11,27 @@ class HTMLAnchorElementImpl extends HTMLElementImpl {
     this._htmlHyperlinkElementUtilsSetup();
   }
 
+  get relList() {
+    if (this._relList === undefined) {
+      this._relList = DOMTokenList.createImpl([], {
+        element: this,
+        attributeLocalName: "rel"
+      });
+    }
+    return this._relList;
+  }
+
   get text() {
     return this.textContent;
   }
   set text(v) {
     this.textContent = v;
+  }
+
+  _attrModified(name) {
+    if (name === "rel" && this._relList !== undefined) {
+      this._relList.attrModified();
+    }
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLAnchorElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLAnchorElement.webidl
@@ -5,7 +5,7 @@ interface HTMLAnchorElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString download;
 //  [CEReactions] attribute USVString ping;
   [CEReactions, Reflect] attribute DOMString rel;
-//  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
   [CEReactions, Reflect] attribute DOMString hreflang;
   [CEReactions, Reflect] attribute DOMString type;
 

--- a/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
@@ -1,5 +1,6 @@
 "use strict";
 const { mixin } = require("../../utils");
+const DOMTokenList = require("../generated/DOMTokenList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const HTMLHyperlinkElementUtilsImpl = require("./HTMLHyperlinkElementUtils-impl").implementation;
 
@@ -8,6 +9,22 @@ class HTMLAreaElementImpl extends HTMLElementImpl {
     super(args, privateData);
 
     this._htmlHyperlinkElementUtilsSetup();
+  }
+
+  get relList() {
+    if (this._relList === undefined) {
+      this._relList = DOMTokenList.createImpl([], {
+        element: this,
+        attributeLocalName: "rel"
+      });
+    }
+    return this._relList;
+  }
+
+  _attrModified(name) {
+    if (name === "rel" && this._relList !== undefined) {
+      this._relList.attrModified();
+    }
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLAreaElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLAreaElement.webidl
@@ -8,7 +8,7 @@ interface HTMLAreaElement : HTMLElement {
 //  [CEReactions] attribute DOMString download;
 //  [CEReactions] attribute USVString ping;
   [CEReactions, Reflect] attribute DOMString rel;
-//  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
 //  [CEReactions] attribute DOMString referrerPolicy;
 
   // also has obsolete members

--- a/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
@@ -1,5 +1,6 @@
 "use strict";
 const { reflectURLAttribute } = require("../../utils");
+const DOMTokenList = require("../generated/DOMTokenList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const idlUtils = require("../generated/utils");
 const { fetchStylesheet } = require("../helpers/stylesheets");
@@ -16,6 +17,17 @@ class HTMLLinkElementImpl extends HTMLElementImpl {
     this.sheet = null;
   }
 
+  get relList() {
+    if (this._relList === undefined) {
+      this._relList = DOMTokenList.createImpl([], {
+        element: this,
+        attributeLocalName: "rel",
+        supportedTokens: new Set(["stylesheet"])
+      });
+    }
+    return this._relList;
+  }
+
   _attach() {
     super._attach();
 
@@ -29,6 +41,10 @@ class HTMLLinkElementImpl extends HTMLElementImpl {
 
     if (name === "href" && this._attached && isExternalResourceLink(this)) {
       obtainTheResource(this);
+    }
+
+    if (name === "rel" && this._relList !== undefined) {
+      this._relList.attrModified();
     }
   }
 

--- a/lib/jsdom/living/nodes/HTMLLinkElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLLinkElement.webidl
@@ -5,7 +5,7 @@ interface HTMLLinkElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString? crossOrigin;
   [CEReactions, Reflect] attribute DOMString rel;
 //  [CEReactions] attribute DOMString as; // (default "")
-//  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
   [CEReactions, Reflect] attribute DOMString media;
 //  [CEReactions] attribute DOMString nonce;
 //  [CEReactions] attribute DOMString integrity;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -106,7 +106,7 @@ relatedTarget.window.html: [fail, Shadow DOM not implemented]
 
 DIR: dom/lists
 
-DOMTokenList-coverage-for-attributes.html: [fail, Several DOMTokenList attributes have not been implemented]
+DOMTokenList-coverage-for-attributes.html: [fail, Several DOMTokenList attributes have not been implemented; has dont-upstream version]
 DOMTokenList-iteration.html: [fail, The test checks a builtin method is from the jsdom context]
 
 ---
@@ -435,6 +435,15 @@ DIR: html/semantics/disabled-elements
 DIR: html/semantics/document-metadata/the-base-element
 
 base_multiple.html: [timeout, We don't support navigation via <a target>]
+
+---
+
+DIR: html/semantics/document-metadata/the-link-element
+
+link-load-error-events.html: [fail, We don't fire error events]
+link-load-error-events.https.html: [fail, We don't fire error events]
+link-rel-attribute.html: [fail, CSS computed style computation]
+link-style-error-01.html: [fail, We don't fire error events]
 
 ---
 

--- a/test/web-platform-tests/to-upstream/dom/lists/DOMTokenList-coverage-for-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/dom/lists/DOMTokenList-coverage-for-attributes-dont-upstream.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DOMTokenList coverage for attributes</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+"use strict";
+
+var pairs = [
+  // Defined in DOM
+  {attr: "classList", sup: ["anyElement"]},
+  // Defined in HTML except for a which is also SVG
+  {attr: "relList", sup: ["a", "area", "link"]},
+  // Defined in HTML
+  // {attr: "htmlFor", sup: ["output"]},
+  // {attr: "sandbox", sup: ["iframe"]},
+  // {attr: "sizes", sup: ["link"]}
+];
+var namespaces = [
+  "http://www.w3.org/1999/xhtml",
+  "http://www.w3.org/2000/svg",
+  "http://www.w3.org/1998/Math/MathML",
+  "http://example.com/",
+  ""
+];
+
+var elements = ["a", "area", "link", "iframe", "output", "td", "th"];
+function testAttr(pair, new_el){
+  return (pair.attr === "classList" ||
+          // (pair.attr === "relList" && new_el.localName === "a" &&
+          //  new_el.namespaceURI === "http://www.w3.org/2000/svg") ||
+          (new_el.namespaceURI === "http://www.w3.org/1999/xhtml" &&
+           pair.sup.indexOf(new_el.localName) != -1));
+}
+
+pairs.forEach(function(pair) {
+  namespaces.forEach(function(ns) {
+    elements.forEach(function(el) {
+      var new_el = document.createElementNS(ns, el);
+      if (testAttr(pair, new_el)) {
+        test(function() {
+          assert_class_string(new_el[pair.attr], "DOMTokenList");
+        }, new_el.localName + "." + pair.attr + " in " + new_el.namespaceURI + " namespace should be DOMTokenList.");
+      }
+      else {
+        test(function() {
+          assert_equals(new_el[pair.attr], undefined);
+       }, new_el.localName + "." + pair.attr + " in " + new_el.namespaceURI + " namespace should be undefined.");
+      }
+    });
+  });
+});
+
+</script>


### PR DESCRIPTION
`<link>` elements have a limited set of tokens. In our case, only `stylesheet` is supported for now.

I've added a dont-upstream version of a test which checks all DOMTokenList-based properties, with the ones we don't yet support disabled.