### PR TITLE
Fixed fragment code example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ For the very simplest of cases, you might not need a whole `JSDOM` instance with
 const frag = JSDOM.fragment(`<p>Hello</p><p><strong>Hi!</strong>`);
 
 frag.childNodes.length === 2;
-frag.querySelector("strong").textContent = "Why hello there!";
+frag.querySelector("strong").textContent === "Hi!";
 // etc.
 ```
 


### PR DESCRIPTION
I think the example somehow got out of sync. Otherwise it wouldn't be clear to me why the example should work this way.

Hope it helps.