### PR TITLE
Verify that attributes don't have namespaces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -290,5 +290,21 @@
       { "ancestor": "NodeImpl", "hook": "_childTextContentChangeSteps" },
       { "ancestor": "ElementImpl", "hook": "_attrModified" }
     ]
-  }
+  },
+
+  // Rules limited to specific locations
+  "overrides": [
+    {
+      "files": ["lib/**"],
+      "rules": {
+        "no-restricted-properties": ["error",
+          { "property": "getAttribute", "message": "Use 'getAttributeNS' with null as the namespace to access attributes within jsdom" },
+          { "property": "setAttribute", "message": "Use 'setAttributeNS' with null as the namespace to access attributes within jsdom" },
+          { "property": "hasAttribute", "message": "Use 'hasAttributeNS' with null as the namespace to access attributes within jsdom" },
+          { "property": "removeAttribute", "message": "Use 'removeAttributeNS' with null as the namespace to access attributes within jsdom" },
+          { "property": "toggleAttribute", "message": "Use 'setAttributeNS' and 'removeAttributeNS' with null as the namespace to access attributes within jsdom" }
+        ]
+      }
+    }
+  ]
 }

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -332,10 +332,10 @@ function Window(options) {
       impl.text = text;
     }
     if (value !== undefined) {
-      impl.setAttribute("value", value);
+      impl.setAttributeNS(null, "value", value);
     }
     if (defaultSelected) {
-      impl.setAttribute("selected", "");
+      impl.setAttributeNS(null, "selected", "");
     }
     impl._selectedness = selected;
 
@@ -359,10 +359,10 @@ function Window(options) {
     const impl = idlUtils.implForWrapper(img);
 
     if (arguments.length > 0) {
-      impl.setAttribute("width", String(arguments[0]));
+      impl.setAttributeNS(null, "width", String(arguments[0]));
     }
     if (arguments.length > 1) {
-      impl.setAttribute("height", String(arguments[1]));
+      impl.setAttributeNS(null, "height", String(arguments[1]));
     }
 
     return img;
@@ -383,10 +383,10 @@ function Window(options) {
   function Audio(src) {
     const audio = window._document.createElement("audio");
     const impl = idlUtils.implForWrapper(audio);
-    impl.setAttribute("preload", "auto");
+    impl.setAttributeNS(null, "preload", "auto");
 
     if (src !== undefined) {
-      impl.setAttribute("src", String(src));
+      impl.setAttributeNS(null, "src", String(src));
     }
 
     return audio;

--- a/lib/jsdom/browser/resources/per-document-resource-loader.js
+++ b/lib/jsdom/browser/resources/per-document-resource-loader.js
@@ -66,9 +66,9 @@ module.exports = class PerDocumentResourceLoader {
       }
     };
 
-    if (element.localName === "script" && element.hasAttribute("async")) {
+    if (element.localName === "script" && element.hasAttributeNS(null, "async")) {
       this._asyncQueue.push(request, onLoadWrapped, onErrorWrapped, this._queue.getLastScript());
-    } else if (element.localName === "script" && element.hasAttribute("defer")) {
+    } else if (element.localName === "script" && element.hasAttributeNS(null, "defer")) {
       this._deferQueue.push(request, onLoadWrapped, onErrorWrapped, false, element);
     } else {
       this._queue.push(request, onLoadWrapped, onErrorWrapped, false, element);

--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -8,6 +8,8 @@ const { queueAttributeMutationRecord } = require("./helpers/mutation-observers")
 // The following three are for https://dom.spec.whatwg.org/#concept-element-attribute-has. We don't just have a
 // predicate tester since removing that kind of flexibility gives us the potential for better future optimizations.
 
+/* eslint-disable no-restricted-properties */
+
 exports.hasAttribute = function (element, A) {
   return element._attributeList.includes(A);
 };

--- a/lib/jsdom/living/attributes/NamedNodeMap-impl.js
+++ b/lib/jsdom/living/attributes/NamedNodeMap-impl.js
@@ -46,9 +46,11 @@ exports.implementation = class NamedNodeMapImpl {
     return attributes.getAttributeByNameNS(this._element, namespace, localName);
   }
   setNamedItem(attr) {
+    // eslint-disable-next-line no-restricted-properties
     return attributes.setAttribute(this._element, attr);
   }
   setNamedItemNS(attr) {
+    // eslint-disable-next-line no-restricted-properties
     return attributes.setAttribute(this._element, attr);
   }
   removeNamedItem(qualifiedName) {

--- a/lib/jsdom/living/helpers/document-base-url.js
+++ b/lib/jsdom/living/helpers/document-base-url.js
@@ -46,7 +46,7 @@ function frozenBaseURL(baseElement, fallbackBaseURL) {
   // https://html.spec.whatwg.org/multipage/semantics.html#frozen-base-url
   // The spec is eager (setting the frozen base URL when things change); we are lazy (getting it when we need to)
 
-  const baseHrefAttribute = baseElement.getAttribute("href");
+  const baseHrefAttribute = baseElement.getAttributeNS(null, "href");
   const result = whatwgURL.parseURL(baseHrefAttribute, { baseURL: fallbackBaseURL });
   return result === null ? fallbackBaseURL : result;
 }

--- a/lib/jsdom/living/helpers/focusing.js
+++ b/lib/jsdom/living/helpers/focusing.js
@@ -22,7 +22,7 @@ exports.isFocusableAreaElement = elImpl => {
     return true;
   }
 
-  if (!Number.isNaN(parseInt(elImpl.getAttribute("tabindex")))) {
+  if (!Number.isNaN(parseInt(elImpl.getAttributeNS(null, "tabindex")))) {
     return true;
   }
 
@@ -31,7 +31,7 @@ exports.isFocusableAreaElement = elImpl => {
       return true;
     }
 
-    if (elImpl._localName === "a" && elImpl.hasAttribute("href")) {
+    if (elImpl._localName === "a" && elImpl.hasAttributeNS(null, "href")) {
       return true;
     }
 

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -29,14 +29,14 @@ const submittableLocalNames = new Set(["button", "input", "keygen", "object", "s
 exports.isDisabled = formControl => {
   if (formControl.localName === "button" || formControl.localName === "input" || formControl.localName === "select" ||
       formControl.localName === "textarea") {
-    if (formControl.hasAttribute("disabled")) {
+    if (formControl.hasAttributeNS(null, "disabled")) {
       return true;
     }
   }
 
   let e = formControl.parentNode;
   while (e) {
-    if (e.localName === "fieldset" && e.hasAttribute("disabled")) {
+    if (e.localName === "fieldset" && e.hasAttributeNS(null, "disabled")) {
       const firstLegendElementChild = firstChildWithLocalName(e, "legend");
       if (!firstLegendElementChild || !firstLegendElementChild.contains(formControl)) {
         return true;
@@ -159,7 +159,7 @@ exports.sanitizeValueByType = (input, val) => {
     case "email":
       // https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email):value-sanitization-algorithm
       // https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email):value-sanitization-algorithm-2
-      if (input.hasAttribute("multiple")) {
+      if (input.hasAttributeNS(null, "multiple")) {
         val = val.split(",").map(token => stripLeadingAndTrailingASCIIWhitespace(token)).join(",");
       } else {
         val = stripNewlines(val);
@@ -227,7 +227,7 @@ exports.sanitizeValueByType = (input, val) => {
 // https://github.com/whatwg/html/issues/4050 for some discussion.
 
 exports.formOwner = formControl => {
-  const formAttr = formControl.getAttribute("form");
+  const formAttr = formControl.getAttributeNS(null, "form");
   if (formAttr === "") {
     return null;
   }
@@ -239,7 +239,7 @@ exports.formOwner = formControl => {
   let firstElementWithId;
   for (const descendant of domSymbolTree.treeIterator(root)) {
     if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&
-      descendant.getAttribute("id") === formAttr) {
+      descendant.getAttributeNS(null, "id") === formAttr) {
       firstElementWithId = descendant;
       break;
     }

--- a/lib/jsdom/living/helpers/stylesheets.js
+++ b/lib/jsdom/living/helpers/stylesheets.js
@@ -60,8 +60,8 @@ function fetchStylesheetInternal(elementImpl, urlString, parsedURL) {
   let defaultEncoding = document._encoding;
   const resourceLoader = document._resourceLoader;
 
-  if (elementImpl.localName === "link" && elementImpl.hasAttribute("charset")) {
-    defaultEncoding = whatwgEncoding.labelToName(elementImpl.getAttribute("charset"));
+  if (elementImpl.localName === "link" && elementImpl.hasAttributeNS(null, "charset")) {
+    defaultEncoding = whatwgEncoding.labelToName(elementImpl.getAttributeNS(null, "charset"));
   }
 
   function onStylesheetLoad(data) {

--- a/lib/jsdom/living/named-properties-window.js
+++ b/lib/jsdom/living/named-properties-window.js
@@ -38,9 +38,9 @@ function namedPropertyResolver(window, name, values) {
         continue;
       }
 
-      if (node.getAttribute("id") === name) {
+      if (node.getAttributeNS(null, "id") === name) {
         results.push(node);
-      } else if (node.getAttribute("name") === name && isNamedPropertyElement(node)) {
+      } else if (node.getAttributeNS(null, "name") === name && isNamedPropertyElement(node)) {
         results.push(node);
       }
     }
@@ -61,7 +61,7 @@ function namedPropertyResolver(window, name, values) {
     const node = objects[i];
 
     if ("contentWindow" in node && !hasOwnProp.call(node, "contentWindow") &&
-       node.getAttribute("name") === name) {
+       node.getAttributeNS(null, "name") === name) {
       return node.contentWindow;
     }
   }
@@ -93,11 +93,11 @@ exports.elementAttributeModified = function (element, name, value, oldValue) {
 
     // (tracker will be null if the document has no Window)
     if (tracker) {
-      if (name === "id" && (!useName || element.getAttribute("name") !== oldValue)) {
+      if (name === "id" && (!useName || element.getAttributeNS(null, "name") !== oldValue)) {
         tracker.untrack(oldValue, element);
       }
 
-      if (name === "name" && element.getAttribute("id") !== oldValue) {
+      if (name === "name" && element.getAttributeNS(null, "id") !== oldValue) {
         tracker.untrack(oldValue, element);
       }
 
@@ -116,10 +116,10 @@ exports.nodeAttachedToDocument = function (node) {
     return;
   }
 
-  tracker.track(node.getAttribute("id"), node);
+  tracker.track(node.getAttributeNS(null, "id"), node);
 
   if (isNamedPropertyElement(node)) {
-    tracker.track(node.getAttribute("name"), node);
+    tracker.track(node.getAttributeNS(null, "name"), node);
   }
 };
 
@@ -133,9 +133,9 @@ exports.nodeDetachedFromDocument = function (node) {
     return;
   }
 
-  tracker.untrack(node.getAttribute("id"), node);
+  tracker.untrack(node.getAttributeNS(null, "id"), node);
 
   if (isNamedPropertyElement(node)) {
-    tracker.untrack(node.getAttribute("name"), node);
+    tracker.untrack(node.getAttributeNS(null, "name"), node);
   }
 };

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -420,7 +420,7 @@ class DocumentImpl extends NodeImpl {
       element: this,
       query: () => domSymbolTree.treeToArray(this, {
         filter: node => (node._localName === "a" || node._localName === "area") &&
-                        node.hasAttribute("href") &&
+                        node.hasAttributeNS(null, "href") &&
                         node._namespaceURI === HTML_NS
       })
     });
@@ -436,7 +436,7 @@ class DocumentImpl extends NodeImpl {
       element: this,
       query: () => domSymbolTree.treeToArray(this, {
         filter: node => node._localName === "a" &&
-                        node.hasAttribute("name") &&
+                        node.hasAttributeNS(null, "name") &&
                         node._namespaceURI === HTML_NS
       })
     });
@@ -531,7 +531,7 @@ class DocumentImpl extends NodeImpl {
     return NodeList.createImpl([], {
       element: this,
       query: () => domSymbolTree.treeToArray(this, {
-        filter: node => node.getAttribute && node.getAttribute("name") === elementName
+        filter: node => node.getAttributeNS && node.getAttributeNS(null, "name") === elementName
       })
     });
   }

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -80,7 +80,7 @@ class ElementImpl extends NodeImpl {
   _attach() {
     namedPropertiesWindow.nodeAttachedToDocument(this);
 
-    const id = this.getAttribute("id");
+    const id = this.getAttributeNS(null, "id");
     if (id) {
       attachId(id, this, this._ownerDocument);
     }
@@ -93,7 +93,7 @@ class ElementImpl extends NodeImpl {
 
     namedPropertiesWindow.nodeDetachedFromDocument(this);
 
-    const id = this.getAttribute("id");
+    const id = this.getAttributeNS(null, "id");
     if (id) {
       detachId(id, this, this._ownerDocument);
     }
@@ -306,18 +306,22 @@ class ElementImpl extends NodeImpl {
   }
 
   setAttributeNode(attr) {
+    // eslint-disable-next-line no-restricted-properties
     return attributes.setAttribute(this, attr);
   }
 
   setAttributeNodeNS(attr) {
+    // eslint-disable-next-line no-restricted-properties
     return attributes.setAttribute(this, attr);
   }
 
   removeAttributeNode(attr) {
+    // eslint-disable-next-line no-restricted-properties
     if (!attributes.hasAttribute(this, attr)) {
       throw new DOMException("Tried to remove an attribute that was not present", "NotFoundError");
     }
 
+    // eslint-disable-next-line no-restricted-properties
     attributes.removeAttribute(this, attr);
 
     return attr;

--- a/lib/jsdom/living/nodes/ElementCSSInlineStyle-impl.js
+++ b/lib/jsdom/living/nodes/ElementCSSInlineStyle-impl.js
@@ -6,7 +6,7 @@ class ElementCSSInlineStyle {
     this._style = new cssstyle.CSSStyleDeclaration(newCssText => {
       if (!this._settingCssText) {
         this._settingCssText = true;
-        this.setAttribute("style", newCssText);
+        this.setAttributeNS(null, "style", newCssText);
         this._settingCssText = false;
       }
     });

--- a/lib/jsdom/living/nodes/GlobalEventHandlers-impl.js
+++ b/lib/jsdom/living/nodes/GlobalEventHandlers-impl.js
@@ -80,7 +80,7 @@ class GlobalEventHandlersImpl {
       return;
     }
 
-    const val = this.getAttribute(propName);
+    const val = this.getAttributeNS(null, propName);
     const handler = val === null ? null : { body: val };
     this._setEventHandlerFor(event, handler);
   }

--- a/lib/jsdom/living/nodes/HTMLAndSVGElementShared-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAndSVGElementShared-impl.js
@@ -16,14 +16,14 @@ class HTMLAndSVGElementSharedImpl {
 
   // TODO this should be [Reflect]able if we added default value support to webidl2js's [Reflect]
   get tabIndex() {
-    if (!this.hasAttribute("tabindex")) {
+    if (!this.hasAttributeNS(null, "tabindex")) {
       return focusing.isFocusableAreaElement(this) ? 0 : -1;
     }
-    return conversions.long(this.getAttribute("tabindex"));
+    return conversions.long(this.getAttributeNS(null, "tabindex"));
   }
 
   set tabIndex(value) {
-    this.setAttribute("tabindex", String(value));
+    this.setAttributeNS(null, "tabindex", String(value));
   }
 
   focus() {

--- a/lib/jsdom/living/nodes/HTMLBaseElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLBaseElement-impl.js
@@ -7,7 +7,7 @@ class HTMLBaseElementImpl extends HTMLElementImpl {
   get href() {
     const document = this._ownerDocument;
 
-    const url = this.hasAttribute("href") ? this.getAttribute("href") : "";
+    const url = this.hasAttributeNS(null, "href") ? this.getAttributeNS(null, "href") : "";
     const parsed = whatwgURL.parseURL(url, { baseURL: fallbackBaseURL(document) });
 
     if (parsed === null) {
@@ -18,7 +18,7 @@ class HTMLBaseElementImpl extends HTMLElementImpl {
   }
 
   set href(value) {
-    this.setAttribute("href", value);
+    this.setAttributeNS(null, "href", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
@@ -29,7 +29,7 @@ class HTMLButtonElementImpl extends HTMLElementImpl {
   }
 
   _getValue() {
-    const valueAttr = this.getAttribute("value");
+    const valueAttr = this.getAttributeNS(null, "value");
     return valueAttr === null ? "" : valueAttr;
   }
 
@@ -42,7 +42,7 @@ class HTMLButtonElementImpl extends HTMLElementImpl {
   }
 
   get type() {
-    const typeAttr = (this.getAttribute("type") || "").toLowerCase();
+    const typeAttr = (this.getAttributeNS(null, "type") || "").toLowerCase();
     switch (typeAttr) {
       case "submit":
       case "reset":
@@ -59,10 +59,10 @@ class HTMLButtonElementImpl extends HTMLElementImpl {
       case "submit":
       case "reset":
       case "button":
-        this.setAttribute("type", v);
+        this.setAttributeNS(null, "type", v);
         break;
       default:
-        this.setAttribute("type", "submit");
+        this.setAttributeNS(null, "type", "submit");
         break;
     }
   }

--- a/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
@@ -88,23 +88,23 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
   }
 
   get width() {
-    const parsed = parseInt(this.getAttribute("width"));
+    const parsed = parseInt(this.getAttributeNS(null, "width"));
     return isNaN(parsed) || parsed < 0 || parsed > 2147483647 ? 300 : parsed;
   }
 
   set width(v) {
     v = v > 2147483647 ? 300 : v;
-    this.setAttribute("width", String(v));
+    this.setAttributeNS(null, "width", String(v));
   }
 
   get height() {
-    const parsed = parseInt(this.getAttribute("height"));
+    const parsed = parseInt(this.getAttributeNS(null, "height"));
     return isNaN(parsed) || parsed < 0 || parsed > 2147483647 ? 150 : parsed;
   }
 
   set height(v) {
     v = v > 2147483647 ? 150 : v;
-    this.setAttribute("height", String(v));
+    this.setAttributeNS(null, "height", String(v));
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLCollection-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCollection-impl.js
@@ -25,11 +25,11 @@ exports.implementation = class HTMLCollectionImpl {
     }
     this._update();
     for (const element of this._list) {
-      if (element.getAttribute("id") === key) {
+      if (element.getAttributeNS(null, "id") === key) {
         return element;
       }
       if (element._namespaceURI === HTML_NS) {
-        const name = element.getAttribute("name");
+        const name = element.getAttributeNS(null, "name");
         if (name === key) {
           return element;
         }
@@ -55,12 +55,12 @@ exports.implementation = class HTMLCollectionImpl {
     this._update();
     const result = new Set();
     for (const element of this._list) {
-      const id = element.getAttribute("id");
+      const id = element.getAttributeNS(null, "id");
       if (id) {
         result.add(id);
       }
       if (element._namespaceURI === HTML_NS) {
-        const name = element.getAttribute("name");
+        const name = element.getAttributeNS(null, "name");
         if (name) {
           result.add(name);
         }

--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -27,7 +27,11 @@ class HTMLElementImpl extends ElementImpl {
     const parent = this.parentNode;
     if (parent && parent._localName === "details" &&
         this === firstChildWithLocalName(parent, "summary")) {
-      parent.toggleAttribute("open");
+      if (parent.hasAttributeNS(null, "open")) {
+        parent.removeAttributeNS(null, "open");
+      } else {
+        parent.setAttributeNS(null, "open", "");
+      }
     }
   }
 
@@ -59,7 +63,7 @@ class HTMLElementImpl extends ElementImpl {
   }
 
   get draggable() {
-    const attributeValue = this.getAttribute("draggable");
+    const attributeValue = this.getAttributeNS(null, "draggable");
 
     if (attributeValue === "true") {
       return true;
@@ -67,14 +71,14 @@ class HTMLElementImpl extends ElementImpl {
       return false;
     }
 
-    return this._localName === "img" || (this._localName === "a" && this.hasAttribute("href"));
+    return this._localName === "img" || (this._localName === "a" && this.hasAttributeNS(null, "href"));
   }
   set draggable(value) {
-    this.setAttribute("draggable", String(value));
+    this.setAttributeNS(null, "draggable", String(value));
   }
 
   get dir() {
-    let dirValue = this.getAttribute("dir");
+    let dirValue = this.getAttributeNS(null, "dir");
     if (dirValue !== null) {
       dirValue = dirValue.toLowerCase();
 
@@ -85,7 +89,7 @@ class HTMLElementImpl extends ElementImpl {
     return "";
   }
   set dir(value) {
-    this.setAttribute("dir", value);
+    this.setAttributeNS(null, "dir", value);
   }
 
   _attrModified(name, value, oldValue) {

--- a/lib/jsdom/living/nodes/HTMLEmbedElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLEmbedElement-impl.js
@@ -8,7 +8,7 @@ class HTMLEmbedElementImpl extends HTMLElementImpl {
   }
 
   set src(value) {
-    this.setAttribute("src", value);
+    this.setAttributeNS(null, "src", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -99,7 +99,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   get method() {
-    let method = this.getAttribute("method");
+    let method = this.getAttributeNS(null, "method");
     if (method) {
       method = method.toLowerCase();
     }
@@ -111,11 +111,11 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   set method(V) {
-    this.setAttribute("method", V);
+    this.setAttributeNS(null, "method", V);
   }
 
   get enctype() {
-    let type = this.getAttribute("enctype");
+    let type = this.getAttributeNS(null, "enctype");
     if (type) {
       type = type.toLowerCase();
     }
@@ -127,11 +127,11 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   set enctype(V) {
-    this.setAttribute("enctype", V);
+    this.setAttributeNS(null, "enctype", V);
   }
 
   get action() {
-    const attributeValue = this.getAttribute("action");
+    const attributeValue = this.getAttributeNS(null, "action");
     if (attributeValue === null || attributeValue === "") {
       return this._ownerDocument.URL;
     }
@@ -140,7 +140,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   set action(V) {
-    this.setAttribute("action", V);
+    this.setAttributeNS(null, "action", V);
   }
 
   // If the checkValidity() method is invoked, the user agent must statically validate the

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -259,7 +259,7 @@ class HTMLFrameElementImpl extends HTMLElementImpl {
   }
 
   set src(value) {
-    this.setAttribute("src", value);
+    this.setAttributeNS(null, "src", value);
   }
 
   get longDesc() {
@@ -267,7 +267,7 @@ class HTMLFrameElementImpl extends HTMLElementImpl {
   }
 
   set longDesc(value) {
-    this.setAttribute("longdesc", value);
+    this.setAttributeNS(null, "longdesc", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js
+++ b/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js
@@ -17,14 +17,14 @@ exports.implementation = class HTMLHyperlinkElementUtilsImpl {
 
   // https://html.spec.whatwg.org/multipage/semantics.html#get-an-element's-target
   _getAnElementsTarget() {
-    if (this.hasAttribute("target")) {
-      return this.getAttribute("target");
+    if (this.hasAttributeNS(null, "target")) {
+      return this.getAttributeNS(null, "target");
     }
 
     const baseEl = this._ownerDocument.querySelector("base[target]");
 
     if (baseEl) {
-      return baseEl.getAttribute("target");
+      return baseEl.getAttributeNS(null, "target");
     }
 
     return "";
@@ -91,7 +91,7 @@ exports.implementation = class HTMLHyperlinkElementUtilsImpl {
     const { url } = this;
 
     if (url === null) {
-      const href = this.getAttribute("href");
+      const href = this.getAttributeNS(null, "href");
       return href === null ? "" : href;
     }
 
@@ -99,7 +99,7 @@ exports.implementation = class HTMLHyperlinkElementUtilsImpl {
   }
 
   set href(v) {
-    this.setAttribute("href", v);
+    this.setAttributeNS(null, "href", v);
   }
 
   get origin() {
@@ -355,7 +355,7 @@ function reinitializeURL(hheu) {
 }
 
 function setTheURL(hheu) {
-  const href = hheu.getAttribute("href");
+  const href = hheu.getAttributeNS(null, "href");
   if (href === null) {
     hheu.url = null;
     return;
@@ -367,5 +367,5 @@ function setTheURL(hheu) {
 }
 
 function updateHref(hheu) {
-  hheu.setAttribute("href", whatwgURL.serializeURL(hheu.url));
+  hheu.setAttributeNS(null, "href", whatwgURL.serializeURL(hheu.url));
 }

--- a/lib/jsdom/living/nodes/HTMLImageElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLImageElement-impl.js
@@ -18,7 +18,7 @@ class HTMLImageElementImpl extends HTMLElementImpl {
           };
         }
         this._currentSrc = null;
-        if (this.hasAttribute("src")) {
+        if (this.hasAttributeNS(null, "src")) {
           const resourceLoader = document._resourceLoader;
           let request;
 
@@ -58,37 +58,37 @@ class HTMLImageElementImpl extends HTMLElementImpl {
   }
 
   set src(value) {
-    this.setAttribute("src", value);
+    this.setAttributeNS(null, "src", value);
   }
 
   get srcset() {
-    return conversions.USVString(this.getAttribute("srcset"));
+    return conversions.USVString(this.getAttributeNS(null, "srcset"));
   }
 
   set srcset(value) {
-    this.setAttribute("srcset", value);
+    this.setAttributeNS(null, "srcset", value);
   }
 
   get height() {
     // Just like on browsers, if no width / height is defined, we fall back on the
     // dimensions of the internal image data.
-    return this.hasAttribute("height") ?
-           conversions["unsigned long"](this.getAttribute("height")) :
+    return this.hasAttributeNS(null, "height") ?
+           conversions["unsigned long"](this.getAttributeNS(null, "height")) :
            this.naturalHeight;
   }
 
   set height(V) {
-    this.setAttribute("height", String(V));
+    this.setAttributeNS(null, "height", String(V));
   }
 
   get width() {
-    return this.hasAttribute("width") ?
-           conversions["unsigned long"](this.getAttribute("width")) :
+    return this.hasAttributeNS(null, "width") ?
+           conversions["unsigned long"](this.getAttributeNS(null, "width")) :
            this.naturalWidth;
   }
 
   set width(V) {
-    this.setAttribute("width", String(V));
+    this.setAttributeNS(null, "width", String(V));
   }
 
   get naturalHeight() {
@@ -112,7 +112,7 @@ class HTMLImageElementImpl extends HTMLElementImpl {
   }
 
   set lowsrc(value) {
-    this.setAttribute("lowsrc", value);
+    this.setAttributeNS(null, "lowsrc", value);
   }
 
   get longDesc() {
@@ -120,7 +120,7 @@ class HTMLImageElementImpl extends HTMLElementImpl {
   }
 
   set longDesc(value) {
-    this.setAttribute("longdesc", value);
+    this.setAttributeNS(null, "longdesc", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -343,12 +343,12 @@ class HTMLInputElementImpl extends HTMLElementImpl {
         return this._value !== null ? this._value : "";
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default
       case "default": {
-        const attr = this.getAttribute("value");
+        const attr = this.getAttributeNS(null, "value");
         return attr !== null ? attr : "";
       }
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
       case "default/on": {
-        const attr = this.getAttribute("value");
+        const attr = this.getAttributeNS(null, "value");
         return attr !== null ? attr : "on";
       }
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-filename
@@ -383,7 +383,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
       case "default":
       case "default/on":
-        this.setAttribute("value", val);
+        this.setAttributeNS(null, "value", val);
         break;
 
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-filename
@@ -417,12 +417,12 @@ class HTMLInputElementImpl extends HTMLElementImpl {
   }
 
   get type() {
-    const type = this.getAttribute("type");
+    const type = this.getAttributeNS(null, "type");
     return type ? type.toLowerCase() : "text";
   }
 
   set type(type) {
-    this.setAttribute("type", type);
+    this.setAttributeNS(null, "type", type);
   }
 
   _dispatchSelectEvent() {
@@ -555,56 +555,56 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     if (value < 0) {
       throw new DOMException("The index is not in the allowed range.", "IndexSizeError");
     }
-    this.setAttribute("maxlength", String(value));
+    this.setAttributeNS(null, "maxlength", String(value));
   }
 
   get maxLength() {
-    if (!this.hasAttribute("maxlength")) {
+    if (!this.hasAttributeNS(null, "maxlength")) {
       return 524288; // stole this from chrome
     }
-    return parseInt(this.getAttribute("maxlength"));
+    return parseInt(this.getAttributeNS(null, "maxlength"));
   }
 
   set minLength(value) {
     if (value < 0) {
       throw new DOMException("The index is not in the allowed range.", "IndexSizeError");
     }
-    this.setAttribute("minlength", String(value));
+    this.setAttributeNS(null, "minlength", String(value));
   }
 
   get minLength() {
-    if (!this.hasAttribute("minlength")) {
+    if (!this.hasAttributeNS(null, "minlength")) {
       return 0;
     }
-    return parseInt(this.getAttribute("minlength"));
+    return parseInt(this.getAttributeNS(null, "minlength"));
   }
 
   get size() {
-    if (!this.hasAttribute("size")) {
+    if (!this.hasAttributeNS(null, "size")) {
       return 20;
     }
-    return parseInt(this.getAttribute("size"));
+    return parseInt(this.getAttributeNS(null, "size"));
   }
 
   set size(value) {
     if (value <= 0) {
       throw new DOMException("The index is not in the allowed range.", "IndexSizeError");
     }
-    this.setAttribute("size", String(value));
+    this.setAttributeNS(null, "size", String(value));
   }
 
   get src() {
-    return conversions.USVString(this.getAttribute("src"));
+    return conversions.USVString(this.getAttributeNS(null, "src"));
   }
 
   set src(value) {
-    this.setAttribute("src", value);
+    this.setAttributeNS(null, "src", value);
   }
 
   // https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
   get _minimum() {
     let min = this._defaultMinimum;
-    const attr = this.getAttribute("min");
+    const attr = this.getAttributeNS(null, "min");
     const convertStringToNumber = this._convertStringToNumber;
     if (attr !== null && convertStringToNumber !== undefined) {
       const parsed = convertStringToNumber(attr);
@@ -617,7 +617,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
   get _maximum() {
     let max = this._defaultMaximum;
-    const attr = this.getAttribute("max");
+    const attr = this.getAttributeNS(null, "max");
     const convertStringToNumber = this._convertStringToNumber;
     if (attr !== null && convertStringToNumber !== undefined) {
       const parsed = convertStringToNumber(attr);
@@ -653,8 +653,8 @@ class HTMLInputElementImpl extends HTMLElementImpl {
   // https://html.spec.whatwg.org/multipage/input.html#attr-input-step
   get _step() {
     let step = this._defaultStep;
-    if (this.hasAttribute("step") && !asciiCaseInsensitiveMatch(this.getAttribute("step"), "any")) {
-      const parsedStep = parseFloatingPointNumber(this.getAttribute("step"));
+    if (this.hasAttributeNS(null, "step") && !asciiCaseInsensitiveMatch(this.getAttributeNS(null, "step"), "any")) {
+      const parsedStep = parseFloatingPointNumber(this.getAttributeNS(null, "step"));
       if (!isNaN(parsedStep) && parsedStep > 0) {
         step = parsedStep;
       }
@@ -688,14 +688,14 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
   // https://html.spec.whatwg.org/multipage/input.html#concept-input-min-zero
   get _stepBase() {
-    const parseAttribute = attributeName => parseFloatingPointNumber(this.getAttribute(attributeName));
-    if (this.hasAttribute("min")) {
+    const parseAttribute = attributeName => parseFloatingPointNumber(this.getAttributeNS(null, attributeName));
+    if (this.hasAttributeNS(null, "min")) {
       const min = parseAttribute("min");
       if (!isNaN(min)) {
         return min;
       }
     }
-    if (this.hasAttribute("value")) {
+    if (this.hasAttributeNS(null, "value")) {
       const value = parseAttribute("value");
       if (!isNaN(value)) {
         return value;
@@ -723,7 +723,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     // https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
     const willNotValidateTypes = new Set(["hidden", "reset", "button"]);
     // https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
-    const readOnly = this.hasAttribute("readonly");
+    const readOnly = this.hasAttributeNS(null, "readonly");
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
     return willNotValidateTypes.has(this.type) || readOnly;
@@ -735,7 +735,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
         // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-being-missing
         valueMissing: () => {
-          if (!this.hasAttribute("required")) {
+          if (!this.hasAttributeNS(null, "required")) {
             return false;
           }
           if (this.type === "checkbox") {
@@ -775,16 +775,16 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
         // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-pattern-mismatch
         patternMismatch: () => {
-          if (!this.hasAttribute("pattern") || !this._attributeApplies("pattern") || this.value === "") {
+          if (!this.hasAttributeNS(null, "pattern") || !this._attributeApplies("pattern") || this.value === "") {
             return false;
           }
           let regExp;
           try {
-            regExp = new RegExp(this.getAttribute("pattern"), "u");
+            regExp = new RegExp(this.getAttributeNS(null, "pattern"), "u");
           } catch (e) {
             return false;
           }
-          if (this.type === "email" && this.hasAttribute("multiple")) {
+          if (this.type === "email" && this.hasAttributeNS(null, "multiple")) {
             return splitOnCommas(this.value).every(value => regExp.test(value));
           }
           return !regExp.test(this.value);
@@ -800,7 +800,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
           if (!this._attributeApplies("step")) {
             return false;
           }
-          const step = parseFloatingPointNumber(this.getAttribute("step"));
+          const step = parseFloatingPointNumber(this.getAttributeNS(null, "step"));
           if (isNaN(step) || step <= 0) {
             return false;
           }
@@ -827,7 +827,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
             // Constraint validation [multiple=true]: While the value of the element is not a valid e-mail address list,
             // the element is suffering from a type mismatch.
-            return !isValidEmailAddress(this.value, this.hasAttribute("multiple"));
+            return !isValidEmailAddress(this.value, this.hasAttributeNS(null, "multiple"));
           } else if (this.type === "url") {
             // https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)
             // Constraint validation: While the value of the element is neither the empty string

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -30,15 +30,15 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
   }
 
   get control() {
-    if (this.hasAttribute("for")) {
-      const forValue = this.getAttribute("for");
+    if (this.hasAttributeNS(null, "for")) {
+      const forValue = this.getAttributeNS(null, "for");
       if (forValue === "") {
         return null;
       }
       const root = this.getRootNode({});
       for (const descendant of domSymbolTree.treeIterator(root)) {
         if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&
-          descendant.getAttribute("id") === forValue) {
+          descendant.getAttributeNS(null, "id") === forValue) {
           return isLabelable(descendant) ? descendant : null;
         }
       }

--- a/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
@@ -54,7 +54,7 @@ class HTMLLinkElementImpl extends HTMLElementImpl {
   }
 
   set href(value) {
-    this.setAttribute("href", value);
+    this.setAttributeNS(null, "href", value);
   }
 }
 
@@ -79,7 +79,7 @@ function maybeFetchAndProcess(el) {
 // https://html.spec.whatwg.org/multipage/semantics.html#default-fetch-and-process-the-linked-resource
 // TODO: refactor into general link-fetching like the spec.
 function fetchAndProcess(el) {
-  const href = el.getAttribute("href");
+  const href = el.getAttributeNS(null, "href");
 
   if (href === null || href === "") {
     return;

--- a/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
@@ -83,13 +83,13 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
     }
   }
   get defaultMuted() {
-    return this.getAttribute("muted") !== null;
+    return this.getAttributeNS(null, "muted") !== null;
   }
   set defaultMuted(v) {
     if (v) {
-      this.setAttribute("muted", v);
+      this.setAttributeNS(null, "muted", v);
     } else {
-      this.removeAttribute("muted");
+      this.removeAttributeNS(null, "muted");
     }
   }
   get volume() {
@@ -128,7 +128,7 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
   }
 
   set src(value) {
-    this.setAttribute("src", value);
+    this.setAttributeNS(null, "src", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMeterElement-impl.js
@@ -12,7 +12,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
 
   // https://html.spec.whatwg.org/multipage/form-elements.html#concept-meter-minimum
   get _minimumValue() {
-    const min = this.getAttribute("min");
+    const min = this.getAttributeNS(null, "min");
     if (min === null) {
       return 0;
     }
@@ -27,7 +27,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   get _maximumValue() {
     let candidate = 1.0;
 
-    const max = this.getAttribute("max");
+    const max = this.getAttributeNS(null, "max");
     if (max !== null) {
       const parsed = parseFloatingPointNumber(max);
       if (!Number.isNaN(parsed)) {
@@ -43,7 +43,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   get _actualValue() {
     let candidate = 0;
 
-    const value = this.getAttribute("value");
+    const value = this.getAttributeNS(null, "value");
     if (value !== null) {
       const parsed = parseFloatingPointNumber(value);
       if (!Number.isNaN(parsed)) {
@@ -65,7 +65,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
     const minimumValue = this._minimumValue;
     let candidate = minimumValue;
 
-    const low = this.getAttribute("low");
+    const low = this.getAttributeNS(null, "low");
     if (low !== null) {
       const parsed = parseFloatingPointNumber(low);
       if (!Number.isNaN(parsed)) {
@@ -86,7 +86,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
     const maximumValue = this._maximumValue;
     let candidate = maximumValue;
 
-    const high = this.getAttribute("high");
+    const high = this.getAttributeNS(null, "high");
     if (high !== null) {
       const parsed = parseFloatingPointNumber(high);
       if (!Number.isNaN(parsed)) {
@@ -108,7 +108,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
     const maximumValue = this._maximumValue;
     let candidate = (minimumValue + maximumValue) / 2;
 
-    const optimum = this.getAttribute("optimum");
+    const optimum = this.getAttributeNS(null, "optimum");
     if (optimum !== null) {
       const parsed = parseFloatingPointNumber(optimum);
       if (!Number.isNaN(parsed)) {
@@ -132,7 +132,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   }
 
   set value(val) {
-    this.setAttribute("value", String(val));
+    this.setAttributeNS(null, "value", String(val));
   }
 
   get min() {
@@ -140,7 +140,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   }
 
   set min(val) {
-    this.setAttribute("min", String(val));
+    this.setAttributeNS(null, "min", String(val));
   }
 
   get max() {
@@ -148,7 +148,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   }
 
   set max(val) {
-    this.setAttribute("max", String(val));
+    this.setAttributeNS(null, "max", String(val));
   }
 
   get low() {
@@ -156,7 +156,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   }
 
   set low(val) {
-    this.setAttribute("low", String(val));
+    this.setAttributeNS(null, "low", String(val));
   }
 
   get high() {
@@ -164,7 +164,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   }
 
   set high(val) {
-    this.setAttribute("high", String(val));
+    this.setAttributeNS(null, "high", String(val));
   }
 
   get optimum() {
@@ -172,7 +172,7 @@ class HTMLMeterElementImpl extends HTMLElementImpl {
   }
 
   set optimum(val) {
-    this.setAttribute("optimum", String(val));
+    this.setAttributeNS(null, "optimum", String(val));
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLModElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLModElement-impl.js
@@ -5,11 +5,11 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
 class HTMLModElementImpl extends HTMLElementImpl {
   get cite() {
-    return conversions.USVString(this.getAttribute("cite"));
+    return conversions.USVString(this.getAttributeNS(null, "cite"));
   }
 
   set cite(value) {
-    this.setAttribute("cite", value);
+    this.setAttributeNS(null, "cite", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLOListElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOListElement-impl.js
@@ -4,7 +4,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
 class HTMLOListElementImpl extends HTMLElementImpl {
   get start() {
-    const value = parseInt(this.getAttribute("start"));
+    const value = parseInt(this.getAttributeNS(null, "start"));
 
     if (!isNaN(value)) {
       return value;
@@ -13,7 +13,7 @@ class HTMLOListElementImpl extends HTMLElementImpl {
     return 1;
   }
   set start(value) {
-    this.setAttribute("start", value);
+    this.setAttributeNS(null, "start", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLObjectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLObjectElement-impl.js
@@ -20,7 +20,7 @@ class HTMLObjectElementImpl extends HTMLElementImpl {
   }
 
   set data(V) {
-    this.setAttribute("data", V);
+    this.setAttributeNS(null, "data", V);
   }
 
   get codeBase() {
@@ -28,7 +28,7 @@ class HTMLObjectElementImpl extends HTMLElementImpl {
   }
 
   set codeBase(V) {
-    this.setAttribute("codebase", V);
+    this.setAttributeNS(null, "codebase", V);
   }
 
   _barredFromConstraintValidationSpecialization() {

--- a/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
@@ -20,7 +20,7 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     // Remove the selectedness flag from all other options in this select
     const select = this._selectNode;
 
-    if (select && !select.hasAttribute("multiple")) {
+    if (select && !select.hasAttributeNS(null, "multiple")) {
       for (const option of select.options) {
         if (option !== this) {
           option._selectedness = false;
@@ -38,7 +38,7 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
 
   _attrModified(name) {
     if (!this._dirtyness && name === "selected") {
-      this._selectedness = this.hasAttribute("selected");
+      this._selectedness = this.hasAttributeNS(null, "selected");
       if (this._selectedness) {
         this._removeOtherSelectedness();
       }

--- a/lib/jsdom/living/nodes/HTMLOptionsCollection-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionsCollection-impl.js
@@ -33,8 +33,8 @@ exports.implementation = class HTMLOptionsCollectionImpl extends HTMLCollectionI
     this._update();
     const result = new Set();
     for (const element of this._list) {
-      result.add(element.getAttribute("id"));
-      result.add(element.getAttribute("name"));
+      result.add(element.getAttributeNS(null, "id"));
+      result.add(element.getAttributeNS(null, "name"));
     }
     return result;
   }

--- a/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLProgressElement-impl.js
@@ -11,7 +11,7 @@ class HTMLProgressElementImpl extends HTMLElementImpl {
   }
 
   get value() {
-    const parsedValue = parseFloatingPointNumber(this.getAttribute("value"));
+    const parsedValue = parseFloatingPointNumber(this.getAttributeNS(null, "value"));
 
     if (!isNaN(parsedValue) && parsedValue > 0) {
       return parsedValue > this.max ? this.max : parsedValue;
@@ -20,11 +20,11 @@ class HTMLProgressElementImpl extends HTMLElementImpl {
     return 0;
   }
   set value(value) {
-    this.setAttribute("value", value);
+    this.setAttributeNS(null, "value", value);
   }
 
   get max() {
-    const parsedMax = parseFloatingPointNumber(this.getAttribute("max"));
+    const parsedMax = parseFloatingPointNumber(this.getAttributeNS(null, "max"));
 
     if (!isNaN(parsedMax) && parsedMax > 0) {
       return parsedMax;
@@ -33,11 +33,11 @@ class HTMLProgressElementImpl extends HTMLElementImpl {
     return 1.0;
   }
   set max(value) {
-    this.setAttribute("max", value);
+    this.setAttributeNS(null, "max", value);
   }
 
   get position() {
-    if (!this.hasAttribute("value")) {
+    if (!this.hasAttributeNS(null, "value")) {
       return -1;
     }
 

--- a/lib/jsdom/living/nodes/HTMLQuoteElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLQuoteElement-impl.js
@@ -5,11 +5,11 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
 class HTMLQuoteElementImpl extends HTMLElementImpl {
   get cite() {
-    return conversions.USVString(this.getAttribute("cite"));
+    return conversions.USVString(this.getAttributeNS(null, "cite"));
   }
 
   set cite(value) {
-    this.setAttribute("cite", value);
+    this.setAttributeNS(null, "cite", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
@@ -63,7 +63,7 @@ class HTMLScriptElementImpl extends HTMLElementImpl {
   _fetchExternalScript(src) {
     const document = this._ownerDocument;
     const resourceLoader = document._resourceLoader;
-    const defaultEncoding = whatwgEncoding.labelToName(this.getAttribute("charset")) || document._encoding;
+    const defaultEncoding = whatwgEncoding.labelToName(this.getAttributeNS(null, "charset")) || document._encoding;
     let request;
 
     if (!this._canRunScript()) {
@@ -134,7 +134,7 @@ class HTMLScriptElementImpl extends HTMLElementImpl {
 
     // TODO: this text check doesn't seem completely the same as the spec, which e.g. will try to execute scripts with
     // child element nodes. Spec bug? https://github.com/whatwg/html/issues/3419
-    if (!this.hasAttribute("src") && this.text.length === 0) {
+    if (!this.hasAttributeNS(null, "src") && this.text.length === 0) {
       return;
     }
 
@@ -156,7 +156,7 @@ class HTMLScriptElementImpl extends HTMLElementImpl {
 
     // At this point we completely depart from the spec.
 
-    if (this.hasAttribute("src")) {
+    if (this.hasAttributeNS(null, "src")) {
       this._fetchExternalScript(this.src);
     } else {
       this._fetchInternalScript();
@@ -170,8 +170,8 @@ class HTMLScriptElementImpl extends HTMLElementImpl {
   }
 
   _getTypeString() {
-    const typeAttr = this.getAttribute("type");
-    const langAttr = this.getAttribute("language");
+    const typeAttr = this.getAttributeNS(null, "type");
+    const langAttr = this.getAttributeNS(null, "language");
 
     if (typeAttr === "") {
       return "text/javascript";
@@ -209,7 +209,7 @@ class HTMLScriptElementImpl extends HTMLElementImpl {
   }
 
   set src(V) {
-    this.setAttribute("src", V);
+    this.setAttributeNS(null, "src", V);
   }
 
   // https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -45,14 +45,14 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 
   _formReset() {
     for (const option of this.options) {
-      option._selectedness = option.hasAttribute("selected");
+      option._selectedness = option.hasAttributeNS(null, "selected");
       option._dirtyness = false;
     }
     this._askedForAReset();
   }
 
   _askedForAReset() {
-    if (this.hasAttribute("multiple")) {
+    if (this.hasAttributeNS(null, "multiple")) {
       return;
     }
 
@@ -62,11 +62,11 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     if (size === 1 && !selected.length) {
       // select the first option that is not disabled
       for (const option of this.options) {
-        let disabled = option.hasAttribute("disabled");
+        let disabled = option.hasAttributeNS(null, "disabled");
         const parentNode = domSymbolTree.parent(option);
         if (parentNode &&
           parentNode.nodeName.toUpperCase() === "OPTGROUP" &&
-          parentNode.hasAttribute("disabled")) {
+          parentNode.hasAttributeNS(null, "disabled")) {
           disabled = true;
         }
 
@@ -108,8 +108,8 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   get _displaySize() {
-    if (this.hasAttribute("size")) {
-      const attr = this.getAttribute("size");
+    if (this.hasAttributeNS(null, "size")) {
+      const attr = this.getAttributeNS(null, "size");
       // We don't allow hexadecimal numbers here.
       // eslint-disable-next-line radix
       const size = parseInt(attr, 10);
@@ -117,7 +117,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
         return size;
       }
     }
-    return this.hasAttribute("multiple") ? 4 : 1;
+    return this.hasAttributeNS(null, "multiple") ? 4 : 1;
   }
 
   get options() {
@@ -179,7 +179,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   get type() {
-    return this.hasAttribute("multiple") ? "select-multiple" : "select-one";
+    return this.hasAttributeNS(null, "multiple") ? "select-multiple" : "select-one";
   }
 
   get [idlUtils.supportedPropertyIndices]() {
@@ -226,7 +226,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   _barredFromConstraintValidationSpecialization() {
-    return this.hasAttribute("readonly");
+    return this.hasAttributeNS(null, "readonly");
   }
 
   // Constraint validation: If the element has its required attribute specified,
@@ -238,7 +238,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     if (!this._validity) {
       this._validity = ValidityState.createImpl(this, {
         valueMissing: () => {
-          if (!this.hasAttribute("required")) {
+          if (!this.hasAttributeNS(null, "required")) {
             return false;
           }
           const selectedOptionIndex = this.selectedIndex;
@@ -256,7 +256,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   // element's placeholder label option.
   // https://html.spec.whatwg.org/multipage/form-elements.html#placeholder-label-option
   get _hasPlaceholderOption() {
-    return this.hasAttribute("required") && !this.hasAttribute("multiple") &&
+    return this.hasAttributeNS(null, "required") && !this.hasAttributeNS(null, "multiple") &&
       this._displaySize === 1 && this.options.length > 0 && this.options.item(0).value === "" &&
       this.options.item(0).parentNode._localName !== "optgroup";
   }

--- a/lib/jsdom/living/nodes/HTMLSlotElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSlotElement-impl.js
@@ -13,7 +13,7 @@ class HTMLSlotElementImpl extends HTMLElementImpl {
 
   // https://dom.spec.whatwg.org/#slot-name
   get name() {
-    return this.getAttribute("name") || "";
+    return this.getAttributeNS(null, "name") || "";
   }
 
   _attrModified(name, value, oldValue) {

--- a/lib/jsdom/living/nodes/HTMLSourceElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSourceElement-impl.js
@@ -9,15 +9,15 @@ class HTMLSourceElementImpl extends HTMLElementImpl {
   }
 
   set src(value) {
-    this.setAttribute("src", value);
+    this.setAttributeNS(null, "src", value);
   }
 
   get srcset() {
-    return conversions.USVString(this.getAttribute("srcset"));
+    return conversions.USVString(this.getAttributeNS(null, "srcset"));
   }
 
   set srcset(value) {
-    this.setAttribute("srcset", value);
+    this.setAttributeNS(null, "srcset", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLStyleElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLStyleElement-impl.js
@@ -55,7 +55,7 @@ class HTMLStyleElementImpl extends HTMLElementImpl {
       return;
     }
 
-    const type = this.getAttribute("type");
+    const type = this.getAttributeNS(null, "type");
     if (type !== null && type !== "" && !asciiCaseInsensitiveMatch(type, "text/css")) {
       return;
     }

--- a/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
@@ -26,19 +26,19 @@ function reflectedAttributeClampedToRange(attrValue, min, max, defaultValue = 0)
 
 class HTMLTableCellElementImpl extends HTMLElementImpl {
   get colSpan() {
-    return reflectedAttributeClampedToRange(this.getAttribute("colspan"), 1, 1000, 1);
+    return reflectedAttributeClampedToRange(this.getAttributeNS(null, "colspan"), 1, 1000, 1);
   }
 
   set colSpan(V) {
-    this.setAttribute("colspan", String(V));
+    this.setAttributeNS(null, "colspan", String(V));
   }
 
   get rowSpan() {
-    return reflectedAttributeClampedToRange(this.getAttribute("rowspan"), 0, 65534, 1);
+    return reflectedAttributeClampedToRange(this.getAttributeNS(null, "rowspan"), 0, 65534, 1);
   }
 
   set rowSpan(V) {
-    this.setAttribute("rowspan", String(V));
+    this.setAttributeNS(null, "rowspan", String(V));
   }
 
   get cellIndex() {
@@ -51,7 +51,7 @@ class HTMLTableCellElementImpl extends HTMLElementImpl {
   }
 
   get scope() {
-    let value = this.getAttribute("scope");
+    let value = this.getAttributeNS(null, "scope");
     if (value === null) {
       return "";
     }
@@ -66,7 +66,7 @@ class HTMLTableCellElementImpl extends HTMLElementImpl {
   }
 
   set scope(V) {
-    this.setAttribute("scope", V);
+    this.setAttributeNS(null, "scope", V);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
@@ -175,42 +175,42 @@ class HTMLTextAreaElementImpl extends HTMLElementImpl {
   }
 
   get cols() {
-    if (!this.hasAttribute("cols")) {
+    if (!this.hasAttributeNS(null, "cols")) {
       return 20;
     }
-    return parseInt(this.getAttribute("cols"));
+    return parseInt(this.getAttributeNS(null, "cols"));
   }
 
   set cols(value) {
     if (value <= 0) {
       throw new DOMException("The index is not in the allowed range.", "IndexSizeError");
     }
-    this.setAttribute("cols", String(value));
+    this.setAttributeNS(null, "cols", String(value));
   }
 
   get rows() {
-    if (!this.hasAttribute("rows")) {
+    if (!this.hasAttributeNS(null, "rows")) {
       return 2;
     }
-    return parseInt(this.getAttribute("rows"));
+    return parseInt(this.getAttributeNS(null, "rows"));
   }
 
   set rows(value) {
     if (value <= 0) {
       throw new DOMException("The index is not in the allowed range.", "IndexSizeError");
     }
-    this.setAttribute("rows", String(value));
+    this.setAttributeNS(null, "rows", String(value));
   }
 
   _barredFromConstraintValidationSpecialization() {
-    return this.hasAttribute("readonly");
+    return this.hasAttributeNS(null, "readonly");
   }
 
   // https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-required
   get validity() {
     if (!this._validity) {
       this._validity = ValidityState.createImpl(this, {
-        valueMissing: () => this.hasAttribute("required") && this.value === ""
+        valueMissing: () => this.hasAttributeNS(null, "required") && this.value === ""
       });
     }
     return this._validity;

--- a/lib/jsdom/living/nodes/HTMLTrackElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTrackElement-impl.js
@@ -12,7 +12,7 @@ class HTMLTrackElementImpl extends HTMLElementImpl {
     return reflectURLAttribute(this, "src");
   }
   set src(value) {
-    this.setAttribute("src", value);
+    this.setAttributeNS(null, "src", value);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLVideoElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLVideoElement-impl.js
@@ -9,7 +9,7 @@ class HTMLVideoElementImpl extends HTMLMediaElementImpl {
   }
 
   set poster(value) {
-    this.setAttribute("poster", value);
+    this.setAttributeNS(null, "poster", value);
   }
 
   get videoWidth() {

--- a/lib/jsdom/living/nodes/SVGSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/SVGSVGElement-impl.js
@@ -20,7 +20,7 @@ class SVGSVGElementImpl extends SVGGraphicsElementImpl {
   getElementById(elementId) {
     // TODO: optimize with _ids caching trick; see Document class.
     for (const node of domSymbolTree.treeIterator(this)) {
-      if (node.nodeType === ELEMENT_NODE && node.getAttribute("id") === elementId) {
+      if (node.nodeType === ELEMENT_NODE && node.getAttributeNS(null, "id") === elementId) {
         return node;
       }
     }

--- a/lib/jsdom/living/svg/SVGAnimatedString-impl.js
+++ b/lib/jsdom/living/svg/SVGAnimatedString-impl.js
@@ -9,15 +9,15 @@ class SVGAnimatedStringImpl {
   }
 
   get baseVal() {
-    if (!this._element.hasAttribute(this._attribute)) {
-      if (this._attributeDeprecated !== undefined && this._element.hasAttribute(this._attributeDeprecated)) {
-        return this._element.getAttribute(this._attributeDeprecated);
+    if (!this._element.hasAttributeNS(null, this._attribute)) {
+      if (this._attributeDeprecated !== undefined && this._element.hasAttributeNS(null, this._attributeDeprecated)) {
+        return this._element.getAttributeNS(null, this._attributeDeprecated);
       } else if (this._initialValue !== undefined) {
         return this._initialValue;
       }
       return "";
     }
-    return this._element.getAttribute(this._attribute);
+    return this._element.getAttributeNS(null, this._attribute);
   }
 
   get animVal() {
@@ -25,12 +25,12 @@ class SVGAnimatedStringImpl {
   }
 
   set baseVal(base) {
-    if (!this._element.hasAttribute(this._attribute) &&
+    if (!this._element.hasAttributeNS(null, this._attribute) &&
         this._attributeDeprecated !== undefined &&
-        this._element.hasAttribute(this._attributeDeprecated)) {
-      this._element.setAttribute(this._attributeDeprecated, base);
+        this._element.hasAttributeNS(null, this._attributeDeprecated)) {
+      this._element.setAttributeNS(null, this._attributeDeprecated, base);
     } else {
-      this._element.setAttribute(this._attribute, base);
+      this._element.setAttributeNS(null, this._attribute, base);
     }
   }
 }

--- a/lib/jsdom/living/svg/SVGListBase.js
+++ b/lib/jsdom/living/svg/SVGListBase.js
@@ -30,8 +30,8 @@ class List {
       return;
     }
     let value = [];
-    if (this._element.hasAttribute(this._attribute)) {
-      value = this._attributeRegistryEntry.getValue(this._element.getAttribute(this._attribute));
+    if (this._element.hasAttributeNS(null, this._attribute)) {
+      value = this._attributeRegistryEntry.getValue(this._element.getAttributeNS(null, this._attribute));
     }
     if (value.length === 0 && this._attributeRegistryEntry.initialValue !== undefined) {
       value = this._attributeRegistryEntry.getValue(this._attributeRegistryEntry.initialValue);
@@ -43,7 +43,7 @@ class List {
 
   _reserialize() {
     const elements = this._list;
-    this._element.setAttribute(this._attribute, this._attributeRegistryEntry.serialize(elements));
+    this._element.setAttributeNS(null, this._attribute, this._attributeRegistryEntry.serialize(elements));
     // Prevent ping-ponging back and forth between _reserialize() and _synchronize().
     this._version = this._element._version;
   }

--- a/lib/jsdom/living/xhr/FormData-impl.js
+++ b/lib/jsdom/living/xhr/FormData-impl.js
@@ -114,7 +114,7 @@ function constructTheFormDataSet(form, submitter) {
     if (field.type === "radio" && field._checkedness === false) {
       continue;
     }
-    if (field.type !== "image" && (!field.hasAttribute("name") || field.getAttribute("name") === "")) {
+    if (field.type !== "image" && (!field.hasAttributeNS(null, "name") || field.getAttributeNS(null, "name") === "")) {
       continue;
     }
     if (field.localName === "object") { // in jsdom, no objects are "using a plugin"
@@ -125,7 +125,7 @@ function constructTheFormDataSet(form, submitter) {
 
     // Omit special processing of <input type="image"> since so far we don't actually ever pass submitter
 
-    const nameAttr = field.getAttribute("name");
+    const nameAttr = field.getAttributeNS(null, "name");
     const name = nameAttr === null ? "" : nameAttr;
 
     if (field.localName === "select") {
@@ -135,7 +135,7 @@ function constructTheFormDataSet(form, submitter) {
         }
       }
     } else if (field.localName === "input" && (type === "checkbox" || type === "radio")) {
-      const value = field.hasAttribute("value") ? field.getAttribute("value") : "on";
+      const value = field.hasAttributeNS(null, "value") ? field.getAttributeNS(null, "value") : "on";
       formDataSet.push({ name, value, type });
     } else if (type === "file") {
       for (let i = 0; i < field.files.length; ++i) {
@@ -149,7 +149,7 @@ function constructTheFormDataSet(form, submitter) {
       formDataSet.push({ name, value: field._getValue(), type });
     }
 
-    const dirname = field.getAttribute("dirname");
+    const dirname = field.getAttributeNS(null, "dirname");
     if (dirname !== null && dirname !== "") {
       const dir = "ltr"; // jsdom does not (yet?) implement actual directionality
       formDataSet.push({ name: dirname, value: dir, type: "direction" });

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -107,7 +107,7 @@ exports.memoizeQuery = function memoizeQuery(fn) {
 };
 
 exports.reflectURLAttribute = (elementImpl, contentAttributeName) => {
-  const attributeValue = elementImpl.getAttribute(contentAttributeName);
+  const attributeValue = elementImpl.getAttributeNS(null, contentAttributeName);
   if (attributeValue === null || attributeValue === "") {
     return "";
   }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "st": "^1.2.2",
     "watchify": "^3.11.0",
     "wd": "^1.11.1",
-    "webidl2js": "^9.2.0"
+    "webidl2js": "^9.2.1"
   },
   "browser": {
     "canvas": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4873,10 +4873,10 @@ webidl2@^10.3.3:
   resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-10.3.3.tgz#9e6562df1ecd466dba0cdb713a0db073bbe1039a"
   integrity sha512-C3rxCpkX2XQ9FW1EIllN0nW2zlN21S+PgE59xQ6ErI5awVaXYm3TTsDDsdCYIfwjVwNZZIpKjcW1xJF89ZlAew==
 
-webidl2js@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/webidl2js/-/webidl2js-9.2.0.tgz#ffa31b569dbcc6886f60ce798d65f0cb8012bc43"
-  integrity sha512-OMLUy2yYzOUyFvqcY1Fkxca1kNurE/WpdrQ4gbRif7/59suwAiRGpAg3Uiha2IkTb75gJYN/j76vMWL44YK7Kw==
+webidl2js@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/webidl2js/-/webidl2js-9.2.1.tgz#f7bbf3e2956d99e9c9437971545b3695c6b5234d"
+  integrity sha512-2NMaYDjyCYugmqhMGMCilwtWmoRGDLa43Ws28Vzbf9VjB6Djr9Biu88D0JRvUicigl67OT2GnyEfXcSz5V+A/w==
   dependencies:
     co "^4.6.0"
     pn "^1.1.0"


### PR DESCRIPTION
Following the discussion in https://github.com/jsdom/jsdom/pull/2546.

This includes linting rules to prevent `getAttribute()`, `hasAttribute()`, `removeAttribute()` and `toggleAttribute()` from being used in favour of their NS-alternatives.