### PR TITLE
Implement the translate attribute

### DIFF
--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -35,6 +35,30 @@ class HTMLElementImpl extends ElementImpl {
     }
   }
 
+  // https://html.spec.whatwg.org/multipage/dom.html#the-translate-attribute
+  get translate() {
+    const translateAttr = this.getAttributeNS(null, "translate");
+
+    if (translateAttr === "yes" || translateAttr === "") {
+      return true;
+    } else if (translateAttr === "no") {
+      return false;
+    }
+
+    if (this === this.ownerDocument.documentElement) {
+      return true;
+    }
+
+    return this.parentElement && this.parentElement.translate;
+  }
+  set translate(value) {
+    if (value === true) {
+      this.setAttributeNS(null, "translate", "yes");
+    } else {
+      this.setAttributeNS(null, "translate", "no");
+    }
+  }
+
   click() {
     // https://html.spec.whatwg.org/multipage/interaction.html#dom-click
     // https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-synthetic-mouse-event

--- a/lib/jsdom/living/nodes/HTMLElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLElement.webidl
@@ -4,7 +4,7 @@ interface HTMLElement : Element {
   // metadata attributes
   [CEReactions, Reflect] attribute DOMString title;
   [CEReactions, Reflect] attribute DOMString lang;
-//  [CEReactions] attribute boolean translate;
+  [CEReactions] attribute boolean translate;
   [CEReactions] attribute DOMString dir;
   [SameObject] readonly attribute DOMStringMap dataset;
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -360,12 +360,6 @@ the-lang-attribute-007.html: [fail, Unknown]
 the-lang-attribute-008.html: [fail, Unknown]
 the-lang-attribute-009.html: [fail, Unknown]
 the-lang-attribute-010.html: [fail, Unknown]
-the-translate-attribute-007.html: [fail, Unknown]
-the-translate-attribute-008.html: [fail, Unknown]
-the-translate-attribute-009.html: [fail, Unknown]
-the-translate-attribute-010.html: [fail, Unknown]
-the-translate-attribute-011.html: [fail, Unknown]
-the-translate-attribute-012.html: [fail, Unknown]
 
 ---
 


### PR DESCRIPTION
Implemented based on https://html.spec.whatwg.org/multipage/dom.html#the-translate-attribute, with the current translation mode computed on access.