### PR TITLE
Make getComputedStyle() throw for incorrect argument type

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -5,6 +5,7 @@ const { CSSStyleDeclaration } = require("cssstyle");
 const { Performance: RawPerformance } = require("w3c-hr-time");
 const notImplemented = require("./not-implemented");
 const { define, mixin } = require("../utils");
+const Element = require("../living/generated/Element");
 const EventTarget = require("../living/generated/EventTarget");
 const namedPropertiesWindow = require("../living/named-properties-window");
 const cssom = require("cssom");
@@ -32,14 +33,13 @@ const SessionHistory = require("../living/window/SessionHistory");
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
 
+const defaultStyleSheet = require("./default-stylesheet");
+let parsedDefaultStyleSheet;
+
 // NB: the require() must be after assigning `module.exports` because this require() is circular
 // TODO: this above note might not even be true anymore... figure out the cycle and document it, or clean up.
 module.exports = Window;
 const dom = require("../living");
-
-const cssSelectorSplitRE = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
-
-const defaultStyleSheet = cssom.parse(require("./default-stylesheet"));
 
 dom.Window = Window;
 
@@ -495,24 +495,31 @@ function Window(options) {
     WebSocketImpl.cleanUpWindow(this);
   };
 
-  this.getComputedStyle = function (node) {
-    const nodeImpl = idlUtils.implForWrapper(node);
-    const s = node.style;
-    const cs = new CSSStyleDeclaration();
-    const { forEach } = Array.prototype;
+  this.getComputedStyle = function (elt) {
+    elt = Element.convert(elt);
+
+    const declaration = new CSSStyleDeclaration();
+    const { forEach, indexOf } = Array.prototype;
+    const { style } = elt;
 
     function setPropertiesFromRule(rule) {
       if (!rule.selectorText) {
         return;
       }
 
-      const selectors = rule.selectorText.split(cssSelectorSplitRE);
+      const cssSelectorSplitRe = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
+      const selectors = rule.selectorText.split(cssSelectorSplitRe);
       let matched = false;
+
       for (const selectorText of selectors) {
-        if (selectorText !== "" && selectorText !== "," && !matched && matchesDontThrow(nodeImpl, selectorText)) {
+        if (selectorText !== "" && selectorText !== "," && !matched && matchesDontThrow(elt, selectorText)) {
           matched = true;
           forEach.call(rule.style, property => {
-            cs.setProperty(property, rule.style.getPropertyValue(property), rule.style.getPropertyPriority(property));
+            declaration.setProperty(
+              property,
+              rule.style.getPropertyValue(property),
+              rule.style.getPropertyPriority(property)
+            );
           });
         }
       }
@@ -521,7 +528,7 @@ function Window(options) {
     function readStylesFromStyleSheet(sheet) {
       forEach.call(sheet.cssRules, rule => {
         if (rule.media) {
-          if (Array.prototype.indexOf.call(rule.media, "screen") !== -1) {
+          if (indexOf.call(rule.media, "screen") !== -1) {
             forEach.call(rule.cssRules, setPropertiesFromRule);
           }
         } else {
@@ -530,14 +537,17 @@ function Window(options) {
       });
     }
 
-    readStylesFromStyleSheet(defaultStyleSheet);
-    forEach.call(node.ownerDocument.styleSheets, readStylesFromStyleSheet);
+    if (!parsedDefaultStyleSheet) {
+      parsedDefaultStyleSheet = cssom.parse(defaultStyleSheet);
+    }
+    readStylesFromStyleSheet(parsedDefaultStyleSheet);
+    forEach.call(elt.ownerDocument.styleSheets, readStylesFromStyleSheet);
 
-    forEach.call(s, property => {
-      cs.setProperty(property, s.getPropertyValue(property), s.getPropertyPriority(property));
+    forEach.call(style, property => {
+      declaration.setProperty(property, style.getPropertyValue(property), style.getPropertyPriority(property));
     });
 
-    return cs;
+    return declaration;
   };
 
   // The captureEvents() and releaseEvents() methods must do nothing


### PR DESCRIPTION
Fixes https://github.com/jsdom/jsdom/issues/2481 by throwing a TypeError if the argument is not an Element. I also took the opportunity to do a bit of clean up and change the default stylesheet to parse lazily which saves ~8ms during initialization for situations when `window.getComputedStyle()` never gets used.

These type-related bugs are likely already covered by the larger tests which we can't enable yet due to other reasons, so I don't think we need a new specific test case for this.