### PR TITLE
Support SVGTitleElement, fix document.title and <title>'s text property

### DIFF
--- a/lib/jsdom/living/helpers/traversal.js
+++ b/lib/jsdom/living/helpers/traversal.js
@@ -4,9 +4,9 @@ const { HTML_NS } = require("./namespaces");
 
 // All these operate on and return impls, not wrappers!
 
-exports.closest = (e, localName) => {
+exports.closest = (e, localName, namespace = HTML_NS) => {
   while (e) {
-    if (e.localName === localName && e.namespaceURI === HTML_NS) {
+    if (e.localName === localName && e.namespaceURI === namespace) {
       return e;
     }
     e = domSymbolTree.parent(e);
@@ -15,56 +15,56 @@ exports.closest = (e, localName) => {
   return null;
 };
 
-exports.childrenByHTMLLocalName = (parent, localName) => {
+exports.childrenByLocalName = (parent, localName, namespace = HTML_NS) => {
   return domSymbolTree.childrenToArray(parent, { filter(node) {
-    return node._localName === localName && node._namespaceURI === HTML_NS;
+    return node._localName === localName && node._namespaceURI === namespace;
   } });
 };
 
-exports.descendantsByHTMLLocalName = (parent, localName) => {
+exports.descendantsByLocalName = (parent, localName, namespace = HTML_NS) => {
   return domSymbolTree.treeToArray(parent, { filter(node) {
-    return node._localName === localName && node._namespaceURI === HTML_NS && node !== parent;
+    return node._localName === localName && node._namespaceURI === namespace && node !== parent;
   } });
 };
 
-exports.childrenByHTMLLocalNames = (parent, localNamesSet) => {
+exports.childrenByLocalNames = (parent, localNamesSet, namespace = HTML_NS) => {
   return domSymbolTree.childrenToArray(parent, { filter(node) {
-    return localNamesSet.has(node._localName) && node._namespaceURI === HTML_NS;
+    return localNamesSet.has(node._localName) && node._namespaceURI === namespace;
   } });
 };
 
-exports.descendantsByHTMLLocalNames = (parent, localNamesSet) => {
+exports.descendantsByLocalNames = (parent, localNamesSet, namespace = HTML_NS) => {
   return domSymbolTree.treeToArray(parent, { filter(node) {
     return localNamesSet.has(node._localName) &&
-           node._namespaceURI === HTML_NS &&
+           node._namespaceURI === namespace &&
            node !== parent;
   } });
 };
 
-exports.firstChildWithHTMLLocalName = (parent, localName) => {
+exports.firstChildWithLocalName = (parent, localName, namespace = HTML_NS) => {
   const iterator = domSymbolTree.childrenIterator(parent);
   for (const child of iterator) {
-    if (child._localName === localName && child._namespaceURI === HTML_NS) {
+    if (child._localName === localName && child._namespaceURI === namespace) {
       return child;
     }
   }
   return null;
 };
 
-exports.firstChildWithHTMLLocalNames = (parent, localNamesSet) => {
+exports.firstChildWithLocalNames = (parent, localNamesSet, namespace = HTML_NS) => {
   const iterator = domSymbolTree.childrenIterator(parent);
   for (const child of iterator) {
-    if (localNamesSet.has(child._localName) && child._namespaceURI === HTML_NS) {
+    if (localNamesSet.has(child._localName) && child._namespaceURI === namespace) {
       return child;
     }
   }
   return null;
 };
 
-exports.firstDescendantWithHTMLLocalName = (parent, localName) => {
+exports.firstDescendantWithLocalName = (parent, localName, namespace = HTML_NS) => {
   const iterator = domSymbolTree.treeIterator(parent);
   for (const descendant of iterator) {
-    if (descendant._localName === localName && descendant._namespaceURI === HTML_NS) {
+    if (descendant._localName === localName && descendant._namespaceURI === namespace) {
       return descendant;
     }
   }

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -13,6 +13,7 @@ const { StyleSheetList } = require("../../level2/style");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const eventAccessors = require("../helpers/create-event-accessor");
 const { asciiLowercase, stripAndCollapseASCIIWhitespace } = require("../helpers/strings");
+const { childTextContent } = require("../helpers/text");
 const { HTML_NS, SVG_NS } = require("../helpers/namespaces");
 const DOMException = require("domexception");
 const HTMLToDOM = require("../../browser/htmltodom");
@@ -543,33 +544,59 @@ class DocumentImpl extends NodeImpl {
   }
 
   get title() {
-    // TODO SVG
+    const { documentElement } = this;
+    let value = "";
 
-    const titleElement = firstDescendantWithLocalName(this, "title");
-    let value = titleElement !== null ? titleElement.textContent : "";
+    if (documentElement && documentElement._localName === "svg") {
+      const svgTitleElement = firstChildWithLocalName(documentElement, "title", SVG_NS);
+
+      if (svgTitleElement) {
+        value = childTextContent(svgTitleElement);
+      }
+    } else {
+      const titleElement = firstDescendantWithLocalName(this, "title");
+
+      if (titleElement) {
+        value = childTextContent(titleElement);
+      }
+    }
+
     value = stripAndCollapseASCIIWhitespace(value);
+
     return value;
   }
 
-  set title(val) {
-    // TODO SVG
-
-    const titleElement = firstDescendantWithLocalName(this, "title");
-    const headElement = this.head;
-
-    if (titleElement === null && headElement === null) {
-      return;
-    }
-
+  set title(value) {
+    const { documentElement } = this;
     let element;
-    if (titleElement !== null) {
-      element = titleElement;
-    } else {
-      element = this.createElement("title");
-      headElement._append(element);
-    }
 
-    element.textContent = val;
+    if (documentElement && documentElement._localName === "svg") {
+      element = firstChildWithLocalName(documentElement, "title", SVG_NS);
+
+      if (!element) {
+        element = this.createElementNS(SVG_NS, "title");
+
+        this._insert(element, documentElement.firstChild);
+      }
+
+      element.textContent = value;
+    } else if (documentElement && documentElement._namespaceURI === HTML_NS) {
+      const titleElement = firstDescendantWithLocalName(this, "title");
+      const headElement = this.head;
+
+      if (titleElement === null && headElement === null) {
+        return;
+      }
+
+      if (titleElement !== null) {
+        element = titleElement;
+      } else {
+        element = this.createElement("title");
+        headElement._append(element);
+      }
+
+      element.textContent = value;
+    }
   }
 
   get dir() {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -6,7 +6,7 @@ const NodeImpl = require("./Node-impl").implementation;
 const idlUtils = require("../generated/utils");
 const NODE_TYPE = require("../node-type");
 const { mixin, memoizeQuery } = require("../../utils");
-const { firstChildWithHTMLLocalName, firstChildWithHTMLLocalNames, firstDescendantWithHTMLLocalName } =
+const { firstChildWithLocalName, firstChildWithLocalNames, firstDescendantWithLocalName } =
   require("../helpers/traversal");
 const whatwgURL = require("whatwg-url");
 const { StyleSheetList } = require("../../level2/style");
@@ -545,7 +545,7 @@ class DocumentImpl extends NodeImpl {
   get title() {
     // TODO SVG
 
-    const titleElement = firstDescendantWithHTMLLocalName(this, "title");
+    const titleElement = firstDescendantWithLocalName(this, "title");
     let value = titleElement !== null ? titleElement.textContent : "";
     value = stripAndCollapseASCIIWhitespace(value);
     return value;
@@ -554,7 +554,7 @@ class DocumentImpl extends NodeImpl {
   set title(val) {
     // TODO SVG
 
-    const titleElement = firstDescendantWithHTMLLocalName(this, "title");
+    const titleElement = firstDescendantWithLocalName(this, "title");
     const headElement = this.head;
 
     if (titleElement === null && headElement === null) {
@@ -582,7 +582,7 @@ class DocumentImpl extends NodeImpl {
   }
 
   get head() {
-    return this.documentElement ? firstChildWithHTMLLocalName(this.documentElement, "head") : null;
+    return this.documentElement ? firstChildWithLocalName(this.documentElement, "head") : null;
   }
 
   get body() {
@@ -592,7 +592,7 @@ class DocumentImpl extends NodeImpl {
       return null;
     }
 
-    return firstChildWithHTMLLocalNames(this.documentElement, new Set(["body", "frameset"]));
+    return firstChildWithLocalNames(this.documentElement, new Set(["body", "frameset"]));
   }
 
   set body(value) {

--- a/lib/jsdom/living/nodes/HTMLFieldSetElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFieldSetElement-impl.js
@@ -5,7 +5,7 @@ const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
 const { formOwner } = require("../helpers/form-controls");
 const { mixin } = require("../../utils");
-const { descendantsByHTMLLocalNames } = require("../helpers/traversal");
+const { descendantsByLocalNames } = require("../helpers/traversal");
 
 const listedElements = new Set(["button", "fieldset", "input", "object", "output", "select", "textarea"]);
 
@@ -13,7 +13,7 @@ class HTMLFieldSetElementImpl extends HTMLElementImpl {
   get elements() {
     return HTMLCollection.createImpl([], {
       element: this,
-      query: () => descendantsByHTMLLocalNames(this, listedElements)
+      query: () => descendantsByLocalNames(this, listedElements)
     });
   }
 

--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
-const { descendantsByHTMLLocalNames } = require("../helpers/traversal");
+const { descendantsByLocalNames } = require("../helpers/traversal");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const HTMLCollection = require("../generated/HTMLCollection");
 const notImplemented = require("../../browser/not-implemented");
@@ -54,7 +54,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   get elements() {
     return HTMLCollection.createImpl([], {
       element: this,
-      query: () => descendantsByHTMLLocalNames(this, listedElements)
+      query: () => descendantsByLocalNames(this, listedElements)
     });
   }
 

--- a/lib/jsdom/living/nodes/HTMLTableElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableElement-impl.js
@@ -3,7 +3,7 @@ const DOMException = require("domexception");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const { HTML_NS } = require("../helpers/namespaces");
 const { domSymbolTree } = require("../helpers/internal-constants");
-const { firstChildWithHTMLLocalName, childrenByHTMLLocalName } = require("../helpers/traversal");
+const { firstChildWithLocalName, childrenByLocalName } = require("../helpers/traversal");
 const HTMLCollection = require("../generated/HTMLCollection");
 const NODE_TYPE = require("../node-type");
 
@@ -24,7 +24,7 @@ function tHeadInsertionPoint(table) {
 
 class HTMLTableElementImpl extends HTMLElementImpl {
   get caption() {
-    return firstChildWithHTMLLocalName(this, "caption");
+    return firstChildWithLocalName(this, "caption");
   }
 
   set caption(value) {
@@ -41,7 +41,7 @@ class HTMLTableElementImpl extends HTMLElementImpl {
   }
 
   get tHead() {
-    return firstChildWithHTMLLocalName(this, "thead");
+    return firstChildWithLocalName(this, "thead");
   }
 
   set tHead(value) {
@@ -61,7 +61,7 @@ class HTMLTableElementImpl extends HTMLElementImpl {
   }
 
   get tFoot() {
-    return firstChildWithHTMLLocalName(this, "tfoot");
+    return firstChildWithLocalName(this, "tfoot");
   }
 
   set tFoot(value) {
@@ -95,11 +95,11 @@ class HTMLTableElementImpl extends HTMLElementImpl {
             }
 
             if (child._localName === "thead") {
-              headerRows.push(...childrenByHTMLLocalName(child, "tr"));
+              headerRows.push(...childrenByLocalName(child, "tr"));
             } else if (child._localName === "tbody") {
-              bodyRows.push(...childrenByHTMLLocalName(child, "tr"));
+              bodyRows.push(...childrenByLocalName(child, "tr"));
             } else if (child._localName === "tfoot") {
-              footerRows.push(...childrenByHTMLLocalName(child, "tr"));
+              footerRows.push(...childrenByLocalName(child, "tr"));
             } else if (child._localName === "tr") {
               bodyRows.push(child);
             }
@@ -116,7 +116,7 @@ class HTMLTableElementImpl extends HTMLElementImpl {
     if (!this._tBodies) {
       this._tBodies = HTMLCollection.createImpl([], {
         element: this,
-        query: () => childrenByHTMLLocalName(this, "tbody")
+        query: () => childrenByLocalName(this, "tbody")
       });
     }
     return this._tBodies;
@@ -125,7 +125,7 @@ class HTMLTableElementImpl extends HTMLElementImpl {
   createTBody() {
     const el = this._ownerDocument.createElement("TBODY");
 
-    const tbodies = childrenByHTMLLocalName(this, "tbody");
+    const tbodies = childrenByLocalName(this, "tbody");
     const insertionPoint = tbodies[tbodies.length - 1];
 
     if (insertionPoint) {

--- a/lib/jsdom/living/nodes/HTMLTableRowElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableRowElement-impl.js
@@ -4,7 +4,7 @@ const DOMException = require("domexception");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const HTMLCollection = require("../generated/HTMLCollection");
 const { HTML_NS } = require("../helpers/namespaces");
-const { childrenByHTMLLocalNames } = require("../helpers/traversal");
+const { childrenByLocalNames } = require("../helpers/traversal");
 const { domSymbolTree } = require("../helpers/internal-constants");
 
 const cellLocalNames = new Set(["td", "th"]);
@@ -14,7 +14,7 @@ class HTMLTableRowElementImpl extends HTMLElementImpl {
     if (!this._cells) {
       this._cells = HTMLCollection.createImpl([], {
         element: this,
-        query: () => childrenByHTMLLocalNames(this, cellLocalNames)
+        query: () => childrenByLocalNames(this, cellLocalNames)
       });
     }
     return this._cells;

--- a/lib/jsdom/living/nodes/HTMLTableSectionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableSectionElement-impl.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
-const { childrenByHTMLLocalName } = require("../helpers/traversal");
+const { childrenByLocalName } = require("../helpers/traversal");
 const HTMLCollection = require("../generated/HTMLCollection");
 const DOMException = require("domexception");
 
@@ -10,7 +10,7 @@ class HTMLTableSectionElementImpl extends HTMLElementImpl {
     if (!this._rows) {
       this._rows = HTMLCollection.createImpl([], {
         element: this,
-        query: () => childrenByHTMLLocalName(this, "tr")
+        query: () => childrenByLocalName(this, "tr")
       });
     }
     return this._rows;

--- a/lib/jsdom/living/nodes/HTMLTitleElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTitleElement-impl.js
@@ -1,15 +1,15 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+const { childTextContent } = require("../helpers/text");
 
 class HTMLTitleElementImpl extends HTMLElementImpl {
   get text() {
-    // TODO this is quite incorrect
-    return this.innerHTML;
+    return childTextContent(this);
   }
 
-  set text(s) {
-    this.textContent = s;
+  set text(value) {
+    this.textContent = value;
   }
 }
 

--- a/lib/jsdom/living/nodes/SVGTitleElement-impl.js
+++ b/lib/jsdom/living/nodes/SVGTitleElement-impl.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const SVGElementImpl = require("./SVGElement-impl").implementation;
+
+class SVGTitleElementImpl extends SVGElementImpl { }
+
+module.exports = {
+  implementation: SVGTitleElementImpl
+};

--- a/lib/jsdom/living/nodes/SVGTitleElement.webidl
+++ b/lib/jsdom/living/nodes/SVGTitleElement.webidl
@@ -1,0 +1,4 @@
+// https://svgwg.org/svg2-draft/struct.html#InterfaceSVGTitleElement
+[Exposed=Window]
+interface SVGTitleElement : SVGElement {
+};

--- a/lib/jsdom/living/register-elements.js
+++ b/lib/jsdom/living/register-elements.js
@@ -355,6 +355,10 @@ const mappings = {
     SVGSVGElement: {
       file: require("./generated/SVGSVGElement.js"),
       tags: ["svg"]
+    },
+    SVGTitleElement: {
+      file: require("./generated/SVGTitleElement.js"),
+      tags: ["title"]
     }
   }
 };

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -454,6 +454,10 @@ style_type_change.html: [fail, Spec mismatches tests https://github.com/whatwg/h
 
 ---
 
+DIR: html/semantics/document-metadata/the-title-element
+
+---
+
 DIR: html/semantics/embedded-content/media-elements/offsets-into-the-media-resource
 
 currentTime.html: [timeout, Loading metadata is not implemented]

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -339,8 +339,6 @@ DIR: html/dom/documents/dom-tree-accessors
 Document.currentScript.html: [timeout, Unknown]
 document.getElementsByName/document.getElementsByName-namespace-xhtml.xhtml: [fail, Needs MathML and SVG support]
 document.getElementsByName/document.getElementsByName-namespace.html: [fail, Needs MathML and SVG support]
-document.title-09.html: [fail, Requires SVG support]
-document.title-not-in-html-svg.html: [fail, Unknown]
 nameditem-01.html: [fail, Unknown]
 nameditem-02.html: [fail, Unknown]
 nameditem-04.html: [fail, Unknown]


### PR DESCRIPTION
This adds `SVGTitleElement` and support for using it in `document.title` according to the spec at https://html.spec.whatwg.org/multipage/dom.html#document.title.

As part of this I've renamed and added an optional namespace argument for the traversal helpers to make matching elements outside the HTML namespace easier.

I've also fixed the getter of `<title>`s `text` property to correctly use the child text content instead of innerHTML: https://html.spec.whatwg.org/multipage/semantics.html#dom-title-text

This currently includes the changes from https://github.com/jsdom/jsdom/pull/2434 since one of the new tests, `document.title-not-in-html-svg.html`, is fixed through this.