### PR TITLE
Fix <option>'s label and value properties

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
@@ -1,4 +1,5 @@
 "use strict";
+
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const { stripAndCollapseASCIIWhitespace } = require("../helpers/strings");
 const { domSymbolTree } = require("../helpers/internal-constants");
@@ -14,6 +15,7 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     this._selectedness = false;
     this._dirtyness = false;
   }
+
   _removeOtherSelectedness() {
     // Remove the selectedness flag from all other options in this select
     const select = this._selectNode;
@@ -26,12 +28,14 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
       }
     }
   }
+
   _askForAReset() {
     const select = this._selectNode;
     if (select) {
       select._askedForAReset();
     }
   }
+
   _attrModified(name) {
     if (!this._dirtyness && name === "selected") {
       this._selectedness = this.hasAttribute("selected");
@@ -42,6 +46,7 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     }
     super._attrModified.apply(this, arguments);
   }
+
   get _selectNode() {
     let select = domSymbolTree.parent(this);
     if (!select) {
@@ -56,23 +61,30 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     }
     return select;
   }
+
   get form() {
     return formOwner(this);
   }
+
   get text() {
     // TODO is not correctly excluding script and SVG script descendants
     return stripAndCollapseASCIIWhitespace(this.textContent);
   }
-  set text(V) {
-    this.textContent = V;
+  set text(value) {
+    this.textContent = value;
   }
 
   get value() {
-    return this.hasAttribute("value") ? this.getAttribute("value") : this.text;
+    if (this.hasAttributeNS(null, "value")) {
+      return this.getAttributeNS(null, "value");
+    }
+
+    return this.text;
   }
-  set value(val) {
-    this.setAttribute("value", val);
+  set value(value) {
+    this.setAttributeNS(null, "value", value);
   }
+
   get index() {
     const select = closest(this, "select");
     if (select === null) {
@@ -81,6 +93,7 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
 
     return select.options.indexOf(this);
   }
+
   get selected() {
     return this._selectedness;
   }
@@ -94,23 +107,15 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     this._modified();
   }
 
-  // TODO this is quite wrong
   get label() {
-    if (this.hasAttribute("label")) {
-      return this.getAttribute("label");
+    if (this.hasAttributeNS(null, "label")) {
+      return this.getAttributeNS(null, "label");
     }
-    const select = this._selectNode;
-    if (select) {
-      return select.getAttribute("label");
-    }
-    return null;
-  }
 
-  set label(V) {
-    const select = this._selectNode;
-    if (select) {
-      select.setAttribute("label", V);
-    }
+    return this.text;
+  }
+  set label(value) {
+    this.setAttributeNS(null, "label", value);
   }
 }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -567,9 +567,7 @@ DIR: html/semantics/forms/the-meter-element
 
 DIR: html/semantics/forms/the-option-element
 
-option-label.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-impl.js]
 option-text-recurse.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-impl.js]
-option-value.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-impl.js]
 
 ---
 


### PR DESCRIPTION
For reasons that are not clear to me, this [test](https://github.com/web-platform-tests/wpt/blob/master/html/semantics/forms/the-option-element/option-label-value.js) which passes in all browsers requires that the `label` and `value` attributes don't belong to a namespace. There doesn't appear to be any special instructions regarding this in the [specification](https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-label).

Is this merely missing from the spec, or is it something we're actually supposed to check for all attributes?