### PR TITLE
Run child text content change steps when inserting CDATASection node

### DIFF
--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -673,7 +673,8 @@ class NodeImpl extends EventTargetImpl {
 
       this._modified();
 
-      if (node.nodeType === NODE_TYPE.TEXT_NODE) {
+      if (node.nodeType === NODE_TYPE.TEXT_NODE ||
+          node.nodeType === NODE_TYPE.CDATA_SECTION_NODE) {
         this._childTextContentChangeSteps();
       }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -562,7 +562,6 @@ DIR: html/semantics/forms/the-textarea-element
 
 textarea-maxlength.html: [fail, Unknown]
 textarea-minlength.html: [fail, Unknown]
-value-defaultValue-textContent-xhtml.xhtml: [fail, Unknown]
 
 ---
 


### PR DESCRIPTION
While the specification only references Text nodes [in this step](https://dom.spec.whatwg.org/#ref-for-concept-node-text-change-ext), it seems like the inclusion of CDATASection nodes is implied unless the term [exclusive Text node](https://dom.spec.whatwg.org/#exclusive-text-node) is used.

If that's the case there are several places in the code where we should be matching against both Text nodes and CDATASection nodes instead of just the former, though only this location seems to be covered by our current tests. I'll create an issue for the remaining cases if this is correct.