### PR TITLE
Fix style property on <a> and <area> elements

### DIFF
--- a/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
@@ -28,7 +28,9 @@ class HTMLAnchorElementImpl extends HTMLElementImpl {
     this.textContent = v;
   }
 
-  _attrModified(name) {
+  _attrModified(name, value, oldValue) {
+    super._attrModified(name, value, oldValue);
+
     if (name === "rel" && this._relList !== undefined) {
       this._relList.attrModified();
     }

--- a/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
@@ -21,7 +21,9 @@ class HTMLAreaElementImpl extends HTMLElementImpl {
     return this._relList;
   }
 
-  _attrModified(name) {
+  _attrModified(name, value, oldValue) {
+    super._attrModified(name, value, oldValue);
+
     if (name === "rel" && this._relList !== undefined) {
       this._relList.attrModified();
     }


### PR DESCRIPTION
Fixes a regression introduced through https://github.com/jsdom/jsdom/commit/064527e2cbc003debe0bc826f893519f1ceb64bc where the `style` property on `<a>` and `<area>` elements would not get updated correctly. Given how specific the issue is, I'm not sure if adding a test would make sense here.

Resolves https://github.com/jsdom/jsdom/issues/2437.