### PR TITLE
Add canvas as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,14 @@
   "_dependenciesComments": {
     "parse5": "Pinned to exact version number because we monkeypatch its internals (see htmltodom.js)"
   },
+  "peerDependencies": {
+    "canvas": "^2.5.0"
+  },
+  "peerDependenciesMeta": {
+    "canvas": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "benchmark": "1.0.0",
     "browserify": "^16.2.3",


### PR DESCRIPTION
Following the discussion in https://github.com/jsdom/jsdom/issues/2603. This may cause a warning to appear in npm during installation as it doesn't currently support optional peer dependencies.