### PR TITLE
Fixes #1579 JSDOM throws error for nonexistent file uri

### DIFF
--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -160,30 +160,21 @@ function createClient(xhr) {
 
     const client = new EventEmitter();
 
-    let readableStream;
+    const readableStream = fs.createReadStream(filePath, { encoding: null });
 
-    if (fs.existsSync(filePath)) {
-      readableStream = fs.createReadStream(filePath, { encoding: null });
+    readableStream.on("data", chunk => {
+      response.emit("data", chunk);
+      client.emit("data", chunk);
+    });
 
-      readableStream.on("data", chunk => {
-        response.emit("data", chunk);
-        client.emit("data", chunk);
-      });
+    readableStream.on("end", () => {
+      response.emit("end");
+      client.emit("end");
+    });
 
-      readableStream.on("end", () => {
-        response.emit("end");
-        client.emit("end");
-      });
-
-      readableStream.on("error", err => {
-        response.emit("error", err);
-        client.emit("error", err);
-      });
-    } else {
-      process.nextTick(() => {
-        client.emit("error", "File '" + filePath + "' does not exist");
-      });
-    }
+    readableStream.on("error", err => {
+      client.emit("error", err);
+    });
 
     client.abort = function () {
       readableStream.destroy();

--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -164,25 +164,26 @@ function createClient(xhr) {
 
     if (fs.existsSync(filePath)) {
       readableStream = fs.createReadStream(filePath, { encoding: null });
+
+      readableStream.on("data", chunk => {
+        response.emit("data", chunk);
+        client.emit("data", chunk);
+      });
+
+      readableStream.on("end", () => {
+        response.emit("end");
+        client.emit("end");
+      });
+
+      readableStream.on("error", err => {
+        response.emit("error", err);
+        client.emit("error", err);
+      });
     } else {
-      response.emit("error", "File '" + filePath + "' does not exist");
-      client.emit("error", "File '" + filePath + "' does not exist");
+      process.nextTick(() =>  {
+        client.emit("error", "File '" + filePath + "' does not exist");
+      });
     }
-
-    readableStream.on("data", chunk => {
-      response.emit("data", chunk);
-      client.emit("data", chunk);
-    });
-
-    readableStream.on("end", () => {
-      response.emit("end");
-      client.emit("end");
-    });
-
-    readableStream.on("error", err => {
-      response.emit("error", err);
-      client.emit("error", err);
-    });
 
     client.abort = function () {
       readableStream.destroy();

--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -160,7 +160,14 @@ function createClient(xhr) {
 
     const client = new EventEmitter();
 
-    const readableStream = fs.createReadStream(filePath, { encoding: null });
+    let readableStream;
+
+    if (fs.existsSync(filePath)) {
+      readableStream = fs.createReadStream(filePath, { encoding: null });
+    } else {
+      response.emit("error", "File '" + filePath + "' does not exist");
+      client.emit("error", "File '" + filePath + "' does not exist");
+    }
 
     readableStream.on("data", chunk => {
       response.emit("data", chunk);

--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -58,7 +58,7 @@ function dispatchError(xhr) {
 
   if (xhr._ownerDocument) {
     const error = new Error(errMessage);
-    error.type = "XMLHttpRequest";
+    error.type = "XMLHttpRequest"; // TODO this should become "resource loading" when XHR goes through resource loader
 
     xhr._ownerDocument._defaultView._virtualConsole.emit("jsdomError", error);
   }

--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -180,7 +180,7 @@ function createClient(xhr) {
         client.emit("error", err);
       });
     } else {
-      process.nextTick(() =>  {
+      process.nextTick(() => {
         client.emit("error", "File '" + filePath + "' does not exist");
       });
     }

--- a/test/api/resources.js
+++ b/test/api/resources.js
@@ -307,7 +307,7 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
         return assertError(element);
       });
 
-      it("should fire an error event downloading via XHR", { slow: 500 }, () => {
+      it("should fire an load event downloading via XHR", { slow: 500 }, () => {
         const url = resourceServer404();
         const virtualConsole = ignoreResourceLoadingErrorsVC();
         const { window } = new JSDOM(``, { resources: "usable", virtualConsole, url });
@@ -317,7 +317,7 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
         xhr.open("GET", url);
         xhr.send();
 
-        return assertError(xhr);
+        return assertLoaded(xhr);
       });
     });
 
@@ -391,7 +391,7 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
         return assertError(element);
       });
 
-      it("should fire an error event downloading via XHR", { slow: 500 }, () => {
+      it("should fire a load event downloading via XHR", { slow: 500 }, () => {
         const url = resourceServer503();
         const virtualConsole = ignoreResourceLoadingErrorsVC();
         const { window } = new JSDOM(``, { resources: "usable", virtualConsole, url });
@@ -401,7 +401,7 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
         xhr.open("GET", url);
         xhr.send();
 
-        return assertError(xhr);
+        return assertLoaded(xhr);
       });
     });
 
@@ -923,7 +923,7 @@ function ignoreResourceLoadingErrorsVC() {
   const vc = new VirtualConsole();
   vc.sendTo(console, { omitJSDOMErrors: true });
   vc.on("jsdomError", err => {
-    if (err.type !== "resource loading") {
+    if (err.type !== "resource loading" && err.type !== "XMLHttpRequest") {
       // eslint-disable-next-line no-console
       console.error(err.stack, err.detail);
     }

--- a/test/api/resources.js
+++ b/test/api/resources.js
@@ -306,6 +306,19 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
 
         return assertError(element);
       });
+
+      it("should fire an error event downloading a file via file uri", () => {
+        const { window } = new JSDOM(``, { url: "file:///" });
+
+        const xhr = new window.XMLHttpRequest();
+        setUpLoadingAsserts(xhr);
+        xhr.open("GET", "file:///nonexisting.txt");
+        xhr.send();
+
+        return assertError(xhr).then(() => {
+          assert.isTrue(xhr.errorFired);
+        });
+      });
     });
 
     describe("resources returns 503", () => {

--- a/test/api/resources.js
+++ b/test/api/resources.js
@@ -237,7 +237,7 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
       });
     });
 
-    describe("resources returns 404", () => {
+    describe("resource returns 404", () => {
       it(
         "should fire an error event downloading images if and only if canvas is installed",
         { slow: 500 },
@@ -307,21 +307,21 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
         return assertError(element);
       });
 
-      it("should fire an error event downloading a file via file uri", () => {
-        const { window } = new JSDOM(``, { url: "file:///" });
+      it("should fire an error event downloading via XHR", { slow: 500 }, () => {
+        const url = resourceServer404();
+        const virtualConsole = ignoreResourceLoadingErrorsVC();
+        const { window } = new JSDOM(``, { resources: "usable", virtualConsole, url });
 
         const xhr = new window.XMLHttpRequest();
         setUpLoadingAsserts(xhr);
-        xhr.open("GET", "file:///nonexisting.txt");
+        xhr.open("GET", url);
         xhr.send();
 
-        return assertError(xhr).then(() => {
-          assert.isTrue(xhr.errorFired);
-        });
+        return assertError(xhr);
       });
     });
 
-    describe("resources returns 503", () => {
+    describe("resource returns 503", () => {
       it(
         "should fire an error event downloading images if and only if canvas is installed",
         { slow: 500 },
@@ -389,6 +389,99 @@ describe("API: resource loading configuration", { skipIfBrowser: true }, () => {
         dom.window.document.body.appendChild(element);
 
         return assertError(element);
+      });
+
+      it("should fire an error event downloading via XHR", { slow: 500 }, () => {
+        const url = resourceServer503();
+        const virtualConsole = ignoreResourceLoadingErrorsVC();
+        const { window } = new JSDOM(``, { resources: "usable", virtualConsole, url });
+
+        const xhr = new window.XMLHttpRequest();
+        setUpLoadingAsserts(xhr);
+        xhr.open("GET", url);
+        xhr.send();
+
+        return assertError(xhr);
+      });
+    });
+
+    describe("resource is a nonexistant file: URL", () => {
+      const url = "file:///nonexistant-asdf-1234.txt"; // hope nobody has a file named this on their system
+
+      it(
+        "should fire an error event downloading images if and only if canvas is installed",
+        { slow: 500 },
+        () => {
+          const dom = new JSDOM(``, { resources: "usable", virtualConsole: ignoreResourceLoadingErrorsVC() });
+
+          const element = dom.window.document.createElement("img");
+          setUpLoadingAsserts(element);
+          element.src = url;
+          dom.window.document.body.appendChild(element);
+
+          return canvas ? assertError(element) : assertNotLoaded(element);
+        }
+      );
+
+      it("should fire an error event downloading stylesheets", { slow: 500 }, () => {
+        const virtualConsole = ignoreResourceLoadingErrorsVC();
+        const dom = new JSDOM(``, { resources: "usable", virtualConsole });
+
+        const element = dom.window.document.createElement("link");
+        setUpLoadingAsserts(element);
+        element.rel = "stylesheet";
+        element.href = url;
+        dom.window.document.body.appendChild(element);
+
+        return assertError(element);
+      });
+
+      it("should fire an error event downloading scripts", { slow: 500 }, () => {
+        const virtualConsole = ignoreResourceLoadingErrorsVC();
+        const dom = new JSDOM(``, { resources: "usable", runScripts: "dangerously", virtualConsole });
+
+        const element = dom.window.document.createElement("script");
+        setUpLoadingAsserts(element);
+        element.src = url;
+        dom.window.document.body.appendChild(element);
+
+        return assertError(element);
+      });
+
+      it("should fire an error event downloading iframes", { slow: 500 }, () => {
+        const virtualConsole = ignoreResourceLoadingErrorsVC();
+        const dom = new JSDOM(``, { resources: "usable", virtualConsole });
+
+        const element = dom.window.document.createElement("iframe");
+        setUpLoadingAsserts(element);
+        element.src = url;
+        dom.window.document.body.appendChild(element);
+
+        return assertError(element);
+      });
+
+      it("should fire an error event downloading frames", { slow: 500 }, () => {
+        const virtualConsole = ignoreResourceLoadingErrorsVC();
+        const dom = new JSDOM(`<frameset></frameset>`, { resources: "usable", virtualConsole });
+
+        const element = dom.window.document.createElement("frame");
+        setUpLoadingAsserts(element);
+        element.src = url;
+        dom.window.document.body.appendChild(element);
+
+        return assertError(element);
+      });
+
+      it("should fire an error event downloading via XHR", { slow: 500 }, () => {
+        const virtualConsole = ignoreResourceLoadingErrorsVC();
+        const { window } = new JSDOM(``, { resources: "usable", virtualConsole, url });
+
+        const xhr = new window.XMLHttpRequest();
+        setUpLoadingAsserts(xhr);
+        xhr.open("GET", url);
+        xhr.send();
+
+        return assertError(xhr);
       });
     });
 


### PR DESCRIPTION
Handle nonexistent file uris similar to urls instead of throwing an exception that is not caught anywhere and causes test frameworks to fail.

Details can be found in #1579 