### PR TITLE
Support DOCTYPEs with a custom name

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -185,6 +185,7 @@ function appendChild(parent, child) {
 const HTML5_DOCTYPE = /<!doctype html>/i;
 const PUBLIC_DOCTYPE = /<!doctype\s+([^\s]+)\s+public\s+"([^"]+)"\s+"([^"]+)"/i;
 const SYSTEM_DOCTYPE = /<!doctype\s+([^\s]+)\s+system\s+"([^"]+)"/i;
+const CUSTOM_NAME_DOCTYPE = /<!doctype\s+([^\s>]+)/i;
 
 function parseDocType(doc, html) {
   if (HTML5_DOCTYPE.test(html)) {
@@ -201,9 +202,8 @@ function parseDocType(doc, html) {
     return createDocumentTypeInternal(doc, systemPieces[1], "", systemPieces[2]);
   }
 
-  // Shouldn't get here (the parser shouldn't let us know about invalid doctypes), but our logic likely isn't
-  // real-world perfect, so let's fallback.
-  return createDocumentTypeInternal(doc, "html", "", "");
+  const namePiece = CUSTOM_NAME_DOCTYPE.exec(html)[1] || "html";
+  return createDocumentTypeInternal(doc, namePiece, "", "");
 }
 
 function createDocumentTypeInternal(ownerDocument, name, publicId, systemId) {

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -156,7 +156,6 @@ DIR: domparsing
 
 DOMParser-parseFromString-html.html: [fail, needs to get "the active document's URL" which is not possible with one DOMParser shared across all windows]
 DOMParser-parseFromString-xml-doctype.html: [fail, Unknown]
-DOMParser-parseFromString-xml-internal-subset.html: [fail, Unknown]
 DOMParser-parseFromString-xml-parsererror.html: [fail, Unknown]
 DOMParser-parseFromString-xml.html: [fail, needs to get "the active document's URL" which is not possible with one DOMParser shared across all windows]
 createContextualFragment.html: [fail, Unknown]


### PR DESCRIPTION
The current code does not recognise custom names/root elements within short DOCTYPES (such as the case of `<!DOCTYPE foo>`), but it seems like non-`html` names are also expected to be initialized as the `name` property of DocumentType nodes.

I decided to keep the existing `HTML5_DOCTYPE` check first as a fast path and add a new regex for the presumably rare case of custom names.