### PR TITLE
pattern should apply to the entire string when computing patternMismatch

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -793,6 +793,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
           let regExp;
           try {
             const pattern = this.getAttributeNS(null, "pattern");
+            // The pattern attribute should be matched against the entire value, not just any subset
             regExp = new RegExp("^(?:" + pattern + ")$", "u");
           } catch (e) {
             return false;

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -792,7 +792,8 @@ class HTMLInputElementImpl extends HTMLElementImpl {
           }
           let regExp;
           try {
-            regExp = new RegExp(this.getAttributeNS(null, "pattern"), "u");
+            const pattern = this.getAttributeNS(null, "pattern");
+            regExp = new RegExp("^(?:" + pattern + ")$", "u");
           } catch (e) {
             return false;
           }

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -497,8 +497,6 @@ formaction.html: [fail, Unknown]
 
 DIR: html/semantics/forms/constraints
 
-form-validation-validity-patternMismatch.html: [fail, https://github.com/jsdom/jsdom/pull/2571]
-
 ---
 
 DIR: html/semantics/forms/form-control-infrastructure


### PR DESCRIPTION
This closes #2494.

This will also require an update of the web platforms tests, specifically form-validation-validity-patternMismatch.html

The test change submitted against web platform tests: https://github.com/web-platform-tests/wpt/pull/16577