### PR TITLE
Set default HTMLMediaElement duration to NaN

### DIFF
--- a/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
@@ -28,7 +28,7 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
     this.currentSrc = "";
     this.buffered = getTimeRangeDummy();
     this.seeking = false;
-    this.duration = 0;
+    this.duration = NaN;
     this.paused = true;
     this.played = getTimeRangeDummy();
     this.seekable = getTimeRangeDummy();

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -453,6 +453,12 @@ style_type_change.html: [fail, Spec mismatches tests https://github.com/whatwg/h
 
 ---
 
+DIR: html/semantics/embedded-content/media-elements/offsets-into-the-media-resource
+
+currentTime.html: [timeout, Loading metadata is not implemented]
+
+---
+
 DIR: html/semantics/forms/attributes-common-to-form-controls
 
 dirname-ltr.html: [timeout, Unknown]


### PR DESCRIPTION
This is tested in https://github.com/web-platform-tests/wpt/blob/master/html/semantics/embedded-content/media-elements/offsets-into-the-media-resource/duration.html.

Fixes https://github.com/jsdom/jsdom/issues/2357.