### PR TITLE
Custom validity messages and htmlFor property for <output>

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const DOMTokenList = require("../generated/DOMTokenList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
@@ -16,6 +17,14 @@ class HTMLOutputElementImpl extends HTMLElementImpl {
     this._customValidityErrorMessage = "";
   }
 
+  _attrModified(name, value, oldValue) {
+    super._attrModified(name, value, oldValue);
+
+    if (name === "for" && this._htmlFor !== undefined) {
+      this._htmlFor.attrModified();
+    }
+  }
+
   _barredFromConstraintValidationSpecialization() {
     return true;
   }
@@ -27,6 +36,16 @@ class HTMLOutputElementImpl extends HTMLElementImpl {
 
     this._defaultValue = "";
     this._valueMode = "default";
+  }
+
+  get htmlFor() {
+    if (this._htmlFor === undefined) {
+      this._htmlFor = DOMTokenList.createImpl([], {
+        element: this,
+        attributeLocalName: "for"
+      });
+    }
+    return this._htmlFor;
   }
 
   get type() {

--- a/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
@@ -12,6 +12,8 @@ class HTMLOutputElementImpl extends HTMLElementImpl {
     this._labels = null;
     this._defaultValue = "";
     this._valueMode = "default";
+
+    this._customValidityErrorMessage = "";
   }
 
   _barredFromConstraintValidationSpecialization() {

--- a/lib/jsdom/living/nodes/HTMLOutputElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLOutputElement.webidl
@@ -1,7 +1,7 @@
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLOutputElement : HTMLElement {
-//  [SameObject, PutForwards=value] readonly attribute DOMTokenList htmlFor;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList htmlFor;
   readonly attribute HTMLFormElement? form;
   [CEReactions, Reflect] attribute DOMString name;
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -561,8 +561,6 @@ option-value.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-i
 
 DIR: html/semantics/forms/the-output-element
 
-output-setcustomvalidity.html: [fail, Not implemented]
-
 ---
 
 DIR: html/semantics/forms/the-select-element

--- a/test/web-platform-tests/to-upstream/dom/lists/DOMTokenList-coverage-for-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/dom/lists/DOMTokenList-coverage-for-attributes-dont-upstream.html
@@ -13,7 +13,7 @@ var pairs = [
   // Defined in HTML except for a which is also SVG
   {attr: "relList", sup: ["a", "area", "link"]},
   // Defined in HTML
-  // {attr: "htmlFor", sup: ["output"]},
+  {attr: "htmlFor", sup: ["output"]},
   // {attr: "sandbox", sup: ["iframe"]},
   // {attr: "sizes", sup: ["link"]}
 ];


### PR DESCRIPTION
Two remaining fixes/features for `<output>`, which we should fully support now. I made sure to include the `super()`-call this time 😄