### PR TITLE
Fix #2374

### DIFF
--- a/lib/jsdom/browser/resources/per-document-resource-loader.js
+++ b/lib/jsdom/browser/resources/per-document-resource-loader.js
@@ -14,6 +14,8 @@ module.exports = class PerDocumentResourceLoader {
   }
 
   fetch(url, { element, onLoad, onError }) {
+    if(this._resourceLoader === null) return null;
+    
     const request = this._resourceLoader.fetch(url, {
       cookieJar: this._document._cookieJar,
       element: idlUtils.wrapperForImpl(element),

--- a/lib/jsdom/browser/resources/per-document-resource-loader.js
+++ b/lib/jsdom/browser/resources/per-document-resource-loader.js
@@ -14,7 +14,9 @@ module.exports = class PerDocumentResourceLoader {
   }
 
   fetch(url, { element, onLoad, onError }) {
-    if(this._resourceLoader === null) return null;
+    if(this._resourceLoader === null){
+      return null;
+    }
     
     const request = this._resourceLoader.fetch(url, {
       cookieJar: this._document._cookieJar,


### PR DESCRIPTION
this._resourceLoader was being defaulted to null, yet no null check before using this._resourceLoader.fetch()