### PR TITLE
Fix MutationObserver _nodeList memory leak

### DIFF
--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -148,23 +148,17 @@ function notifyMutationObservers() {
     const records = [...mo._recordQueue];
     mo._recordQueue = [];
 
-    for (const node of mo._nodeList) {
-      node._registeredObserverList = node._registeredObserverList.filter(registeredObserver => {
-        return registeredObserver.source !== mo;
-      });
+    if (records.length) {
+      try {
+        mo._callback(
+          records.map(idlUtils.wrapperForImpl),
+          idlUtils.wrapperForImpl(mo)
+        );
+      } catch (e) {
+        const { target } = records[0];
+        const window = target._ownerDocument._defaultView;
 
-      if (records.length) {
-        try {
-          mo._callback(
-            records.map(idlUtils.wrapperForImpl),
-            idlUtils.wrapperForImpl(mo)
-          );
-        } catch (e) {
-          const { target } = records[0];
-          const window = target._ownerDocument._defaultView;
-
-          reportException(window, e);
-        }
+        reportException(window, e);
       }
     }
   }

--- a/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
+++ b/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
@@ -15,11 +15,8 @@ class MutationObserverImpl {
   // https://dom.spec.whatwg.org/#dom-mutationobserver-mutationobserver
   constructor(args) {
     const [callback] = args;
-
     this._callback = callback;
-    this._nodeList = [];
     this._recordQueue = [];
-
     this._id = ++mutationObserverId;
   }
 
@@ -52,31 +49,17 @@ class MutationObserverImpl {
     });
 
     if (existingRegisteredObserver) {
-      for (const node of this._nodeList) {
-        node._registeredObserverList = node._registeredObserverList.filter(registeredObserver => {
-          return registeredObserver.source !== existingRegisteredObserver;
-        });
-      }
-
       existingRegisteredObserver.options = options;
     } else {
       target._registeredObserverList.push({
         observer: this,
         options
       });
-
-      this._nodeList.push(target);
     }
   }
 
   // https://dom.spec.whatwg.org/#dom-mutationobserver-disconnect
   disconnect() {
-    for (const node of this._nodeList) {
-      node._registeredObserverList = node._registeredObserverList.filter(registeredObserver => {
-        return registeredObserver.observer !== this;
-      });
-    }
-
     this._recordQueue = [];
   }
 


### PR DESCRIPTION
The MutationObserver kept a `_nodeList` of nodes added to it via `observe()`. When the node was removed from the DOM however, the MO didn't remove its reference to it, causing a memory leak.

From what I can tell, the `_nodeList` isn't actually _really_ needed for anything.

Also, the for-loop in notifying MO's called each MO as many times as it had nodes in the `_nodeList`, when calling each MO once is enough.
