### PR TITLE
Fix HTML serialization breaking after setting certain properties

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -244,6 +244,10 @@ class ElementImpl extends NodeImpl {
   setAttributeNS(namespace, name, value) {
     const extracted = validateNames.validateAndExtract(namespace, name);
 
+    // Because of widespread use of this method internally, e.g. to manually implement attribute/content reflection, we
+    // centralize the conversion to a string here, so that all call sites don't have to do it.
+    value = `${value}`;
+
     attributes.setAttributeValue(this, extracted.localName, value, extracted.prefix, extracted.namespace);
   }
 

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-progress-element/serialization-regression-test.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-progress-element/serialization-regression-test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Regression test for serialization bug with progress.value</title>
+<!-- https://github.com/jsdom/jsdom/issues/2554 -->
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div><progress></progress></div>
+
+<script>
+"use strict";
+
+test(() => {
+  const el = document.querySelector("progress");
+  el.value = 0;
+
+  // Before the jsdom bugfix, this would crash
+  assert_equals(document.querySelector("div").innerHTML, `<progress value="0"></progress>`);
+});
+</script>


### PR DESCRIPTION
Various properties that reflect HTML attributes, e.g. <progress>'s value and max properties, would cause HTML serialization (e.g. via innerHTML) to break after they were set, due to a missing conversion causing jsdom to store the attribute's value as a non-string. This fixes the problem in one central location for robustness, even if it may be more per-spec to fix it all the entry points.

Fixes #2554.

---

I'm curious on collaborators thoughts on this approach. As the commit message notes, it's a tradeoff.