### PR TITLE
Support setting custom validity messages on <fieldset>

### DIFF
--- a/lib/jsdom/living/nodes/HTMLFieldSetElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFieldSetElement-impl.js
@@ -10,6 +10,12 @@ const { descendantsByLocalNames } = require("../helpers/traversal");
 const listedElements = new Set(["button", "fieldset", "input", "object", "output", "select", "textarea"]);
 
 class HTMLFieldSetElementImpl extends HTMLElementImpl {
+  constructor(args, privateData) {
+    super(args, privateData);
+
+    this._customValidityErrorMessage = "";
+  }
+
   get elements() {
     return HTMLCollection.createImpl([], {
       element: this,

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -497,7 +497,6 @@ DIR: html/semantics/forms/the-fieldset-element
 
 HTMLFieldSetElement.html: [fail, Depends on HTMLFormElement's named properties; has dont-upstream version]
 disabled-001.html: [fail, Unknown]
-fieldset-setcustomvalidity.html: [fail, Not implemented]
 
 ---
 


### PR DESCRIPTION
The same fix as `<output>` got in https://github.com/jsdom/jsdom/commit/ce8e8c6837c426a6add4cb6c68b47cc667e38856.