### PR TITLE
Always use "\n" for Blob's native line endings

### DIFF
--- a/lib/jsdom/living/file-api/Blob-impl.js
+++ b/lib/jsdom/living/file-api/Blob-impl.js
@@ -1,9 +1,10 @@
 "use strict";
-const { EOL } = require("os");
 const Blob = require("../generated/Blob");
 
 function convertLineEndingsToNative(s) {
-  return s.replace(/\r\n|\r|\n/g, EOL);
+  // jsdom always pretends to be *nix, for consistency.
+  // See also https://github.com/jsdom/jsdom/issues/2396.
+  return s.replace(/\r\n|\r|\n/g, "\n");
 }
 
 exports.implementation = class BlobImpl {


### PR DESCRIPTION
Closes #2396.