### PR TITLE
Existential check before property access in EventTarget-impl.js

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -323,7 +323,7 @@ function innerInvokeEventListeners(eventImpl, listeners, phase) {
       } else if (target._ownerDocument) {
         // Triggered by most webidl2js'ed instances
         window = target._ownerDocument._defaultView;
-      } else if (wrapper._ownerDocument) {
+      } else if (wrapper && wrapper._ownerDocument) {
         // Currently triggered by XHR and some other non-webidl2js things
         window = wrapper._ownerDocument._defaultView;
       }


### PR DESCRIPTION
- prevent "Cannot read property '_ownerDocument' of undefined" error

I got the above error, and making this change fixed it

- [ ] test is needed, trying to create a minimal reproducible