### PR TITLE
Removes pn dependency

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,6 @@
 "use strict";
 const path = require("path");
-const fs = require("pn/fs");
+const fs = require("fs");
 const vm = require("vm");
 const toughCookie = require("tough-cookie");
 const sniffHTMLEncoding = require("html-encoding-sniffer");
@@ -151,8 +151,12 @@ class JSDOM {
     return Promise.resolve().then(() => {
       options = normalizeFromFileOptions(filename, options);
 
-      return fs.readFile(filename).then(buffer => {
-        return new JSDOM(buffer, options);
+      return new Promise((resolve, reject) => {
+        fs.readFile(filename, (err, buffer) => {
+          if (err) return reject(err);
+
+          return resolve(new JSDOM(buffer, options));
+        });
       });
     });
   }

--- a/lib/api.js
+++ b/lib/api.js
@@ -153,7 +153,9 @@ class JSDOM {
 
       return new Promise((resolve, reject) => {
         fs.readFile(filename, (err, buffer) => {
-          if (err) return reject(err);
+          if (err) {
+            return reject(err);
+          }
 
           return resolve(new JSDOM(buffer, options));
         });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "html-encoding-sniffer": "^1.0.2",
     "nwsapi": "^2.0.9",
     "parse5": "5.1.0",
-    "pn": "^1.1.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "saxes": "^3.1.3",

--- a/test/api/encoding.js
+++ b/test/api/encoding.js
@@ -1,5 +1,5 @@
 "use strict";
-const fs = require("pn/fs");
+const fs = require("fs");
 const path = require("path");
 const { assert } = require("chai");
 const { describe, it, before, after } = require("mocha-sugar-free");
@@ -12,7 +12,13 @@ function fixturePath(fixture) {
 }
 
 function readFixture(fixture) {
-  return fs.readFile(fixturePath(fixture));
+  return new Promise((resolve, reject) => {
+    fs.readFile(fixturePath(fixture), (err, buffer) => {
+      if (err) return reject(err);
+
+      return resolve(buffer);
+    });
+  });
 }
 
 const factories = {

--- a/test/api/encoding.js
+++ b/test/api/encoding.js
@@ -14,7 +14,9 @@ function fixturePath(fixture) {
 function readFixture(fixture) {
   return new Promise((resolve, reject) => {
     fs.readFile(fixturePath(fixture), (err, buffer) => {
-      if (err) return reject(err);
+      if (err) {
+        return reject(err);
+      }
 
       return resolve(buffer);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3712,11 +3712,6 @@ pluralize@^7.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
-pn@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
-  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
-
 portfinder@^1.0.17:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.17.tgz#a8a1691143e46c4735edefcf4fbcccedad26456a"


### PR DESCRIPTION
Since `pn` has deprecation warning and `jsdom` uses to little from it to really need the module, we're better off just removing it.