### PR TITLE
Verify that WPT directories still exist

### DIFF
--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -80,6 +80,10 @@ function checkToRun() {
       throw new Error(`DIR entries must not end with a slash: saw "${doc.DIR}"`);
     }
 
+    if (!fs.existsSync(path.resolve(__dirname, "tests", doc.DIR))) {
+      throw new Error(`The directory "${doc.DIR}" does not exist`);
+    }
+
     if (doc.DIR < lastDir) {
       throw new Error(`Bad lexicographical directory sorting in to-run.yaml: ${doc.DIR} should come before ${lastDir}`);
     }

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -826,10 +826,6 @@ DIR: html/webappapis/timers
 
 ---
 
-DIR: progress-events
-
----
-
 DIR: shadow-dom
 
 Document-prototype-currentScript.html: [timeout, Test not up to date next with updating wpt it should work]


### PR DESCRIPTION
This adds a pretest check to verify that the DIR entries in `to-run.yaml` still are current. The directories are sometimes moved or renamed between updates. I found that `progress-events` has been merged into `xhr` at this point.