### PR TITLE
Implement PageTransitionEvent interface and pageshow event

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -7,6 +7,7 @@ const notImplemented = require("./not-implemented");
 const { define, mixin } = require("../utils");
 const Element = require("../living/generated/Element");
 const EventTarget = require("../living/generated/EventTarget");
+const PageTransitionEvent = require("../living/generated/PageTransitionEvent");
 const namedPropertiesWindow = require("../living/named-properties-window");
 const cssom = require("cssom");
 const postMessage = require("../living/post-message");
@@ -632,10 +633,15 @@ function Window(options) {
     }
 
     if (window.document.readyState === "complete") {
-      fireAnEvent("load", window);
+      fireAnEvent("load", window, undefined, {}, window.document);
     } else {
       window.document.addEventListener("load", () => {
-        fireAnEvent("load", window);
+        fireAnEvent("load", window, undefined, {}, window.document);
+
+        if (!idlUtils.implForWrapper(window._document)._pageShowingFlag) {
+          idlUtils.implForWrapper(window._document)._pageShowingFlag = true;
+          fireAnEvent("pageshow", window, PageTransitionEvent, { persisted: false }, window.document);
+        }
       });
     }
   });

--- a/lib/jsdom/living/events/PageTransitionEvent-impl.js
+++ b/lib/jsdom/living/events/PageTransitionEvent-impl.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const EventImpl = require("./Event-impl").implementation;
+
+const PageTransitionEventInit = require("../generated/PageTransitionEventInit");
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#pagetransitionevent
+class PageTransitionEventImpl extends EventImpl {
+  initPageTransitionEvent(type, bubbles, cancelable, persisted) {
+    if (this._dispatchFlag) {
+      return;
+    }
+
+    this.initEvent(type, bubbles, cancelable);
+    this.persisted = persisted;
+  }
+}
+PageTransitionEventImpl.defaultInit = PageTransitionEventInit.convert(undefined);
+
+exports.implementation = PageTransitionEventImpl;

--- a/lib/jsdom/living/events/PageTransitionEvent.webidl
+++ b/lib/jsdom/living/events/PageTransitionEvent.webidl
@@ -1,0 +1,9 @@
+[Exposed=Window,
+ Constructor(DOMString type, optional PageTransitionEventInit eventInitDict)]
+interface PageTransitionEvent : Event {
+  readonly attribute boolean persisted;
+};
+
+dictionary PageTransitionEventInit : EventInit {
+  boolean persisted = false;
+};

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -38,6 +38,7 @@ exports.UIEvent = require("./generated/UIEvent").interface;
 exports.MouseEvent = require("./generated/MouseEvent").interface;
 exports.KeyboardEvent = require("./generated/KeyboardEvent").interface;
 exports.TouchEvent = require("./generated/TouchEvent").interface;
+exports.PageTransitionEvent = require("./generated/PageTransitionEvent").interface;
 exports.ProgressEvent = require("./generated/ProgressEvent").interface;
 exports.StorageEvent = require("./generated/StorageEvent").interface;
 exports.CompositionEvent = require("./generated/CompositionEvent").interface;

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -140,6 +140,7 @@ class DocumentImpl extends NodeImpl {
     this._ids = Object.create(null);
     this._attached = true;
     this._currentScript = null;
+    this._pageShowingFlag = false;
     this._cookieJar = privateData.options.cookieJar;
     this._parseOptions = privateData.options.parseOptions;
     this._scriptingDisabled = privateData.options.scriptingDisabled;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -177,7 +177,6 @@ DIR: html/browsers/browsing-the-web/history-traversal
 browsing_context_name.html: [timeout, Unknown]
 browsing_context_name_cross_origin.html: [timeout, Unknown]
 browsing_context_name_cross_origin_2.html: [fail, window.name not implemented]
-events.html: [fail, PageTransitionEvent not defined]
 persisted-user-state-restoration/resume-timer-on-history-back.html: [timeout, Unknown]
 persisted-user-state-restoration/scroll-restoration-basic.html: [fail, Not implemented]
 persisted-user-state-restoration/scroll-restoration-fragment-scrolling-cross-origin.html: [fail, depends on requestAnimationFrame]
@@ -777,7 +776,6 @@ parsing-html-fragments/*: [timeout, Unknown]
 parsing/DOMContentLoaded-defer.html: [fail, Script execution timing]
 parsing/html-integration-point.html: [fail, Incorrect handling of encoded entity references inside <noframes> element]
 parsing/html5lib*: [timeout, Unknown]
-parsing/the-end.html: [fail-slow, Load event has wrong target]
 serializing-html-fragments/serializing.html: [fail, https://github.com/inikulin/parse5/pull/286 / https://github.com/whatwg/html/pull/4238]
 
 ---


### PR DESCRIPTION
Also sets the correct target for the load event - the document rather than window - through the legacy target override flag per https://html.spec.whatwg.org/multipage/parsing.html#the-end.