### PR TITLE
Update note for screenLeft and screenTop properties on window

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -591,14 +591,11 @@ function Window(options) {
     pageXOffset: 0,
     pageYOffset: 0,
     screenX: 0,
+    screenLeft: 0,
     screenY: 0,
+    screenTop: 0,
     scrollX: 0,
     scrollY: 0,
-
-    // Not in spec, but likely to be added eventually:
-    // https://github.com/w3c/csswg-drafts/issues/1091
-    screenLeft: 0,
-    screenTop: 0,
 
     alert: notImplementedMethod("window.alert"),
     blur: notImplementedMethod("window.blur"),


### PR DESCRIPTION
These were indeed added to the spec in https://github.com/w3c/csswg-drafts/pull/2669.