### PR TITLE
Include the url of the XML document in error messages

### DIFF
--- a/lib/jsdom/browser/parser/xml.js
+++ b/lib/jsdom/browser/parser/xml.js
@@ -179,7 +179,7 @@ function parseFragment(markup, contextElement) {
 function parseIntoDocument(markup, ownerDocument) {
   const parser = createParser(ownerDocument, ownerDocument, {
     xmlns: true,
-    fileName: ownerDocument.location.href
+    fileName: ownerDocument.location && ownerDocument.location.href
   });
 
   parser.write(markup).close();

--- a/lib/jsdom/browser/parser/xml.js
+++ b/lib/jsdom/browser/parser/xml.js
@@ -178,7 +178,8 @@ function parseFragment(markup, contextElement) {
 
 function parseIntoDocument(markup, ownerDocument) {
   const parser = createParser(ownerDocument, ownerDocument, {
-    xmlns: true
+    xmlns: true,
+    fileName: ownerDocument.location.href
   });
 
   parser.write(markup).close();

--- a/test/api/basics.js
+++ b/test/api/basics.js
@@ -43,4 +43,13 @@ describe("JSDOM() constructor first argument", () => {
 
     assert.strictEqual(document1.innerHTML, document2.innerHTML);
   });
+
+  describe("error reporting", () => {
+    it("should include the URL when reporting an XML parse error", () => {
+      assert.throws(() => new JSDOM("<doc><!-- ... ---></doc>", {
+        url: "https://example.com/",
+        contentType: "text/xml"
+      }), "https://example.com/:1:17: malformed comment.");
+    });
+  });
 });


### PR DESCRIPTION
Previously it would say eg. `undefined:1:17: malformed comment.`
Fixed by passing in the url as the `fileName` when creating the parser.