### PR TITLE
Improve the performance of parsing text

### DIFF
--- a/benchmark/html/index.js
+++ b/benchmark/html/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  parsing: require("./parsing")
+};

--- a/benchmark/html/parsing.js
+++ b/benchmark/html/parsing.js
@@ -1,0 +1,12 @@
+"use strict";
+const suite = require("../document-suite");
+
+// Measures the time spent parsing and creating a large text node
+// https://github.com/jsdom/jsdom/pull/2419
+
+exports.text = suite(document => {
+  document.body.innerHTML = `
+  <p>
+    ${"Some methods have unexpected implications for performance. ".repeat(5000)}
+  </p>`;
+});

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -2,7 +2,8 @@
 
 module.exports = {
   jsdom: require("./jsdom"),
-  dom: require("./dom")
+  dom: require("./dom"),
+  html: require("./html")
 };
 
 require("./prepare-suites")("", module.exports);

--- a/lib/jsdom/living/nodes/CharacterData-impl.js
+++ b/lib/jsdom/living/nodes/CharacterData-impl.js
@@ -33,10 +33,10 @@ class CharacterDataImpl extends NodeImpl {
     }
 
     if (offset + count > length) {
-      return this._data.substring(offset);
+      return this._data.slice(offset);
     }
 
-    return this._data.substring(offset, offset + count);
+    return this._data.slice(offset, offset + count);
   }
 
   appendData(data) {
@@ -62,8 +62,8 @@ class CharacterDataImpl extends NodeImpl {
       count = length - offset;
     }
 
-    const start = this._data.substring(0, offset);
-    const end = this._data.substring(offset + count);
+    const start = this._data.slice(0, offset);
+    const end = this._data.slice(offset + count);
 
     this._data = start + data + end;
 


### PR DESCRIPTION
While testing various solutions for the performance regression described in https://github.com/jsdom/jsdom/issues/2350 and https://github.com/jsdom/jsdom/issues/2416, I came across this optimisation.

As it's parsing, parse5 feeds us a new chunk of text when it encounters a whitespace character in the current text node, which we insert into the existing text through CharacterData's `replaceData()` method with the help of `String.prototype.substring()`.

It turns out that despite being very similar in purpose, using `String.prototype.slice()` repeatedly can be significantly faster than `String.prototype.substring()` in V8 under certain conditions. The difference really adds up in the test cases supplied in https://github.com/jsdom/jsdom/issues/2350 which goes from ~3000ms to ~500ms and https://github.com/jsdom/jsdom/issues/2416 which goes from ~43000ms to ~230ms on my computer.

After the first use, their initial times are very close at an average of 0.004ms. However, the time it takes to use `substring()` again seems to increase slightly with the length of the string, eventually leading to an average of several milliseconds. The timing of `slice()` in the same place on the other hand has even improved at this point and averages 0.001ms.

The impact of this change is particularly noticeable for large inline `<style>` or `<script>` elements, since these are more likely to contain a single uninterrupted text node than other elements.

This resolves https://github.com/jsdom/jsdom/issues/2350 and https://github.com/jsdom/jsdom/issues/2416.