### PR TITLE
Fix Node.isConnected in the context of a Shadow Tree

### DIFF
--- a/lib/jsdom/living/helpers/traversal.js
+++ b/lib/jsdom/living/helpers/traversal.js
@@ -1,6 +1,5 @@
 "use strict";
 const { domSymbolTree } = require("./internal-constants");
-const { DOCUMENT_NODE } = require("../node-type");
 const { HTML_NS } = require("./namespaces");
 
 // All these operate on and return impls, not wrappers!
@@ -14,16 +13,6 @@ exports.closest = (e, localName) => {
   }
 
   return null;
-};
-
-exports.isConnected = node => {
-  while (node) {
-    if (node.nodeType === DOCUMENT_NODE) {
-      return true;
-    }
-    node = domSymbolTree.parent(node);
-  }
-  return false;
 };
 
 exports.childrenByHTMLLocalName = (parent, localName) => {

--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -63,7 +63,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   _doSubmit() {
-    if (!this._isConnected()) {
+    if (!this.isConnected) {
       return;
     }
     const ev = this._ownerDocument.createEvent("HTMLEvents");

--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
-const { isConnected, descendantsByHTMLLocalNames } = require("../helpers/traversal");
+const { descendantsByHTMLLocalNames } = require("../helpers/traversal");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const HTMLCollection = require("../generated/HTMLCollection");
 const notImplemented = require("../../browser/not-implemented");
@@ -63,7 +63,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   _doSubmit() {
-    if (!isConnected(this)) {
+    if (!this._isConnected()) {
       return;
     }
     const ev = this._ownerDocument.createEvent("HTMLEvents");

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -146,13 +146,15 @@ class NodeImpl extends EventTargetImpl {
     return domSymbolTree.firstChild(this);
   }
 
+  // https://dom.spec.whatwg.org/#dom-node-isconnected
   get isConnected() {
-    for (const ancestor of domSymbolTree.ancestorsIterator(this)) {
-      if (ancestor.nodeType === NODE_TYPE.DOCUMENT_NODE) {
-        return true;
-      }
-    }
-    return false;
+    return this._isConnected();
+  }
+
+  // https://dom.spec.whatwg.org/#connected
+  _isConnected() {
+    const root = shadowIncludingRoot(this);
+    return root && root.nodeType === NODE_TYPE.DOCUMENT_NODE;
   }
 
   get ownerDocument() {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -146,13 +146,9 @@ class NodeImpl extends EventTargetImpl {
     return domSymbolTree.firstChild(this);
   }
 
+  // https://dom.spec.whatwg.org/#connected
   // https://dom.spec.whatwg.org/#dom-node-isconnected
   get isConnected() {
-    return this._isConnected();
-  }
-
-  // https://dom.spec.whatwg.org/#connected
-  _isConnected() {
     const root = shadowIncludingRoot(this);
     return root && root.nodeType === NODE_TYPE.DOCUMENT_NODE;
   }

--- a/test/web-platform-tests/to-upstream/dom/nodes/Node-isConnected-shadow-dom.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Node-isConnected-shadow-dom.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test of Node.isConnected in a shadow tree</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#connected">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+function testIsConnected(mode) {
+  test(() => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const root = host.attachShadow({ mode });
+
+    const node = document.createElement("div");
+    root.appendChild(node);
+
+    assert_true(node.isConnected);
+  }, `Node.isConnected in a ${mode} shadow tree`);
+}
+
+for (const mode of ["closed", "open"]) {
+  testIsConnected(mode);
+}
+</script>


### PR DESCRIPTION
Fix issue described: https://github.com/jsdom/jsdom/issues/1030#issuecomment-437083550

This is an issue that slipped in with the introduction of the [shadow DOM](https://github.com/jsdom/jsdom/pull/2347) the isConnected returns `false` if the element is part of a shadow tree. A new WPT-test needs to be added here, since no test is checking this behavior.
