### PR TITLE
Some Web IDL updates

### DIFF
--- a/lib/jsdom/living/attributes/NamedNodeMap.webidl
+++ b/lib/jsdom/living/attributes/NamedNodeMap.webidl
@@ -1,8 +1,8 @@
 [Exposed=Window, LegacyUnenumerableNamedProperties]
 interface NamedNodeMap {
   readonly attribute unsigned long length;
-  [WebIDL2JSValueAsUnsupported=null] getter Attr? item(unsigned long index);
-  [WebIDL2JSValueAsUnsupported=null] getter Attr? getNamedItem(DOMString qualifiedName);
+  [WebIDL2JSValueAsUnsupported=_null] getter Attr? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter Attr? getNamedItem(DOMString qualifiedName);
   Attr? getNamedItemNS(DOMString? namespace, DOMString localName);
   [CEReactions] Attr? setNamedItem(Attr attr);
   [CEReactions] Attr? setNamedItemNS(Attr attr);

--- a/lib/jsdom/living/file-api/FileList.webidl
+++ b/lib/jsdom/living/file-api/FileList.webidl
@@ -1,5 +1,5 @@
 [Exposed=(Window,Worker), Serializable]
 interface FileList {
-  [WebIDL2JSValueAsUnsupported=null] getter File? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter File? item(unsigned long index);
   readonly attribute unsigned long length;
 };

--- a/lib/jsdom/living/navigator/Navigator.webidl
+++ b/lib/jsdom/living/navigator/Navigator.webidl
@@ -55,16 +55,16 @@ interface NavigatorPlugins {
 interface PluginArray {
   void refresh(optional boolean reload = false);
   readonly attribute unsigned long length;
-  [WebIDL2JSValueAsUnsupported=null] getter Plugin? item(unsigned long index);
-  [WebIDL2JSValueAsUnsupported=null] getter Plugin? namedItem(DOMString name);
+  [WebIDL2JSValueAsUnsupported=_null] getter Plugin? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter Plugin? namedItem(DOMString name);
 };
 
 [Exposed=Window,
  LegacyUnenumerableNamedProperties]
 interface MimeTypeArray {
   readonly attribute unsigned long length;
-  [WebIDL2JSValueAsUnsupported=null] getter MimeType? item(unsigned long index);
-  [WebIDL2JSValueAsUnsupported=null] getter MimeType? namedItem(DOMString name);
+  [WebIDL2JSValueAsUnsupported=_null] getter MimeType? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter MimeType? namedItem(DOMString name);
 };
 
 [Exposed=Window,
@@ -74,8 +74,8 @@ interface Plugin {
   readonly attribute DOMString description;
   readonly attribute DOMString filename;
   readonly attribute unsigned long length;
-  [WebIDL2JSValueAsUnsupported=null] getter MimeType? item(unsigned long index);
-  [WebIDL2JSValueAsUnsupported=null] getter MimeType? namedItem(DOMString name);
+  [WebIDL2JSValueAsUnsupported=_null] getter MimeType? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter MimeType? namedItem(DOMString name);
 };
 
 [Exposed=Window]

--- a/lib/jsdom/living/navigator/Navigator.webidl
+++ b/lib/jsdom/living/navigator/Navigator.webidl
@@ -1,17 +1,18 @@
+// https://html.spec.whatwg.org/#navigator
 [Exposed=Window]
 interface Navigator {
   // objects implementing this interface also implement the interfaces given below
 };
-Navigator implements NavigatorID;
-Navigator implements NavigatorLanguage;
-Navigator implements NavigatorOnLine;
-// Navigator implements NavigatorContentUtils;
-Navigator implements NavigatorCookies;
-Navigator implements NavigatorPlugins;
-Navigator implements NavigatorConcurrentHardware;
+Navigator includes NavigatorID;
+Navigator includes NavigatorLanguage;
+Navigator includes NavigatorOnLine;
+// Navigator includes NavigatorContentUtils;
+Navigator includes NavigatorCookies;
+Navigator includes NavigatorPlugins;
+Navigator includes NavigatorConcurrentHardware;
 
-[NoInterfaceObject, Exposed=(Window,Worker)]
-interface NavigatorID {
+// https://html.spec.whatwg.org/#navigatorid
+interface mixin NavigatorID {
   readonly attribute DOMString appCodeName; // constant "Mozilla"
   readonly attribute DOMString appName; // constant "Netscape"
   readonly attribute DOMString appVersion;
@@ -21,35 +22,32 @@ interface NavigatorID {
   readonly attribute DOMString userAgent;
   [Exposed=Window] readonly attribute DOMString vendor;
   [Exposed=Window] readonly attribute DOMString vendorSub; // constant ""
-
-  // also has additional members in a partial interface
 };
 
-[NoInterfaceObject, Exposed=(Window,Worker)]
-interface NavigatorLanguage {
+// https://html.spec.whatwg.org/#navigatorlanguage
+interface mixin NavigatorLanguage {
   readonly attribute DOMString language;
   readonly attribute FrozenArray<DOMString> languages;
 };
 
-[NoInterfaceObject, Exposed=(Window,Worker)]
-interface NavigatorOnLine {
+// https://html.spec.whatwg.org/#navigatoronline
+interface mixin NavigatorOnLine {
   readonly attribute boolean onLine;
 };
 
-[Exposed=Window,
- NoInterfaceObject]
-interface NavigatorCookies {
+// https://html.spec.whatwg.org/#navigatorcookies
+interface mixin NavigatorCookies {
   readonly attribute boolean cookieEnabled;
 };
 
-[Exposed=Window,
- NoInterfaceObject]
-interface NavigatorPlugins {
+// https://html.spec.whatwg.org/#navigatorplugins
+interface mixin NavigatorPlugins {
   [SameObject] readonly attribute PluginArray plugins;
   [SameObject] readonly attribute MimeTypeArray mimeTypes;
   boolean javaEnabled();
 };
 
+// https://html.spec.whatwg.org/#pluginarray
 [Exposed=Window,
  LegacyUnenumerableNamedProperties]
 interface PluginArray {
@@ -59,6 +57,7 @@ interface PluginArray {
   [WebIDL2JSValueAsUnsupported=_null] getter Plugin? namedItem(DOMString name);
 };
 
+// https://html.spec.whatwg.org/#mimetypearray
 [Exposed=Window,
  LegacyUnenumerableNamedProperties]
 interface MimeTypeArray {
@@ -67,6 +66,7 @@ interface MimeTypeArray {
   [WebIDL2JSValueAsUnsupported=_null] getter MimeType? namedItem(DOMString name);
 };
 
+// https://html.spec.whatwg.org/#dom-plugin
 [Exposed=Window,
  LegacyUnenumerableNamedProperties]
 interface Plugin {
@@ -78,6 +78,7 @@ interface Plugin {
   [WebIDL2JSValueAsUnsupported=_null] getter MimeType? namedItem(DOMString name);
 };
 
+// https://html.spec.whatwg.org/#mimetype
 [Exposed=Window]
 interface MimeType {
   readonly attribute DOMString type;
@@ -86,7 +87,7 @@ interface MimeType {
   readonly attribute Plugin enabledPlugin;
 };
 
-[NoInterfaceObject, Exposed=(Window,Worker)]
-interface NavigatorConcurrentHardware {
+// https://html.spec.whatwg.org/#navigatorconcurrenthardware
+interface mixin NavigatorConcurrentHardware {
   readonly attribute unsigned long long hardwareConcurrency;
 };

--- a/lib/jsdom/living/nodes/ChildNode.webidl
+++ b/lib/jsdom/living/nodes/ChildNode.webidl
@@ -1,11 +1,10 @@
-[NoInterfaceObject,
- Exposed=Window]
-interface ChildNode {
+// https://dom.spec.whatwg.org/#childnode
+interface mixin ChildNode {
   [CEReactions, Unscopable] void before((Node or DOMString)... nodes);
   [CEReactions, Unscopable] void after((Node or DOMString)... nodes);
   [CEReactions, Unscopable] void replaceWith((Node or DOMString)... nodes);
   [CEReactions, Unscopable] void remove();
 };
-DocumentType implements ChildNode;
-Element implements ChildNode;
-CharacterData implements ChildNode;
+DocumentType includes ChildNode;
+Element includes ChildNode;
+CharacterData includes ChildNode;

--- a/lib/jsdom/living/nodes/DOMTokenList.webidl
+++ b/lib/jsdom/living/nodes/DOMTokenList.webidl
@@ -1,7 +1,7 @@
 [Exposed=Window]
 interface DOMTokenList {
   readonly attribute unsigned long length;
-  [WebIDL2JSValueAsUnsupported=null] getter DOMString? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter DOMString? item(unsigned long index);
   boolean contains(DOMString token);
   [CEReactions] void add(DOMString... tokens);
   [CEReactions] void remove(DOMString... tokens);

--- a/lib/jsdom/living/nodes/Document.webidl
+++ b/lib/jsdom/living/nodes/Document.webidl
@@ -1,3 +1,4 @@
+// https://dom.spec.whatwg.org/#document
 [Constructor,
  Exposed=Window]
 interface Document : Node {
@@ -101,8 +102,8 @@ partial interface Document {
   // special event handler IDL attributes that only apply to Document objects
   [LenientThis] attribute EventHandler onreadystatechange;
 };
-Document implements GlobalEventHandlers;
-// Document implements DocumentAndElementEventHandlers;
+Document includes GlobalEventHandlers;
+// Document includes DocumentAndElementEventHandlers;
 
 // https://html.spec.whatwg.org/#Document-partial
 partial interface Document {

--- a/lib/jsdom/living/nodes/Element.webidl
+++ b/lib/jsdom/living/nodes/Element.webidl
@@ -1,3 +1,4 @@
+// https://dom.spec.whatwg.org/#element
 [Exposed=Window]
 interface Element : Node {
   readonly attribute DOMString? namespaceURI;
@@ -88,5 +89,3 @@ partial interface Element {
   readonly attribute long clientWidth;
   readonly attribute long clientHeight;
 };
-
-Element implements Slotable;

--- a/lib/jsdom/living/nodes/ElementCSSInlineStyle.webidl
+++ b/lib/jsdom/living/nodes/ElementCSSInlineStyle.webidl
@@ -1,8 +1,7 @@
-[Exposed=Window,
- NoInterfaceObject]
-interface ElementCSSInlineStyle {
+// https://drafts.csswg.org/cssom/#elementcssinlinestyle
+interface mixin ElementCSSInlineStyle {
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 
-HTMLElement implements ElementCSSInlineStyle;
-SVGElement implements ElementCSSInlineStyle;
+HTMLElement includes ElementCSSInlineStyle;
+SVGElement includes ElementCSSInlineStyle;

--- a/lib/jsdom/living/nodes/ElementContentEditable.webidl
+++ b/lib/jsdom/living/nodes/ElementContentEditable.webidl
@@ -1,6 +1,6 @@
-[Exposed=Window,
- NoInterfaceObject]
-interface ElementContentEditable {
+interface mixin ElementContentEditable {
 //  [CEReactions] attribute DOMString contentEditable;
+//  [CEReactions] attribute DOMString enterKeyHint;
 //  readonly attribute boolean isContentEditable;
+//  [CEReactions] attribute DOMString inputMode;
 };

--- a/lib/jsdom/living/nodes/GlobalEventHandlers.webidl
+++ b/lib/jsdom/living/nodes/GlobalEventHandlers.webidl
@@ -1,6 +1,5 @@
-[Exposed=Window,
- NoInterfaceObject]
-interface GlobalEventHandlers {
+// https://html.spec.whatwg.org/#globaleventhandlers
+interface mixin GlobalEventHandlers {
   attribute EventHandler onabort;
   attribute EventHandler onauxclick;
   attribute EventHandler onblur;

--- a/lib/jsdom/living/nodes/HTMLAnchorElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLAnchorElement.webidl
@@ -1,3 +1,4 @@
+// https://html.spec.whatwg.org/#htmlanchorelement
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLAnchorElement : HTMLElement {
@@ -15,7 +16,7 @@ interface HTMLAnchorElement : HTMLElement {
 
   // also has obsolete members
 };
-HTMLAnchorElement implements HTMLHyperlinkElementUtils;
+HTMLAnchorElement includes HTMLHyperlinkElementUtils;
 
 partial interface HTMLAnchorElement {
   [CEReactions, Reflect] attribute DOMString coords;

--- a/lib/jsdom/living/nodes/HTMLAreaElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLAreaElement.webidl
@@ -1,3 +1,4 @@
+// https://html.spec.whatwg.org/#htmlareaelement
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLAreaElement : HTMLElement {
@@ -13,7 +14,7 @@ interface HTMLAreaElement : HTMLElement {
 
   // also has obsolete members
 };
-HTMLAreaElement implements HTMLHyperlinkElementUtils;
+HTMLAreaElement includes HTMLHyperlinkElementUtils;
 
 partial interface HTMLAreaElement {
   [CEReactions, Reflect] attribute boolean noHref;

--- a/lib/jsdom/living/nodes/HTMLBodyElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLBodyElement.webidl
@@ -1,11 +1,13 @@
+// https://html.spec.whatwg.org/#htmlbodyelement
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLBodyElement : HTMLElement {
   // also has obsolete members
 };
 
-HTMLBodyElement implements WindowEventHandlers;
+HTMLBodyElement includes WindowEventHandlers;
 
+// https://html.spec.whatwg.org/#HTMLBodyElement-partial
 partial interface HTMLBodyElement {
   [CEReactions, Reflect] attribute [TreatNullAs=EmptyString] DOMString text;
   [CEReactions, Reflect] attribute [TreatNullAs=EmptyString] DOMString link;

--- a/lib/jsdom/living/nodes/HTMLCollection.webidl
+++ b/lib/jsdom/living/nodes/HTMLCollection.webidl
@@ -1,6 +1,6 @@
 [Exposed=Window, LegacyUnenumerableNamedProperties]
 interface HTMLCollection {
   readonly attribute unsigned long length;
-  [WebIDL2JSValueAsUnsupported=null] getter Element? item(unsigned long index);
-  [WebIDL2JSValueAsUnsupported=null] getter Element? namedItem(DOMString name);
+  [WebIDL2JSValueAsUnsupported=_null] getter Element? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter Element? namedItem(DOMString name);
 };

--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -4,7 +4,7 @@ const ElementImpl = require("./Element-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
 const ElementCSSInlineStyleImpl = require("./ElementCSSInlineStyle-impl").implementation;
 const GlobalEventHandlersImpl = require("./GlobalEventHandlers-impl").implementation;
-const HTMLAndSVGElementSharedImpl = require("./HTMLAndSVGElementShared-impl").implementation;
+const HTMLOrSVGElementImpl = require("./HTMLOrSVGElement-impl").implementation;
 const { firstChildWithLocalName } = require("../helpers/traversal");
 const { isDisabled } = require("../helpers/form-controls");
 const { fireAnEvent } = require("../helpers/events");
@@ -12,7 +12,7 @@ const { fireAnEvent } = require("../helpers/events");
 class HTMLElementImpl extends ElementImpl {
   constructor(args, privateData) {
     super(args, privateData);
-    this._initHTMLAndSVGElement();
+    this._initHTMLOrSVGElement();
     this._initElementCSSInlineStyle();
     this._initGlobalEvents();
 
@@ -151,7 +151,7 @@ class HTMLElementImpl extends ElementImpl {
 
 mixin(HTMLElementImpl.prototype, ElementCSSInlineStyleImpl.prototype);
 mixin(HTMLElementImpl.prototype, GlobalEventHandlersImpl.prototype);
-mixin(HTMLElementImpl.prototype, HTMLAndSVGElementSharedImpl.prototype);
+mixin(HTMLElementImpl.prototype, HTMLOrSVGElementImpl.prototype);
 
 module.exports = {
   implementation: HTMLElementImpl

--- a/lib/jsdom/living/nodes/HTMLElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLElement.webidl
@@ -1,3 +1,4 @@
+// https://html.spec.whatwg.org/#htmlelement
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLElement : Element {
@@ -24,9 +25,10 @@ interface HTMLElement : Element {
 //  [CEReactions] attribute [TreatNullAs=EmptyString] DOMString innerText;
 };
 
-HTMLElement implements GlobalEventHandlers;
-// HTMLElement implements DocumentAndElementEventHandlers;
-HTMLElement implements ElementContentEditable;
+HTMLElement includes GlobalEventHandlers;
+// HTMLElement includes DocumentAndElementEventHandlers;
+HTMLElement includes ElementContentEditable;
+// HTMLElement includes HTMLOrSVGElement;
 
 // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
 partial interface HTMLElement {

--- a/lib/jsdom/living/nodes/HTMLElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLElement.webidl
@@ -7,28 +7,25 @@ interface HTMLElement : Element {
   [CEReactions, Reflect] attribute DOMString lang;
   [CEReactions] attribute boolean translate;
   [CEReactions] attribute DOMString dir;
-  [SameObject] readonly attribute DOMStringMap dataset;
 
   // user interaction
   [CEReactions, Reflect] attribute boolean hidden;
   void click();
-  [CEReactions] attribute long tabIndex;
-//  We don't support FocusOptions yet
-//  void focus(optional FocusOptions options);
-  void focus();
-  void blur();
   [CEReactions, Reflect] attribute DOMString accessKey;
 //  readonly attribute DOMString accessKeyLabel;
   [CEReactions] attribute boolean draggable;
 //  [CEReactions] attribute boolean spellcheck;
+//  [CEReactions] attribute DOMString autocapitalize;
 
 //  [CEReactions] attribute [TreatNullAs=EmptyString] DOMString innerText;
+
+//  ElementInternals attachInternals();
 };
 
 HTMLElement includes GlobalEventHandlers;
 // HTMLElement includes DocumentAndElementEventHandlers;
 HTMLElement includes ElementContentEditable;
-// HTMLElement includes HTMLOrSVGElement;
+HTMLElement includes HTMLOrSVGElement;
 
 // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
 partial interface HTMLElement {

--- a/lib/jsdom/living/nodes/HTMLFrameSetElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLFrameSetElement.webidl
@@ -1,7 +1,8 @@
+// https://html.spec.whatwg.org/#htmlframesetelement
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLFrameSetElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString cols;
   [CEReactions, Reflect] attribute DOMString rows;
 };
-HTMLFrameSetElement implements WindowEventHandlers;
+HTMLFrameSetElement includes WindowEventHandlers;

--- a/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils.webidl
+++ b/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils.webidl
@@ -1,6 +1,5 @@
-[Exposed=Window,
- NoInterfaceObject]
-interface HTMLHyperlinkElementUtils {
+// https://html.spec.whatwg.org/#htmlhyperlinkelementutils
+interface mixin HTMLHyperlinkElementUtils {
   [CEReactions] stringifier attribute USVString href;
   readonly attribute USVString origin;
   [CEReactions] attribute USVString protocol;

--- a/lib/jsdom/living/nodes/HTMLLinkElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLLinkElement.webidl
@@ -8,7 +8,6 @@ interface HTMLLinkElement : HTMLElement {
 //  [CEReactions] attribute DOMString as; // (default "")
   [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
   [CEReactions, Reflect] attribute DOMString media;
-//  [CEReactions] attribute DOMString nonce;
 //  [CEReactions] attribute DOMString integrity;
   [CEReactions, Reflect] attribute DOMString hreflang;
   [CEReactions, Reflect] attribute DOMString type;

--- a/lib/jsdom/living/nodes/HTMLLinkElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLLinkElement.webidl
@@ -1,3 +1,4 @@
+// https://html.spec.whatwg.org/#htmllinkelement
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLLinkElement : HTMLElement {
@@ -12,15 +13,15 @@ interface HTMLLinkElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString hreflang;
   [CEReactions, Reflect] attribute DOMString type;
 //  [SameObject, PutForwards=value] readonly attribute DOMTokenList sizes;
+//  [CEReactions] attribute USVString imageSrcset;
+//  [CEReactions] attribute DOMString imageSizes;
 //  [CEReactions] attribute DOMString referrerPolicy;
-//  [CEReactions] attribute USVString scope;
-//  [CEReactions] attribute DOMString workerType;
-//  [CEReactions] attribute DOMString updateViaCache;
 
   // also has obsolete members
 };
-HTMLLinkElement implements LinkStyle;
+HTMLLinkElement includes LinkStyle;
 
+// https://html.spec.whatwg.org/#HTMLLinkElement-partial
 partial interface HTMLLinkElement {
   [CEReactions, Reflect] attribute DOMString charset;
   [CEReactions, Reflect] attribute DOMString rev;

--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -4,8 +4,8 @@ const conversions = require("webidl-conversions");
 const focusing = require("../helpers/focusing");
 const DOMStringMap = require("../generated/DOMStringMap");
 
-class HTMLAndSVGElementSharedImpl {
-  _initHTMLAndSVGElement() {
+class HTMLOrSVGElementImpl {
+  _initHTMLOrSVGElement() {
     this._tabIndex = 0;
     this._dataset = DOMStringMap.createImpl([], { element: this });
   }
@@ -53,4 +53,4 @@ class HTMLAndSVGElementSharedImpl {
   }
 }
 
-exports.implementation = HTMLAndSVGElementSharedImpl;
+exports.implementation = HTMLOrSVGElementImpl;

--- a/lib/jsdom/living/nodes/HTMLOrSVGElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement.webidl
@@ -1,0 +1,11 @@
+interface mixin HTMLOrSVGElement {
+  [SameObject] readonly attribute DOMStringMap dataset;
+// TODO: Shouldn't be directly [Reflect]ed
+  [Reflect] attribute DOMString nonce; // intentionally no [CEReactions]
+
+  [CEReactions] attribute long tabIndex;
+//  We don't support FocusOptions yet
+//  void focus(optional FocusOptions options);
+  void focus();
+  void blur();
+};

--- a/lib/jsdom/living/nodes/HTMLScriptElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLScriptElement.webidl
@@ -8,7 +8,6 @@ interface HTMLScriptElement : HTMLElement {
   [CEReactions, Reflect] attribute boolean defer;
   [CEReactions, Reflect] attribute DOMString? crossOrigin;
   [CEReactions] attribute DOMString text;
-  [CEReactions, Reflect] attribute DOMString nonce;
 //  [CEReactions, Reflect] attribute DOMString integrity;
 
 

--- a/lib/jsdom/living/nodes/HTMLSelectElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLSelectElement.webidl
@@ -14,7 +14,7 @@ interface HTMLSelectElement : HTMLElement {
 
   [SameObject] readonly attribute HTMLOptionsCollection options;
   [CEReactions] attribute unsigned long length;
-  [WebIDL2JSValueAsUnsupported=null] getter Element? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter Element? item(unsigned long index);
   HTMLOptionElement? namedItem(DOMString name);
   [CEReactions] void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
   [CEReactions] void remove(); // ChildNode overload

--- a/lib/jsdom/living/nodes/HTMLStyleElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLStyleElement.webidl
@@ -3,7 +3,6 @@
  HTMLConstructor]
 interface HTMLStyleElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString media;
-  [CEReactions, Reflect] attribute DOMString nonce;
 
   // also has obsolete members
 };

--- a/lib/jsdom/living/nodes/HTMLStyleElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLStyleElement.webidl
@@ -1,3 +1,4 @@
+// https://html.spec.whatwg.org/#htmlstyleelement
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLStyleElement : HTMLElement {
@@ -6,8 +7,9 @@ interface HTMLStyleElement : HTMLElement {
 
   // also has obsolete members
 };
-HTMLStyleElement implements LinkStyle;
+HTMLStyleElement includes LinkStyle;
 
+// https://html.spec.whatwg.org/#HTMLStyleElement-partial
 partial interface HTMLStyleElement {
   [CEReactions, Reflect] attribute DOMString type;
 };

--- a/lib/jsdom/living/nodes/LinkStyle.webidl
+++ b/lib/jsdom/living/nodes/LinkStyle.webidl
@@ -1,5 +1,4 @@
-[Exposed=Window,
- NoInterfaceObject]
-interface LinkStyle {
+// https://drafts.csswg.org/cssom/#linkstyle
+interface mixin LinkStyle {
   readonly attribute StyleSheet? sheet;
 };

--- a/lib/jsdom/living/nodes/NodeList.webidl
+++ b/lib/jsdom/living/nodes/NodeList.webidl
@@ -1,6 +1,6 @@
 [Exposed=Window]
 interface NodeList {
-  [WebIDL2JSValueAsUnsupported=null] getter Node? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=_null] getter Node? item(unsigned long index);
   readonly attribute unsigned long length;
   iterable<Node>;
 };

--- a/lib/jsdom/living/nodes/NonDocumentTypeChildNode.webidl
+++ b/lib/jsdom/living/nodes/NonDocumentTypeChildNode.webidl
@@ -1,8 +1,7 @@
-[NoInterfaceObject,
- Exposed=Window]
-interface NonDocumentTypeChildNode {
+// https://dom.spec.whatwg.org/#nondocumenttypechildnode
+interface mixin NonDocumentTypeChildNode {
   readonly attribute Element? previousElementSibling;
   readonly attribute Element? nextElementSibling;
 };
-Element implements NonDocumentTypeChildNode;
-CharacterData implements NonDocumentTypeChildNode;
+Element includes NonDocumentTypeChildNode;
+CharacterData includes NonDocumentTypeChildNode;

--- a/lib/jsdom/living/nodes/NonElementParentNode.webidl
+++ b/lib/jsdom/living/nodes/NonElementParentNode.webidl
@@ -1,7 +1,6 @@
-[NoInterfaceObject,
- Exposed=Window]
-interface NonElementParentNode {
+// https://dom.spec.whatwg.org/#nonelementparentnode
+interface mixin NonElementParentNode {
   Element? getElementById(DOMString elementId);
 };
-Document implements NonElementParentNode;
-DocumentFragment implements NonElementParentNode;
+Document includes NonElementParentNode;
+DocumentFragment includes NonElementParentNode;

--- a/lib/jsdom/living/nodes/ParentNode.webidl
+++ b/lib/jsdom/living/nodes/ParentNode.webidl
@@ -1,6 +1,5 @@
-[NoInterfaceObject,
- Exposed=Window]
-interface ParentNode {
+// https://dom.spec.whatwg.org/#parentnode
+interface mixin ParentNode {
   [SameObject] readonly attribute HTMLCollection children;
   readonly attribute Element? firstElementChild;
   readonly attribute Element? lastElementChild;
@@ -12,6 +11,6 @@ interface ParentNode {
   Element? querySelector(DOMString selectors);
   [NewObject] NodeList querySelectorAll(DOMString selectors);
 };
-Document implements ParentNode;
-DocumentFragment implements ParentNode;
-Element implements ParentNode;
+Document includes ParentNode;
+DocumentFragment includes ParentNode;
+Element includes ParentNode;

--- a/lib/jsdom/living/nodes/SVGElement-impl.js
+++ b/lib/jsdom/living/nodes/SVGElement-impl.js
@@ -7,12 +7,12 @@ const SVGAnimatedString = require("../generated/SVGAnimatedString");
 const ElementImpl = require("./Element-impl").implementation;
 const ElementCSSInlineStyleImpl = require("./ElementCSSInlineStyle-impl").implementation;
 const GlobalEventHandlersImpl = require("./GlobalEventHandlers-impl").implementation;
-const HTMLAndSVGElementSharedImpl = require("./HTMLAndSVGElementShared-impl").implementation;
+const HTMLOrSVGElementImpl = require("./HTMLOrSVGElement-impl").implementation;
 
 class SVGElementImpl extends ElementImpl {
   constructor(args, privateData) {
     super(args, privateData);
-    this._initHTMLAndSVGElement();
+    this._initHTMLOrSVGElement();
     this._initElementCSSInlineStyle();
     this._initGlobalEvents();
   }
@@ -46,6 +46,6 @@ SVGElementImpl.attributeRegistry = new Map();
 
 mixin(SVGElementImpl.prototype, ElementCSSInlineStyleImpl.prototype);
 mixin(SVGElementImpl.prototype, GlobalEventHandlersImpl.prototype);
-mixin(SVGElementImpl.prototype, HTMLAndSVGElementSharedImpl.prototype);
+mixin(SVGElementImpl.prototype, HTMLOrSVGElementImpl.prototype);
 
 exports.implementation = SVGElementImpl;

--- a/lib/jsdom/living/nodes/SVGElement.webidl
+++ b/lib/jsdom/living/nodes/SVGElement.webidl
@@ -14,5 +14,5 @@ interface SVGElement : Element {
   void blur();
 };
 
-SVGElement implements GlobalEventHandlers;
-// SVGElement implements SVGElementInstance;
+SVGElement includes GlobalEventHandlers;
+// SVGElement includes SVGElementInstance;

--- a/lib/jsdom/living/nodes/SVGElement.webidl
+++ b/lib/jsdom/living/nodes/SVGElement.webidl
@@ -4,15 +4,11 @@ interface SVGElement : Element {
   // TODO: implement reflection in webidl2js
   [SameObject] readonly attribute SVGAnimatedString className;
 
-  [SameObject] readonly attribute DOMStringMap dataset;
-
   readonly attribute SVGSVGElement? ownerSVGElement;
   readonly attribute SVGElement? viewportElement;
-
-  attribute long tabIndex;
-  void focus();
-  void blur();
 };
 
 SVGElement includes GlobalEventHandlers;
+// SVGElement includes DocumentAndElementEventHandlers;
 // SVGElement includes SVGElementInstance;
+SVGElement includes HTMLOrSVGElement;

--- a/lib/jsdom/living/nodes/SVGSVGElement.webidl
+++ b/lib/jsdom/living/nodes/SVGSVGElement.webidl
@@ -35,6 +35,6 @@ interface SVGSVGElement : SVGGraphicsElement {
   void forceRedraw();
 };
 
-// SVGSVGElement implements SVGFitToViewBox;
-// SVGSVGElement implements SVGZoomAndPan;
-SVGSVGElement implements WindowEventHandlers;
+// SVGSVGElement includes SVGFitToViewBox;
+// SVGSVGElement includes SVGZoomAndPan;
+SVGSVGElement includes WindowEventHandlers;

--- a/lib/jsdom/living/nodes/Slotable.webidl
+++ b/lib/jsdom/living/nodes/Slotable.webidl
@@ -1,5 +1,6 @@
-// Slotable is a mixin rather than an interface
-// Waiting for https://github.com/jsdom/webidl2js/commit/92598ce3ec39342e27a3ad090a373b20f3b99626
-interface Slotable {
+// https://dom.spec.whatwg.org/#slotable
+interface mixin Slotable {
   readonly attribute HTMLSlotElement? assignedSlot;
 };
+Element includes Slotable;
+Text includes Slotable;

--- a/lib/jsdom/living/nodes/Text.webidl
+++ b/lib/jsdom/living/nodes/Text.webidl
@@ -1,8 +1,7 @@
+// https://dom.spec.whatwg.org/#text
 [Constructor(optional DOMString data = ""),
  Exposed=Window]
 interface Text : CharacterData {
   [NewObject] Text splitText(unsigned long offset);
   readonly attribute DOMString wholeText;
 };
-
-Text implements Slotable;

--- a/lib/jsdom/living/nodes/WindowEventHandlers.webidl
+++ b/lib/jsdom/living/nodes/WindowEventHandlers.webidl
@@ -1,6 +1,4 @@
-[Exposed=Window,
- NoInterfaceObject]
-interface WindowEventHandlers {
+interface mixin WindowEventHandlers {
   attribute EventHandler onafterprint;
   attribute EventHandler onbeforeprint;
   attribute OnBeforeUnloadEventHandler onbeforeunload;

--- a/lib/jsdom/living/webstorage/Storage.webidl
+++ b/lib/jsdom/living/webstorage/Storage.webidl
@@ -2,7 +2,7 @@
 interface Storage {
   readonly attribute unsigned long length;
   DOMString? key(unsigned long index);
-  [WebIDL2JSValueAsUnsupported=null] getter DOMString? getItem(DOMString key);
+  [WebIDL2JSValueAsUnsupported=_null] getter DOMString? getItem(DOMString key);
   setter void setItem(DOMString key, DOMString value);
   deleter void removeItem(DOMString key);
   void clear();


### PR DESCRIPTION
- Escape `null` in [`WebIDL2JSValueAsUnsupported`] per jsdom/webidl2js#117
- Use interface mixins per #2596
- Add `HTMLOrSVGElement` interface mixin to replace our current home-baked `HTMLAndSVGElementShared`
- Add source URLs to a bunch of IDL files