### PR TITLE
Fix bug when appending initially empty fragment to dom node

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -100,7 +100,7 @@ class JSDOM {
     }
   }
 
-  static fragment(string) {
+  static fragment(string = "") {
     if (!sharedFragmentDocument) {
       sharedFragmentDocument = (new JSDOM()).window.document;
     }

--- a/test/api/fragment.js
+++ b/test/api/fragment.js
@@ -59,13 +59,13 @@ describe("API: JSDOM.fragment()", () => {
     assert.notStrictEqual(frag.ownerDocument.defaultView.navigator.userAgent, "Mellblomenator/9000");
   });
 
-  it('should be possible to append to a dom node', () => {
+  it("should be possible to append to a dom node", () => {
     const frag = JSDOM.fragment();
-    const test = (new JSDOM()).window.document.createElement('div');
-    test.innerHTML = 'test';
+    const test = (new JSDOM()).window.document.createElement("div");
+    test.innerHTML = "test";
     frag.appendChild(test);
 
-    const res = (new JSDOM()).window.document.createElement('div');
+    const res = (new JSDOM()).window.document.createElement("div");
     res.appendChild(frag);
     assert.strictEqual(res.outerHTML, "<div><div>test</div></div>");
   });

--- a/test/api/fragment.js
+++ b/test/api/fragment.js
@@ -58,4 +58,15 @@ describe("API: JSDOM.fragment()", () => {
     assert.strictEqual(frag.ownerDocument.contentType, "text/html");
     assert.notStrictEqual(frag.ownerDocument.defaultView.navigator.userAgent, "Mellblomenator/9000");
   });
+
+  it('should be possible to append to a dom node', () => {
+    const frag = JSDOM.fragment();
+    const test = (new JSDOM()).window.document.createElement('div');
+    test.innerHTML = 'test';
+    frag.appendChild(test);
+
+    const res = (new JSDOM()).window.document.createElement('div');
+    res.appendChild(frag);
+    assert.strictEqual(res.outerHTML, "<div><div>test</div></div>");
+  });
 });

--- a/test/api/fragment.js
+++ b/test/api/fragment.js
@@ -59,14 +59,8 @@ describe("API: JSDOM.fragment()", () => {
     assert.notStrictEqual(frag.ownerDocument.defaultView.navigator.userAgent, "Mellblomenator/9000");
   });
 
-  it("should be possible to append to a dom node", () => {
+  it("should default to no nodes", () => {
     const frag = JSDOM.fragment();
-    const test = (new JSDOM()).window.document.createElement("div");
-    test.innerHTML = "test";
-    frag.appendChild(test);
-
-    const res = (new JSDOM()).window.document.createElement("div");
-    res.appendChild(frag);
-    assert.strictEqual(res.outerHTML, "<div><div>test</div></div>");
+    assert.strictEqual(frag.childNodes.length, 0);
   });
 });


### PR DESCRIPTION
I discovered a bug, which is triggered by the test I added (f13cb62)

The next commit fixes it. I am not sure if it is the right fix. The real problem might be a bit deeper, but I am not very familiar with jsdom.

The test output without the fix is

```
1) API: JSDOM.fragment() should be possible to append to a dom node:

      AssertionError: expected '<div>undefined<div>test</div></div>' to equal '<div><div>test</div></div>'
      + expected - actual

      -<div>undefined<div>test</div></div>
      +<div><div>test</div></div>

      at it (test/api/fragment.js:71:12)
      at $mochaNoSugar$runUserTestFunc (node_modules/mocha-sugar-free/lib/mocha-sugar-free.js:64:35)
      at Context.$mochaNoSugar (node_modules/mocha-sugar-free/lib/mocha-sugar-free.js:267:32)
```