### PR TITLE
Bug fixed, charset is undefined when call FileReader.readAsDataURL for type text blob.

### DIFF
--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -103,15 +103,9 @@ class FileReaderImpl extends EventTargetImpl {
             break;
           }
           case "dataURL": {
-            // Spec seems very unclear here; see https://github.com/whatwg/fetch/issues/665#issuecomment-362930079.
-            let dataUrl = "data:";
-            const contentType = MIMEType.parse(file.type);
-            if (contentType) {
-              dataUrl += contentType.toString();
-            }
-            dataUrl += ";base64,";
-            dataUrl += data.toString("base64");
-            this.result = dataUrl;
+            // Spec seems very unclear here; see https://github.com/w3c/FileAPI/issues/104.
+            const contentType = MIMEType.parse(file.type) || "application/octet-stream";
+            this.result = `data:${contentType};base64,${data.toString("base64")}`;
             break;
           }
           case "text": {

--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -2,7 +2,6 @@
 
 const whatwgEncoding = require("whatwg-encoding");
 const MIMEType = require("whatwg-mimetype");
-const querystring = require("querystring");
 const DOMException = require("domexception");
 const EventTargetImpl = require("../events/EventTarget-impl").implementation;
 const ProgressEvent = require("../generated/ProgressEvent");

--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -112,7 +112,7 @@ class FileReaderImpl extends EventTargetImpl {
                 whatwgEncoding.labelToName(contentType.parameters.get("charset")) || "UTF-8";
               const decoded = whatwgEncoding.decode(data, fallbackEncoding);
 
-              contentType.parameters.set("charset", encoding);
+              contentType.parameters.set("charset", contentType.parameters.get("charset") || fallbackEncoding);
               dataUrl += contentType.toString();
               dataUrl += ",";
               dataUrl += querystring.escape(decoded);

--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -107,22 +107,11 @@ class FileReaderImpl extends EventTargetImpl {
             // Spec seems very unclear here; see https://github.com/whatwg/fetch/issues/665#issuecomment-362930079.
             let dataUrl = "data:";
             const contentType = MIMEType.parse(file.type);
-            if (contentType && contentType.type === "text") {
-              const fallbackEncoding = whatwgEncoding.getBOMEncoding(data) ||
-                whatwgEncoding.labelToName(contentType.parameters.get("charset")) || "UTF-8";
-              const decoded = whatwgEncoding.decode(data, fallbackEncoding);
-
-              contentType.parameters.set("charset", contentType.parameters.get("charset") || fallbackEncoding);
+            if (contentType) {
               dataUrl += contentType.toString();
-              dataUrl += ",";
-              dataUrl += querystring.escape(decoded);
-            } else {
-              if (contentType) {
-                dataUrl += contentType.toString();
-              }
-              dataUrl += ";base64,";
-              dataUrl += data.toString("base64");
             }
+            dataUrl += ";base64,";
+            dataUrl += data.toString("base64");
             this.result = dataUrl;
             break;
           }

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -15,7 +15,9 @@ file/send-file-form*: [fail, DataTransfer not implemented]
 filelist-section/filelist.html: [fail, function is not instanceof Function]
 historical.https.html: [fail, Needs Service Worker implementation]
 idlharness.html: [fail, URL.createObjectURL not implemented]
-reading-data-section/**: [timeout, Unknown]
+reading-data-section/FileReader-multiple-reads.html: [timeout, Unknown; spews tons of zeros on the screen when failing]
+reading-data-section/filereader_events.any.html: [fail, Unknown]
+reading-data-section/filereader_result.html: [fail, Unknown]
 url/**: [timeout, blob URLs not implemented]
 
 ---

--- a/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
+++ b/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
@@ -16,7 +16,7 @@ async_test(t => {
   const fileReader = new FileReader();
   fileReader.addEventListener('load', () => {
      // false, result is 'data:text/plain;charset=undefined,Hello'
-     assert_equals(fileReader.result, 'data:text/plain;charset=utf-8;base64,SGVsbG8=', "Initial blob should have a size of 4");
+     assert_equals(fileReader.result, 'data:text/plain;charset=utf-8;base64,SGVsbG8=', "should FileReader result property is dataURL.");
      t.done();
   });
 

--- a/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
+++ b/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<meta charset=utf-8>
-<title>File's lastModified</title>
-<link rel=help href="https://w3c.github.io/FileAPI/#dfn-lastModified">
+<meta charset="utf-8">
+<title>FileAPI Test: FileReader.readAsDataURL</title>
+<link rel="help" href="https://w3c.github.io/FileAPI/#readAsDataURL">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
@@ -15,15 +15,13 @@ async_test(t => {
 
   const fileReader = new FileReader();
   fileReader.addEventListener("load", () => {
-    // false, result is 'data:text/plain;charset=undefined,Hello'
     assert_equals(
       fileReader.result,
-      "data:text/plain;charset=utf-8;base64,SGVsbG8=",
-      "should FileReader result property is dataURL."
+      "data:text/plain;charset=utf-8;base64,SGVsbG8="
     );
     t.done();
   });
 
   fileReader.readAsDataURL(blob);
-});
+}, "readAsDataURL result for Blob with specified MIME type including charset");
 </script>

--- a/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
+++ b/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
@@ -9,15 +9,19 @@
 "use strict";
 
 async_test(t => {
-  const blob = new Blob(['Hello'], {
-   type: 'text/plain;charset=utf-8',
+  const blob = new Blob(["Hello"], {
+    type: "text/plain;charset=utf-8"
   });
 
   const fileReader = new FileReader();
-  fileReader.addEventListener('load', () => {
-     // false, result is 'data:text/plain;charset=undefined,Hello'
-     assert_equals(fileReader.result, 'data:text/plain;charset=utf-8;base64,SGVsbG8=', "should FileReader result property is dataURL.");
-     t.done();
+  fileReader.addEventListener("load", () => {
+    // false, result is 'data:text/plain;charset=undefined,Hello'
+    assert_equals(
+      fileReader.result,
+      "data:text/plain;charset=utf-8;base64,SGVsbG8=",
+      "should FileReader result property is dataURL."
+    );
+    t.done();
   });
 
   fileReader.readAsDataURL(blob);

--- a/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
+++ b/test/web-platform-tests/to-upstream/FileAPI/reading-data-section/filereader_readAsDataURL.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>File's lastModified</title>
+<link rel=help href="https://w3c.github.io/FileAPI/#dfn-lastModified">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+async_test(t => {
+  const blob = new Blob(['Hello'], {
+   type: 'text/plain;charset=utf-8',
+  });
+
+  const fileReader = new FileReader();
+  fileReader.addEventListener('load', () => {
+     // false, result is 'data:text/plain;charset=undefined,Hello'
+     assert_equals(fileReader.result, 'data:text/plain;charset=utf-8;base64,SGVsbG8=', "Initial blob should have a size of 4");
+     t.done();
+  });
+
+  fileReader.readAsDataURL(blob);
+});
+</script>


### PR DESCRIPTION
Bug fixed, charset is undefined when call FileReader.readAsDataURL for type text blob.

I write code following.

```javascript
const blob = new jsdom.window.Blob(['Hello'], {
   type: 'text/plain;charset=utf-8',
});

const fileReader = new jsdom.window.FileReader();
fileReader.addEventListener('load', () => {
   // false, result is 'data:text/plain;charset=undefined,Hello'
   console.log(fileReader.result === 'data:text/plain;charset=utf-8,Hello'); 
});

fileReader.readAsDataURL(blob);
```

I think result is setting blob type charset.
But, result charset is undefined.