### PR TITLE
fix postMessage bug; add documentImpl cross Origin 

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -44,6 +44,11 @@ class JSDOM {
     documentImpl.close();
   }
 
+  get documentImpl() {
+    // for access requestManager
+    return idlUtils.implForWrapper(this[window]._document);
+  }
+
   get window() {
     // It's important to grab the global proxy, instead of just the result of `new Window(...)`, since otherwise things
     // like `window.eval` don't exist.
@@ -243,12 +248,12 @@ function transformOptions(options, encoding, mimeType) {
   }
 
   transformed.windowOptions.cookieJar = options.cookieJar === undefined ?
-                                       new CookieJar() :
-                                       options.cookieJar;
+    new CookieJar() :
+    options.cookieJar;
 
   transformed.windowOptions.virtualConsole = options.virtualConsole === undefined ?
-                                            (new VirtualConsole()).sendTo(console) :
-                                            options.virtualConsole;
+    (new VirtualConsole()).sendTo(console) :
+    options.virtualConsole;
 
   if (!(transformed.windowOptions.virtualConsole instanceof VirtualConsole)) {
     throw new TypeError("virtualConsole must be an instance of VirtualConsole");
@@ -259,7 +264,7 @@ function transformOptions(options, encoding, mimeType) {
   if (options.runScripts !== undefined) {
     transformed.windowOptions.runScripts = String(options.runScripts);
     if (transformed.windowOptions.runScripts !== "dangerously" &&
-        transformed.windowOptions.runScripts !== "outside-only") {
+      transformed.windowOptions.runScripts !== "outside-only") {
       throw new RangeError(`runScripts must be undefined, "dangerously", or "outside-only"`);
     }
   }

--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -27,6 +27,7 @@ module.exports = function (message, targetOrigin) {
   // TODO: event.ports
   // TODO: event.data - structured clone message - requires cloning DOM nodes
   setTimeout(() => {
+
     // impl not ready for fireEvent
     try {
       fireAnEvent("message", this, MessageEvent, { data: message });

--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -27,6 +27,10 @@ module.exports = function (message, targetOrigin) {
   // TODO: event.ports
   // TODO: event.data - structured clone message - requires cloning DOM nodes
   setTimeout(() => {
-    fireAnEvent("message", this, MessageEvent, { data: message });
+    // impl not ready for fireEvent
+    try {
+      fireAnEvent("message", this, MessageEvent, { data: message });
+    } catch (e) {
+    }
   }, 0);
 };

--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -250,10 +250,13 @@ function createClient(xhr) {
     requestHeaders.Accept = "*/*";
   }
 
-  const crossOrigin = flag.origin !== urlObj.origin;
-  if (crossOrigin) {
-    requestHeaders.Origin = flag.origin;
-  }
+  // const crossOrigin = flag.origin !== urlObj.origin;
+  // if (crossOrigin) {
+  //   requestHeaders.Origin = flag.origin;
+  // }
+
+  // always check origin
+  requestHeaders.Origin = flag.origin;
 
   const options = {
     uri,
@@ -280,9 +283,9 @@ function createClient(xhr) {
 
   const { body } = flag;
   const hasBody = body !== undefined &&
-                  body !== null &&
-                  body !== "" &&
-                  !(ucMethod === "HEAD" || ucMethod === "GET");
+    body !== null &&
+    body !== "" &&
+    !(ucMethod === "HEAD" || ucMethod === "GET");
 
   if (hasBody && !flag.formData) {
     options.body = body;


### PR DESCRIPTION
- add `documentImpl` property, for check the network is in idle (requestManager.size)
- skip cross origin check, always use `preflight` (modern browser will send `Origin` header for cross origin check)
- fix `postMessage` error, fire event throw fatal error when impl not ready
