### PR TITLE
Fix <option>'s text getter

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+const { CDATA_SECTION_NODE, TEXT_NODE } = require("../node-type");
+const { HTML_NS, SVG_NS } = require("../helpers/namespaces");
 const { stripAndCollapseASCIIWhitespace } = require("../helpers/strings");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const { closest } = require("../helpers/traversal");
@@ -66,9 +68,22 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     return formOwner(this);
   }
 
+  // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-text
   get text() {
-    // TODO is not correctly excluding script and SVG script descendants
-    return stripAndCollapseASCIIWhitespace(this.textContent);
+    let text = "";
+
+    for (const child of domSymbolTree.treeIterator(this)) {
+      if (child.nodeType === TEXT_NODE || child.nodeType === CDATA_SECTION_NODE) {
+        if (child.parentNode.localName === "script" &&
+           (child.parentNode.namespaceURI === HTML_NS || child.parentNode.namespaceURI === SVG_NS)) {
+          continue;
+        }
+
+        text += child.nodeValue;
+      }
+    }
+
+    return stripAndCollapseASCIIWhitespace(text);
   }
   set text(value) {
     this.textContent = value;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -567,8 +567,6 @@ DIR: html/semantics/forms/the-meter-element
 
 DIR: html/semantics/forms/the-option-element
 
-option-text-recurse.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-impl.js]
-
 ---
 
 DIR: html/semantics/forms/the-output-element


### PR DESCRIPTION
It now correctly excludes descendants of HTML and SVG <script> elements.

EDIT: I've realised that this needs a fix and new test. I'll close it in the meantime.