### PR TITLE
Allow FormData constructor to handle input elements without a value

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -180,7 +180,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
   }
 
   _getValue() {
-    return this._value;
+    return this._value !== null ? this._value : "";
   }
 
   _legacyPreActivationBehavior() {
@@ -340,7 +340,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     switch (valueAttributeMode(this.type)) {
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-value
       case "value":
-        return this._value !== null ? this._value : "";
+        return this._getValue();
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default
       case "default": {
         const attr = this.getAttributeNS(null, "value");

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -158,7 +158,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
     this._selectionStart = this._selectionEnd = 0;
     this._selectionDirection = "none";
-    this._value = null;
+    this._value = "";
     this._dirtyValue = false;
     this._checkedness = false;
     this._dirtyCheckedness = false;
@@ -179,8 +179,10 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     return convertStringToNumberByTypeMap.get(this.type);
   }
 
+  // For <input>, https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-value
+  // is a simple value that is gotten and set, not computed.
   _getValue() {
-    return this._value !== null ? this._value : "";
+    return this._value;
   }
 
   _legacyPreActivationBehavior() {
@@ -364,11 +366,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
       // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-value
       case "value": {
         const oldValue = this._value;
-        if (val === null) {
-          this._value = null;
-        } else {
-          this._value = sanitizeValueByType(this, String(val));
-        }
+        this._value = sanitizeValueByType(this, val);
         this._dirtyValue = true;
 
         if (oldValue !== this._value) {

--- a/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
@@ -74,12 +74,17 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     this.textContent = value;
   }
 
-  get value() {
+  // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-value
+  _getValue() {
     if (this.hasAttributeNS(null, "value")) {
       return this.getAttributeNS(null, "value");
     }
 
     return this.text;
+  }
+
+  get value() {
+    return this._getValue();
   }
   set value(value) {
     this.setAttributeNS(null, "value", value);

--- a/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
@@ -34,6 +34,7 @@ class HTMLTextAreaElementImpl extends HTMLElementImpl {
     return this._rawValue.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   }
 
+  // https://html.spec.whatwg.org/multipage/form-elements.html#textarea-wrapping-transformation
   _getValue() {
     // Hard-wrapping omitted, for now.
     return normalizeToCRLF(this._rawValue);

--- a/lib/jsdom/living/xhr/FormData-impl.js
+++ b/lib/jsdom/living/xhr/FormData-impl.js
@@ -11,7 +11,7 @@ exports.implementation = class FormDataImpl {
     this._entries = [];
 
     if (args[0] !== undefined) {
-      this._entries = constructTheFormDataSet(args[0]);
+      this._entries = constructTheEntryList(args[0]);
     }
   }
 
@@ -26,11 +26,11 @@ exports.implementation = class FormDataImpl {
 
   get(name) {
     const foundEntry = this._entries.find(entry => entry.name === name);
-    return foundEntry !== undefined ? foundEntry.value : null;
+    return foundEntry !== undefined ? idlUtils.tryWrapperForImpl(foundEntry.value) : null;
   }
 
   getAll(name) {
-    return this._entries.filter(entry => entry.name === name).map(entry => entry.value);
+    return this._entries.filter(entry => entry.name === name).map(entry => idlUtils.tryWrapperForImpl(entry.value));
   }
 
   has(name) {
@@ -90,15 +90,15 @@ function createAnEntry(name, value, filename) {
   return entry;
 }
 
-function constructTheFormDataSet(form, submitter) {
-  // https://html.spec.whatwg.org/multipage/forms.html#constructing-form-data-set
+function constructTheEntryList(form, submitter) {
+  // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+  // TODO: handle encoding
+  // TODO: handling "constructing entry list"
 
   const controls = form.elements.filter(isSubmittable); // submittable is a subset of listed
-  const formDataSet = [];
+  const entryList = [];
 
-  for (const fieldWrapper of controls) {
-    const field = fieldWrapper;
-
+  for (const field of controls) {
     if (closest(field, "datalist") !== null) {
       continue;
     }
@@ -114,59 +114,62 @@ function constructTheFormDataSet(form, submitter) {
     if (field.type === "radio" && field._checkedness === false) {
       continue;
     }
-    if (field.type !== "image" && (!field.hasAttributeNS(null, "name") || field.getAttributeNS(null, "name") === "")) {
-      continue;
-    }
     if (field.localName === "object") { // in jsdom, no objects are "using a plugin"
       continue;
     }
 
-    const { type } = field;
+    // TODO: Handle <input type="image">
+    // TODO: handle form-associated custom elements.
 
-    // Omit special processing of <input type="image"> since so far we don't actually ever pass submitter
-
-    const nameAttr = field.getAttributeNS(null, "name");
-    const name = nameAttr === null ? "" : nameAttr;
+    const name = field.getAttributeNS(null, "name");
+    if (name === null || name === "") {
+      continue;
+    }
 
     if (field.localName === "select") {
       for (const option of field.options) {
         if (option._selectedness === true && !isDisabled(field)) {
-          formDataSet.push({ name, value: option.value, type });
+          appendAnEntry(entryList, name, option._getValue());
         }
       }
-    } else if (field.localName === "input" && (type === "checkbox" || type === "radio")) {
+    } else if (field.localName === "input" && (field.type === "checkbox" || field.type === "radio")) {
       const value = field.hasAttributeNS(null, "value") ? field.getAttributeNS(null, "value") : "on";
-      formDataSet.push({ name, value, type });
-    } else if (type === "file") {
-      for (let i = 0; i < field.files.length; ++i) {
-        formDataSet.push({ name, value: field.files.item(i), type });
-      }
-
+      appendAnEntry(entryList, name, value);
+    } else if (field.type === "file") {
       if (field.files.length === 0) {
-        formDataSet.push({ name, value: "", type: "application/octet-stream" });
+        const value = File.createImpl([[], "", { type: "application/octet-stream" }]);
+        appendAnEntry(entryList, name, value);
+      } else {
+        for (let i = 0; i < field.files.length; ++i) {
+          appendAnEntry(entryList, name, field.files.item(i));
+        }
       }
-    } /* skip plugins */ else {
-      formDataSet.push({ name, value: field._getValue(), type });
+    } /* skip plugins. TODO: _charset_ */ else if (field.localName === "textarea") {
+      appendAnEntry(entryList, name, field._getValue(), true);
+    } else {
+      appendAnEntry(entryList, name, field._getValue());
     }
 
     const dirname = field.getAttributeNS(null, "dirname");
     if (dirname !== null && dirname !== "") {
       const dir = "ltr"; // jsdom does not (yet?) implement actual directionality
-      formDataSet.push({ name: dirname, value: dir, type: "direction" });
+      appendAnEntry(entryList, dirname, dir);
     }
   }
 
-  for (const entry of formDataSet) {
-    entry.name = conversions.USVString(normalizeToCRLF(entry.name));
+  // TODO: formdata event
 
-    if (entry.type !== "file" && entry.type !== "textarea") {
-      entry.value = normalizeToCRLF(entry.value);
-    }
+  return entryList;
+}
 
-    if (entry.type !== "file") {
-      entry.value = conversions.USVString(entry.value);
+function appendAnEntry(entryList, name, value, preventLineBreakNormalization = false) {
+  name = conversions.USVString(normalizeToCRLF(name));
+  if (!File.isImpl(value)) {
+    if (!preventLineBreakNormalization) {
+      value = normalizeToCRLF(value);
     }
+    value = conversions.USVString(value);
   }
-
-  return formDataSet;
+  const entry = createAnEntry(name, value);
+  entryList.push(entry);
 }

--- a/lib/jsdom/living/xhr/FormData-impl.js
+++ b/lib/jsdom/living/xhr/FormData-impl.js
@@ -146,7 +146,7 @@ function constructTheFormDataSet(form, submitter) {
         formDataSet.push({ name, value: "", type: "application/octet-stream" });
       }
     } /* skip plugins */ else {
-      formDataSet.push({ name, value: field._getValue(), type });
+      formDataSet.push({ name, value: field._getValue() || "", type });
     }
 
     const dirname = field.getAttributeNS(null, "dirname");

--- a/lib/jsdom/living/xhr/FormData-impl.js
+++ b/lib/jsdom/living/xhr/FormData-impl.js
@@ -146,7 +146,7 @@ function constructTheFormDataSet(form, submitter) {
         formDataSet.push({ name, value: "", type: "application/octet-stream" });
       }
     } /* skip plugins */ else {
-      formDataSet.push({ name, value: field._getValue() || "", type });
+      formDataSet.push({ name, value: field._getValue(), type });
     }
 
     const dirname = field.getAttributeNS(null, "dirname");

--- a/test/web-platform-tests/to-upstream/XMLHttpRequest/formdata-constructor.html
+++ b/test/web-platform-tests/to-upstream/XMLHttpRequest/formdata-constructor.html
@@ -81,6 +81,8 @@ with linebreaks set to CRLF</textarea>
 
   <!-- this generates two form data entries! -->
   <input type="text" name="dirname-is-special" dirname="submit-me-17" value="dirname-value">
+
+  <input type="text" name="submit-me-21">
 </form>
 
 <script>
@@ -126,7 +128,8 @@ test(() => {
     ["dirname-is-special", "dirname-value"],
     ["submit-me-17", "ltr"],
     ["submit-me-18-\uFFFD", "value-\uFFFD"],
-    ["submit-me-\r\n19\r\n", "value"]
+    ["submit-me-\r\n19\r\n", "value"],
+    ["submit-me-21", ""]
   ];
 
   for (const t of expected) {

--- a/test/web-platform-tests/to-upstream/XMLHttpRequest/formdata-constructor.html
+++ b/test/web-platform-tests/to-upstream/XMLHttpRequest/formdata-constructor.html
@@ -115,7 +115,6 @@ test(() => {
     ["submit-me-5", "on"],
     ["submit-me-6", "radio-1"],
     ["submit-me-7", "on"],
-    ["file-1", ""],
     ["submit-me-8", ["text-1", "text-2"]],
     ["submit-me-9", "search-1"],
     ["submit-me-10", "url-1"],
@@ -138,6 +137,14 @@ test(() => {
     const values = Array.isArray(valueOrValues) ? valueOrValues : [valueOrValues];
     assert_array_equals(formData.getAll(field), values, field);
   }
+
+  const fileEntry = formData.getAll("file-1");
+  assert_equals(fileEntry.length, 1);
+  assert_equals(fileEntry[0], formData.get("file-1"));
+  assert_equals(fileEntry[0].constructor, File);
+  assert_equals(fileEntry[0].size, 0);
+  assert_equals(fileEntry[0].name, "");
+  assert_equals(fileEntry[0].type, "application/octet-stream");
 
 }, "test that FormData is correctly constructed from the form data set");
 </script>


### PR DESCRIPTION
Fixes #2523

This PR enables the `FormData` constructor to handle input elements that are defined like:

```html
<input type="text" name="look-at-me" />
```

I couldn't quite see anything in the [Living Standard](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set) that describes what should happen when the value is not defined, but the browser behaviour for this (Chrome/Firefox at least) is to return an empty string.
