### PR TITLE
Fix and run tests on Node.js v11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - 8
+  - 10
+  - stable
 sudo: false
 
 git:
@@ -59,7 +60,7 @@ matrix:
             - libpango1.0-dev
             - libgif-dev
             - build-essential
-    - node_js: 10
+    - node_js: stable
       env: TEST_SUITE=node-canvas
       script: "export CXX=g++-4.8 && yarn add canvas && yarn test --retries 1"
       addons:

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -187,7 +187,7 @@ describe("API: JSDOM class's methods", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const script = new vm.Script("while(true) {}");
 
-      assert.throws(() => dom.runVMScript(script, { timeout: 50 }), "Script execution timed out.");
+      assert.throws(() => dom.runVMScript(script, { timeout: 50 }), /Script execution timed out(?: after 50ms|\.)/);
     });
   });
 

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -13,10 +13,12 @@ const validReasons = new Set([
   "timeout",
   "flaky",
   "mutates-globals",
-  "needs-node10"
+  "needs-node10",
+  "needs-node11"
 ]);
 
 const hasNode10 = Number(process.versions.node.split(".")[0]) >= 10;
+const hasNode11 = Number(process.versions.node.split(".")[0]) >= 11;
 
 const manifestFilename = path.resolve(__dirname, "wpt-manifest.json");
 const manifest = readManifest(manifestFilename);
@@ -52,7 +54,8 @@ describe("web-platform-tests", () => {
           const reason = matchingPattern && toRunDoc[matchingPattern][0];
           const shouldSkip = ["fail-slow", "timeout", "flaky", "mutates-globals"].includes(reason);
           const expectFail = (reason === "fail") ||
-                             (reason === "needs-node10" && !hasNode10);
+                             (reason === "needs-node10" && !hasNode10) ||
+                             (reason === "needs-node11" && !hasNode11);
 
           if (matchingPattern && shouldSkip) {
             specify.skip(`[${reason}] ${testFile}`);

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -862,7 +862,7 @@ unload-a-document/*: [timeout, Requires window.open]
 
 DIR: webstorage
 
-event_no_duplicates.html: [fail, weird microtask/task timing, https://github.com/jsdom/jsdom/pull/2279#issuecomment-408319938]
+event_no_duplicates.html: [needs-node11, Earlier Node.js timers did not match browser behaviour, https://github.com/nodejs/node/pull/22842]
 idlharness.window.html: [fail, Depends on fetch]
 storage_local_window_open.html: [timeout, Depends on window.open()]
 storage_session_window_noopener.html: [fail, Depends on BroadcastChannel]


### PR DESCRIPTION
On Node.js v11, one test began to fail due to a changed error message. Under the assumption that testing for the specific kind of error will be helpful in the future, I've replaced it with a regex that matches both versions.

In addition, one test which had a timing issue - `event_no_duplicates.html` - started passing. Quite likely due to the changes in https://github.com/nodejs/node/pull/22842 which brings Node.js timers closer to browser behaviour. 🎉

I'm not sure if we want to start testing in v11 yet, so I've not changed `.travis.yml`.