### PR TITLE
Disable two recently added <link> tests

### DIFF
--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -436,6 +436,8 @@ link-load-error-events.html: [fail, We don't fire error events]
 link-load-error-events.https.html: [fail, We don't fire error events]
 link-rel-attribute.html: [fail, CSS computed style computation]
 link-style-error-01.html: [fail, We don't fire error events]
+link-style-error-limited-quirks.html: [fail, We don't fire error events]
+link-style-error-quirks.html: [fail, We don't fire error events]
 
 ---
 


### PR DESCRIPTION
Resolves a conflict where the roll in https://github.com/jsdom/jsdom/pull/2380 added two failing <link> tests that didn't get disabled in https://github.com/jsdom/jsdom/pull/2405 since they were merged at the same time.