### PR TITLE
Recognize the .xht file extension

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -191,7 +191,7 @@ function normalizeFromFileOptions(filename, options) {
 
   if (normalized.contentType === undefined) {
     const extname = path.extname(filename);
-    if (extname === ".xhtml" || extname === ".xml") {
+    if (extname === ".xhtml" || extname === ".xht" || extname === ".xml") {
       normalized.contentType = "application/xhtml+xml";
     }
   }

--- a/test/api/fixtures/from-file/xhtml.xht
+++ b/test/api/fixtures/from-file/xhtml.xht
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"></html>

--- a/test/api/from-file.js
+++ b/test/api/from-file.js
@@ -39,6 +39,12 @@ describe("API: JSDOM.fromFile()", { skipIfBrowser: true }, () => {
       });
     });
 
+    it("should default to application/xhtml+xml Content-Type for .xht files", () => {
+      return fromFixtureFile("xhtml.xht").then(dom => {
+        assert.strictEqual(dom.window.document.contentType, "application/xhtml+xml");
+      });
+    });
+
     it("should default to application/xhtml+xml Content-Type for .xml files", () => {
       return fromFixtureFile("xhtml.xml").then(dom => {
         assert.strictEqual(dom.window.document.contentType, "application/xhtml+xml");
@@ -47,6 +53,12 @@ describe("API: JSDOM.fromFile()", { skipIfBrowser: true }, () => {
 
     it("should allow overriding the Content-Type for .xhtml files", () => {
       return fromFixtureFile("xhtml.xhtml", { contentType: "text/html" }).then(dom => {
+        assert.strictEqual(dom.window.document.contentType, "text/html");
+      });
+    });
+
+    it("should allow overriding the Content-Type for .xht files", () => {
+      return fromFixtureFile("xhtml.xht", { contentType: "text/html" }).then(dom => {
         assert.strictEqual(dom.window.document.contentType, "text/html");
       });
     });


### PR DESCRIPTION
The [`.xht`](https://en.wikipedia.org/wiki/XHTML) file extension is a shorter form of `.xhtml` which for completeness we ought to match alongside `.xhtml` and `.xml` in the API. This could potentially be seen as a breaking change that we should save for the next major release (though it's certainly not worth making a major release over this change alone).