### PR TITLE
fix(frame): get pretendToBeVisual opt from parent

### DIFF
--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -109,7 +109,8 @@ function loadFrame(frame, attaching) {
     pool: parentDoc._pool,
     encoding: parentDoc._encoding,
     runScripts: parentDoc._defaultView._runScripts,
-    commonForOrigin: parentDoc._defaultView._commonForOrigin
+    commonForOrigin: parentDoc._defaultView._commonForOrigin,
+    pretendToBeVisual: parentDoc._defaultView._pretendToBeVisual
   });
 
   const contentDoc = frame._contentDocument = idlUtils.implForWrapper(wnd._document);

--- a/test/api/options.js
+++ b/test/api/options.js
@@ -254,6 +254,17 @@ describe("API: constructor options", () => {
         assert.isUndefined(window.requestAnimationFrame);
         assert.isUndefined(window.cancelAnimationFrame);
       });
+
+      it("child frame document should not have rAF", () => {
+        const { window } = new JSDOM(`<body></body>`);
+        const frame = window.document.createElement("iframe");
+        window.document.body.appendChild(frame);
+
+        assert.isUndefined(window.requestAnimationFrame);
+        assert.isUndefined(window.cancelAnimationFrame);
+        assert.isUndefined(frame.contentWindow.requestAnimationFrame);
+        assert.isUndefined(frame.contentWindow.cancelAnimationFrame);
+      });
     });
 
     describe("set to true", () => {
@@ -270,8 +281,17 @@ describe("API: constructor options", () => {
         window.requestAnimationFrame(() => {
           context.done();
         });
-
         // Further functionality tests are in web platform tests
+      });
+
+      it("child frame document should have rAF", { async: true }, context => {
+        const { window } = new JSDOM(`<body></body>`, { pretendToBeVisual: true });
+        const frame = window.document.createElement("iframe");
+        window.document.body.appendChild(frame);
+
+        frame.contentWindow.requestAnimationFrame(() => {
+          context.done();
+        });
       });
     });
   });


### PR DESCRIPTION
This allows a child frame to expose `requestAnimationFrame`
on its Window.

Fixes https://github.com/jsdom/jsdom/issues/2538