### PR TITLE
Add support for links to javascript: urls and fragments

### DIFF
--- a/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
@@ -9,6 +9,12 @@ class HTMLAnchorElementImpl extends HTMLElementImpl {
     super(args, privateData);
 
     this._htmlHyperlinkElementUtilsSetup();
+
+    this._hasActivationBehavior = true;
+  }
+
+  _activationBehavior() {
+    this._followAHyperlink();
   }
 
   get relList() {

--- a/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
@@ -9,6 +9,12 @@ class HTMLAreaElementImpl extends HTMLElementImpl {
     super(args, privateData);
 
     this._htmlHyperlinkElementUtilsSetup();
+
+    this._hasActivationBehavior = true;
+  }
+
+  _activationBehavior() {
+    this._followAHyperlink();
   }
 
   get relList() {

--- a/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js
+++ b/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js
@@ -1,10 +1,85 @@
 "use strict";
 const whatwgURL = require("whatwg-url");
 const { parseURLToResultingURLRecord } = require("../helpers/document-base-url");
+const { asciiCaseInsensitiveMatch } = require("../helpers/strings");
+const { navigate } = require("../window/navigation");
 
 exports.implementation = class HTMLHyperlinkElementUtilsImpl {
   _htmlHyperlinkElementUtilsSetup() {
     this.url = null;
+  }
+
+  // https://html.spec.whatwg.org/multipage/links.html#cannot-navigate
+  _cannotNavigate() {
+    // TODO: Correctly check if the document is fully active
+    return this._localName !== "a" && !this.isConnected;
+  }
+
+  // https://html.spec.whatwg.org/multipage/semantics.html#get-an-element's-target
+  _getAnElementsTarget() {
+    if (this.hasAttribute("target")) {
+      return this.getAttribute("target");
+    }
+
+    const baseEl = this._ownerDocument.querySelector("base[target]");
+
+    if (baseEl) {
+      return baseEl.getAttribute("target");
+    }
+
+    return "";
+  }
+
+  // https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
+  _chooseABrowsingContext(name, current) {
+    let chosen = null;
+
+    if (name === "" || asciiCaseInsensitiveMatch(name, "_self")) {
+      chosen = current;
+    } else if (asciiCaseInsensitiveMatch(name, "_parent")) {
+      chosen = current.parent;
+    } else if (asciiCaseInsensitiveMatch(name, "_top")) {
+      chosen = current.top;
+    } else if (!asciiCaseInsensitiveMatch(name, "_blank")) {
+      // https://github.com/whatwg/html/issues/1440
+    }
+
+    // TODO: Create new browsing context, handle noopener
+
+    return chosen;
+  }
+
+  // https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2
+  _followAHyperlink() {
+    if (this._cannotNavigate()) {
+      return;
+    }
+
+    const source = this._ownerDocument._defaultView;
+    let targetAttributeValue = "";
+
+    if (this._localName === "a" || this._localName === "area") {
+      targetAttributeValue = this._getAnElementsTarget();
+    }
+
+    const noopener = this.relList.contains("noreferrer") || this.relList.contains("noopener");
+
+    const target = this._chooseABrowsingContext(targetAttributeValue, source, noopener);
+
+    if (target === null) {
+      return;
+    }
+
+    const url = parseURLToResultingURLRecord(this.href, this._ownerDocument);
+
+    if (url === null) {
+      return;
+    }
+
+    // TODO: Handle hyperlink suffix and referrerpolicy
+    setTimeout(() => {
+      navigate(target, url, {});
+    }, 0);
   }
 
   toString() {

--- a/lib/jsdom/living/window/navigation.js
+++ b/lib/jsdom/living/window/navigation.js
@@ -23,6 +23,9 @@ exports.navigate = (window, newURL, flags) => {
   // This is NOT a spec-compliant implementation of navigation in any way. It implements a few selective steps that
   // are nice for jsdom users, regarding hash changes and JavaScript URLs. Full navigation support is being worked on
   // and will likely require some additional hooks to be implemented.
+  if (!window._document) {
+    return;
+  }
 
   const document = idlUtils.implForWrapper(window._document);
   const currentURL = document._URL;
@@ -41,7 +44,7 @@ exports.navigate = (window, newURL, flags) => {
 
   // NOT IMPLEMENTED: if resource is a response...
   if (newURL.scheme === "javascript") {
-    window.setTimeout(() => {
+    setTimeout(() => {
       const result = exports.evaluateJavaScriptURL(window, newURL);
       if (typeof result === "string") {
         notImplemented("string results from 'javascript:' URLs", window);

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -216,7 +216,6 @@ child_navigates_parent_submit.html: [timeout, Unknown]
 empty_fragment.html: [fail, Unknown]
 javascript-url-abort/javascript-url-abort-return-value-string.tentative.html: [timeout, Unknown]
 javascript-url-abort/javascript-url-abort-return-value-undefined.tentative.html: [timeout, Unknown]
-javascript-url-global-scope.html: [timeout, Unknown]
 navigation-unload-form-submit.html: [timeout, Unknown]
 navigation-unload-same-origin-fragment.html: [timeout, Unknown]
 refresh/navigate.window.html: [timeout, Unknown]
@@ -613,7 +612,7 @@ DIR: html/semantics/interactive-elements/the-summary-element
 
 DIR: html/semantics/links
 
-following-hyperlinks/activation-behavior.window.html: [fail, Unknown]
+following-hyperlinks/activation-behavior.window.html: [fail, We don't support navigating to new locations]
 links-created-by-a-and-area-elements/htmlanchorelement_noopener.html: [timeout, Unknown]
 links-created-by-a-and-area-elements/target_blank_implicit_noopener.tentative.html: [fail, Depends on BroadcastChannel]
 
@@ -644,7 +643,6 @@ execution-timing/025.html: [fail, Unknown]
 execution-timing/027.html: [fail, Unknown]
 execution-timing/028.html: [fail, Unknown]
 execution-timing/029.html: [fail, Unknown]
-execution-timing/030.html: [fail, Unknown]
 execution-timing/031.html: [fail, Unknown]
 execution-timing/036.html: [fail, Unknown]
 execution-timing/037.html: [fail, Unknown]


### PR DESCRIPTION
A work in progress. The code related to choosing a browsing context and `noreferrer`/`noopener` may be removed as it does not have an effect on the resulting window or document at this point.