### PR TITLE
Set readyState to "complete" for documents created by DOMParser

### DIFF
--- a/lib/jsdom/living/domparsing/DOMParser-impl.js
+++ b/lib/jsdom/living/domparsing/DOMParser-impl.js
@@ -38,6 +38,7 @@ function createScriptingDisabledDocument(parsingMode, contentType, string) {
       parsingMode,
       encoding: "UTF-8",
       contentType,
+      readyState: "complete",
       scriptingDisabled: true
       // TODO: somehow set URL to active document's URL
     }

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -183,7 +183,7 @@ class DocumentImpl extends NodeImpl {
     this._queue = new ResourceQueue({ asyncQueue: this._asyncQueue, paused: false });
     this._deferQueue = new ResourceQueue({ paused: true });
     this._requestManager = new RequestManager();
-    this.readyState = "loading";
+    this.readyState = privateData.options.readyState || "loading";
 
     this._lastFocusedElement = null;
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -163,7 +163,6 @@ createContextualFragment.html: [fail, Unknown]
 innerhtml-05.xhtml: [fail, Unknown]
 insert_adjacent_html-xhtml.xhtml: [fail, Unknown]
 interfaces.any.html: [fail, Depends on fetch]
-xmldomparser.html: [fail, The status returned is "loading", instead of "complete"]
 
 ---
 


### PR DESCRIPTION
The [specification](https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness) is not particularly detailed regarding this, but it appears like documents created by DOMParser should have the "complete" `readyState` immediately, with three out of four browsers agreeing: https://wpt.fyi/results/domparsing/xmldomparser.html

This actually changed (regressed) in https://github.com/jsdom/jsdom/pull/2279.