### PR TITLE
Fix element.blur() on a focused element

### DIFF
--- a/lib/jsdom/living/helpers/focusing.js
+++ b/lib/jsdom/living/helpers/focusing.js
@@ -4,7 +4,7 @@ const FocusEvent = require("../generated/FocusEvent.js");
 const idlUtils = require("../generated/utils.js");
 const { isDisabled } = require("./form-controls.js");
 const { firstChildWithLocalName } = require("./traversal");
-const { fireAnEvent } = require("./events");
+const { createAnEvent } = require("./events");
 const { HTML_NS } = require("./namespaces");
 
 const focusableFormElements = new Set(["input", "select", "textarea", "button"]);
@@ -61,14 +61,16 @@ exports.fireFocusEventWithTargetAdjustment = (name, target, relatedTarget) => {
     return;
   }
 
-  if (target._defaultView) {
-    target = idlUtils.implForWrapper(target._defaultView);
-  }
-
-  fireAnEvent(name, target, FocusEvent, {
+  const event = createAnEvent(name, FocusEvent, {
     composed: true,
     relatedTarget,
     view: target._ownerDocument._defaultView,
     detail: 0
   });
+
+  if (target._defaultView) {
+    target = idlUtils.implForWrapper(target._defaultView);
+  }
+
+  target._dispatch(event);
 };

--- a/test/web-platform-tests/to-upstream/html/editing/focus/focus-management/focus-blur.html
+++ b/test/web-platform-tests/to-upstream/html/editing/focus/focus-management/focus-blur.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>element.focus() / element.blur()</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input>
+
+<script>
+"use strict";
+
+const input = document.querySelector("input");
+
+test(() => {
+  assert_false(input.matches(":focus"));
+
+  input.focus();
+  assert_true(input.matches(":focus"));
+
+  input.blur();
+  assert_false(input.matches(":focus"));
+}, "The focus() and blur() methods change the focus as expected");
+</script>


### PR DESCRIPTION
This regressed in https://github.com/jsdom/jsdom/pull/2463 as it changed the location where the event's `view` property was set.

Resolves https://github.com/jsdom/jsdom/issues/2499.