### PR TITLE
Remove fix for empty DOCTYPE fields

### DIFF
--- a/lib/jsdom/browser/parse5-adapter-parsing.js
+++ b/lib/jsdom/browser/parse5-adapter-parsing.js
@@ -53,17 +53,6 @@ module.exports = class JSDOMParse5Adapter {
   }
 
   setDocumentType(document, name, publicId, systemId) {
-    // parse5 sometimes gives us these as null.
-    if (name === null) {
-      name = "";
-    }
-    if (publicId === null) {
-      publicId = "";
-    }
-    if (systemId === null) {
-      systemId = "";
-    }
-
     const documentType = DocumentType.createImpl([], { name, publicId, systemId, ownerDocument: this._documentImpl });
     document.appendChild(documentType);
   }


### PR DESCRIPTION
The underlying issue was fixed in parse5 v5.0.0: https://github.com/inikulin/parse5/commit/3ed7908e5777ee7ae12347829b589e869bdb671b