### PR TITLE
Add stubs for scroll, scrollBy, and scrollTo functions on window

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -620,9 +620,9 @@ function Window(options) {
     prompt: notImplementedMethod("window.prompt"),
     resizeBy: notImplementedMethod("window.resizeBy"),
     resizeTo: notImplementedMethod("window.resizeTo"),
-    scroll: notImplementedMethod("window.scroll"),
-    scrollBy: notImplementedMethod("window.scrollBy"),
-    scrollTo: notImplementedMethod("window.scrollTo")
+    scroll: () => {},
+    scrollBy: () => {},
+    scrollTo: () => {},
   });
 
   ///// INITIALIZATION


### PR DESCRIPTION
If scrollX, scrollY, etc are all hardcoded to `0`, it seems like it makes sense that `scroll`, `scrollBy`, and `scrollTo` function on the window object are just stubs. Let me know!