### PR TITLE
Fix getting value of Select when selectedIndex is -1

### DIFF
--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -159,9 +159,9 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   get value() {
-    for (let i = 0; i < this.options.length; i++) {
-      if (this.options.item(i)._selectedness) {
-        return this.options.item(i).value;
+    for (const option of this.options) {
+      if (option._selectedness) {
+        return option.value;
       }
     }
 

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -144,7 +144,13 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 
   set selectedIndex(index) {
     for (let i = 0; i < this.options.length; i++) {
-      this.options.item(i).selected = i === index;
+      this.options.item(i)._selectedness = false;
+    }
+
+    const selectedOption = this.options.item(index);
+    if (selectedOption) {
+      selectedOption._selectedness = true;
+      selectedOption._dirtyness = true;
     }
   }
 
@@ -153,14 +159,13 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   get value() {
-    let i = this.selectedIndex;
-    if (this.options.length && (i === -1)) {
-      i = 0;
+    for (let i = 0; i < this.options.length; i++) {
+      if (this.options.item(i)._selectedness) {
+        return this.options.item(i).value;
+      }
     }
-    if (i === -1) {
-      return "";
-    }
-    return this.options.item(i).value;
+
+    return "";
   }
 
   set value(val) {


### PR DESCRIPTION
### Context

When doing get value of Select element with selectedIndex=-1, it
should return empty string "" instead of value of its first option.

Test case:
```js
const jsdom = require("jsdom");
const { JSDOM } = jsdom;

const html = `
<!DOCTYPE html>
<html>
<head>
<meta name="description" content="selectedIndex test">
</head>
<body>
  <select id="select">
    <option value="1">1</option>
    <option value="2">2</option>
    <option vlaue="3">3</option>
  </select>
</body>
</html>
`;

const dom = new JSDOM(html);
const select = dom.window.document.getElementById("select");

select.selectedIndex = -1;

// expectation: ""
console.log(select.value); // "1"

// expectation: -1
console.log(select.selectedIndex); // 0
```


Browser playground: https://jsbin.com/numacir/3/edit?html,console,output
Repl playground: https://repl.it/@JohnNguyen12/IncompatibleIllCpu


### Approach
We update the implementation of `get value() {}` to follow the wording
of whatwg spec.

Also, when Select's `selectedIndex` was modified, we update the Option
elements' `_selectedness` and `_dirtyness` instead of theirs `selected`
attribute. Changing an Option's `selected` atrribute causes parent
Select element to be reset, which makes Select's `selectedIndex` to be
changed to a non `-1` value.

References:
https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-selectedindex
https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-value

---- 
This is my first contribution to `jsdom` repo. So apologize if something was not done correctly. 🙇 

I'll work on adding this test scenario on https://github.com/web-platform-tests/wpt as well.