### PR TITLE
Correctly reflect <ol>'s start property with default value

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOListElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOListElement-impl.js
@@ -2,7 +2,20 @@
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
-class HTMLOListElementImpl extends HTMLElementImpl { }
+class HTMLOListElementImpl extends HTMLElementImpl {
+  get start() {
+    const value = parseInt(this.getAttribute("start"));
+
+    if (!isNaN(value)) {
+      return value;
+    }
+
+    return 1;
+  }
+  set start(value) {
+    this.setAttribute("start", value);
+  }
+}
 
 module.exports = {
   implementation: HTMLOListElementImpl

--- a/lib/jsdom/living/nodes/HTMLOListElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLOListElement.webidl
@@ -2,7 +2,7 @@
  HTMLConstructor]
 interface HTMLOListElement : HTMLElement {
   [CEReactions, Reflect] attribute boolean reversed;
-  [CEReactions, Reflect] attribute long start; // TODO this needs the default value
+  [CEReactions] attribute long start;
   [CEReactions, Reflect] attribute DOMString type;
 
   // also has obsolete members

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -578,10 +578,6 @@ textarea-minlength.html: [fail, Unknown]
 
 DIR: html/semantics/grouping-content
 
-the-ol-element/grouping-ol.html: [fail, Unknown]
-the-ol-element/ol.start-reflection-1.html: [fail, Unknown]
-the-ol-element/ol.start-reflection-2.html: [fail, Unknown]
-
 ---
 
 DIR: html/semantics/interactive-elements/the-details-element


### PR DESCRIPTION
This adds the default value for `<ol>`'s start property which is returned if the content attribute does not contain a valid integer.