### PR TITLE
DOMMatrix & DOMMatrixReadOnly Implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .svn
 .*.swp
 .eslintcache
+.idea/
 gmon.out
 v8.log
 node_modules

--- a/lib/jsdom/living/geometry/DOMMatrix-impl.js
+++ b/lib/jsdom/living/geometry/DOMMatrix-impl.js
@@ -1,0 +1,277 @@
+"use strict";
+
+const DOMMatrixReadOnlyImpl = require("./DOMMatrixReadOnly-impl").implementation;
+const { matrixUtils, matrix3dArrayProperties } = require("../helpers/geometry/matrix");
+const {
+  validateDOMMatrixInit,
+  arrayFromDOMMatrixInit
+} = require("../helpers/geometry/dommatrix-init");
+
+class DOMMatrixImpl extends DOMMatrixReadOnlyImpl {
+  _setMatrixInvalidState() {
+    matrix3dArrayProperties.forEach(prop => {
+      this[prop] = NaN;
+    });
+
+    this.is2D = false;
+  }
+
+  static fromMatrix(other) {
+    other = other instanceof DOMMatrixImpl ? other.toJSON() : other;
+
+    const matrixInitialization = validateDOMMatrixInit(other);
+    const initializationArray = arrayFromDOMMatrixInit(matrixInitialization);
+
+    return new DOMMatrixImpl([initializationArray]);
+  }
+
+  _multiply(a, b) {
+    const order = 4;
+    const result = Array(order * order).fill(0);
+    const _mA = Array.from(a);
+    const _mB = Array.from(b);
+
+    for (let i = 0; i < order; i += 1) {
+      for (let j = 0; j < order; j += 1) {
+        for (let k = 0; k < order; k += 1) {
+          const matrixElementA = _mA[i * order + k];
+          const matrixElementB = _mB[k * order + j];
+          result[i * order + j] += matrixElementA * matrixElementB;
+        }
+      }
+    }
+
+    this._updatePropsFromMatrix(result);
+
+    return this;
+  }
+
+  _getRotationMatrix(x, y, z, alpha) {
+    alpha *= Math.PI / 180;
+
+    const sc = Math.sin(alpha * 0.5) * Math.cos(alpha * 0.5);
+    const sq = Math.pow(Math.sin(alpha * 0.5), 2);
+    const xSq = Math.pow(x, 2);
+    const ySq = Math.pow(y, 2);
+    const zSq = Math.pow(z, 2);
+
+    const m11 = 1 - 2 * (ySq + zSq) * sq;
+    const m12 = 2 * ((x * y * sq) + (z * sc));
+    const m13 = 2 * ((x * z * sq) - (y * sc));
+
+
+    const m21 = 2 * ((x * y * sq) - (z * sc));
+    const m22 = 1 - 2 * (xSq + zSq) * sq;
+    const m23 = 2 * ((y * z * sq) + (x * sc));
+
+    const m31 = 2 * ((x * z * sq) + (y * sc));
+    const m32 = 2 * ((y * z * sq) - (x * sc));
+    const m33 = 1 - 2 * (xSq + ySq) * sq;
+
+    return new DOMMatrixImpl([
+      [
+        m11, m12, m13, 0,
+        m21, m22, m23, 0,
+        m31, m32, m33, 0,
+        0, 0, 0, 1
+      ]
+    ]);
+  }
+
+  multiplySelf(other) {
+    const otherMatrix = DOMMatrixImpl.fromMatrix(other);
+
+    // post multiply
+    return this._multiply(otherMatrix, this);
+  }
+
+  preMultiplySelf(other) {
+    const otherMatrix = DOMMatrixImpl.fromMatrix(other);
+    if (!otherMatrix.is2D) {
+      this.is2D = false;
+    }
+
+    return this._multiply(this, otherMatrix);
+  }
+
+  translateSelf(tX = 0, tY = 0, tZ = 0) {
+    const translationMatrix = new DOMMatrixImpl([
+      [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        tX, tY, tZ, 1
+      ]
+    ]);
+
+    return this.multiplySelf(translationMatrix);
+  }
+
+  scaleSelf(scaleX = 1, scaleY, scaleZ = 1, originX = 0, originY = 0, originZ = 0) {
+    const scalingMatrix = new DOMMatrixImpl([
+      [
+        scaleX, 0, 0, 0,
+        0, scaleY, 0, 0,
+        0, 0, scaleZ, 0,
+        0, 0, 0, 1
+      ]
+    ]);
+    this.translateSelf(originX, originY, originZ);
+    if (typeof scaleY === "undefined") {
+      scaleY = scaleX;
+    }
+    this.multiplySelf(scalingMatrix);
+    this.translateSelf(-originX, -originY, -originZ);
+    if (scaleZ !== 1 || originZ !== 0) {
+      this.is2D = false;
+    }
+
+    return this;
+  }
+
+  scale3dSelf(scale = 1, originX = 0, originY = 0, originZ = 0) {
+    const scalingMatrix = new DOMMatrixImpl([
+      [
+        scale, 0, 0, 0,
+        0, scale, 0, 0,
+        0, 0, scale, 0,
+        0, 0, 0, 1
+      ]
+    ]);
+    this.translateSelf(originX, originY, originZ);
+    this.multiplySelf(scalingMatrix);
+    this.translateSelf(-originX, -originY, -originZ);
+    if (scale !== 1) {
+      this.is2D = false;
+    }
+
+    return this;
+  }
+
+  rotateSelf(rotX = 0, rotY, rotZ) {
+    if (typeof rotY === "undefined" &&
+        typeof rotZ === "undefined") {
+      rotZ = rotX;
+      rotX = 0;
+      rotY = 0;
+    }
+
+    if (typeof rotY === "undefined") {
+      rotY = 0;
+    }
+
+    if (typeof rotZ === "undefined") {
+      rotZ = 0;
+    }
+
+    if (rotX !== 0 || rotY !== 0) {
+      this.is2D = false;
+    }
+
+    this.multiplySelf(this._getRotationMatrix(0, 0, 1, rotZ));
+    this.multiplySelf(this._getRotationMatrix(0, 1, 0, rotY));
+
+    return this.multiplySelf(this._getRotationMatrix(1, 0, 0, rotX));
+  }
+
+  rotateFromVectorSelf(x = 0, y = 0) {
+    // dot product for vectors (1, 0), (x, y) will always be x
+    const dp = x;
+    const vec1Mag = Math.sqrt(Math.pow(1, 2) + Math.pow(0, 2));
+    const vec2Mag = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
+    const angle = x === 0 && y === 0 ?
+      0 :
+      Math.acos(dp / (vec1Mag * vec2Mag)) * (180 / Math.PI);
+
+    return this.multiplySelf(this._getRotationMatrix(0, 0, 1, angle));
+  }
+
+  rotateAxisAngleSelf(x = 0, y = 0, z = 0, angle = 0) {
+    // Interestingly, this vector must be normalized. AFAIK, this isn't
+    // explicitly documented anywhere but it makes sense in the context of the rotation
+    //  matrix algorithm.
+    const { x: xNorm, y: yNorm, z: zNorm } = matrixUtils.normalizeVector(x, y, z);
+
+    if (x !== 0 || y !== 0) {
+      this.is2D = false;
+    }
+
+    return this.multiplySelf(this._getRotationMatrix(xNorm, yNorm, zNorm, angle));
+  }
+
+  skewXSelf(sX = 0) {
+    sX = Math.tan(matrixUtils.toRadians(sX));
+    return this.multiplySelf(new DOMMatrixImpl([
+      [
+        1, 0, 0, 0,
+        sX, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ]
+    ]));
+  }
+
+  skewYSelf(sY = 0) {
+    sY = Math.tan(matrixUtils.toRadians(sY));
+    return this.multiplySelf(new DOMMatrixImpl([
+      [
+        1, sY, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ]
+    ]));
+  }
+
+  invertSelf() {
+    const order = 4;
+    // instead of mucking around with 1D matrices here,
+    // it's much more intuitive to preform the elimination on 2D matrices and convert the result back
+    // down to a 1D matrix.
+    const left = matrixUtils.to2DMatrix(Array.from(this), order);
+    const right = [
+      [1, 0, 0, 0],
+      [0, 1, 0, 0],
+      [0, 0, 1, 0],
+      [0, 0, 0, 1]
+    ];
+
+    for (let row = 0; row < order; row += 1) {
+      const pivotRow = matrixUtils.getPivotRow(left, row);
+      matrixUtils.swapRows(left, pivotRow, row);
+      matrixUtils.swapRows(right, pivotRow, row);
+      const diagonal = left[row][row];
+      if (diagonal === 0) {
+        this._setMatrixInvalidState();
+        return this;
+      }
+
+      for (let col = 0; col < order; col += 1) {
+        left[row][col] /= diagonal;
+        right[row][col] /= diagonal;
+      }
+
+      for (let k = 0; k < order; k += 1) {
+        if (k === row) {
+          continue;
+        }
+
+        const factor = left[k][row];
+        for (let col = 0; col < order; col += 1) {
+          left[k][col] -= factor * left[row][col];
+          right[k][col] -= factor * right[row][col];
+        }
+      }
+    }
+
+    this._updatePropsFromMatrix(matrixUtils.to1DMatrix(right));
+
+    return this;
+  }
+
+  setMatrixValue(trasformList) {
+    throw new Error(`Function not implemented`);
+  }
+}
+
+module.exports.implementation = DOMMatrixImpl;

--- a/lib/jsdom/living/geometry/DOMMatrix-impl.js
+++ b/lib/jsdom/living/geometry/DOMMatrix-impl.js
@@ -108,6 +108,9 @@ class DOMMatrixImpl extends DOMMatrixReadOnlyImpl {
   }
 
   scaleSelf(scaleX = 1, scaleY, scaleZ = 1, originX = 0, originY = 0, originZ = 0) {
+    if (typeof scaleY === "undefined") {
+      scaleY = scaleX;
+    }
     const scalingMatrix = new DOMMatrixImpl([
       [
         scaleX, 0, 0, 0,
@@ -117,11 +120,9 @@ class DOMMatrixImpl extends DOMMatrixReadOnlyImpl {
       ]
     ]);
     this.translateSelf(originX, originY, originZ);
-    if (typeof scaleY === "undefined") {
-      scaleY = scaleX;
-    }
     this.multiplySelf(scalingMatrix);
     this.translateSelf(-originX, -originY, -originZ);
+
     if (scaleZ !== 1 || originZ !== 0) {
       this.is2D = false;
     }
@@ -191,12 +192,46 @@ class DOMMatrixImpl extends DOMMatrixReadOnlyImpl {
     // explicitly documented anywhere but it makes sense in the context of the rotation
     //  matrix algorithm.
     const { x: xNorm, y: yNorm, z: zNorm } = matrixUtils.normalizeVector(x, y, z);
-
     if (x !== 0 || y !== 0) {
       this.is2D = false;
     }
 
     return this.multiplySelf(this._getRotationMatrix(xNorm, yNorm, zNorm, angle));
+  }
+
+  perspectiveSelf(d) {
+    // https://drafts.csswg.org/css-transforms-2/#PerspectiveDefined
+    //  helper for css function
+    const p = d ? -1 / d : 0;
+
+    const perspectiveMatrix = new DOMMatrixImpl([
+      [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, p,
+        0, 0, 0, 1
+      ]
+    ]);
+
+    return this.multiplySelf(perspectiveMatrix);
+  }
+
+  skewSelf(sX, sY = 0) {
+    // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skew
+    // https://drafts.csswg.org/css-transforms-1/#SkewDefined
+    // For css functions
+
+    sX = Math.tan(matrixUtils.toRadians(sX));
+    sY = Math.tan(matrixUtils.toRadians(sY));
+
+    return this.multiplySelf(new DOMMatrixImpl([
+      [
+        1, sY, 0, 0,
+        sX, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ]
+    ]));
   }
 
   skewXSelf(sX = 0) {
@@ -226,7 +261,7 @@ class DOMMatrixImpl extends DOMMatrixReadOnlyImpl {
   invertSelf() {
     const order = 4;
     // instead of mucking around with 1D matrices here,
-    // it's much more intuitive to preform the elimination on 2D matrices and convert the result back
+    // it's much more intuitive to perform the elimination on 2D matrices and convert the result back
     // down to a 1D matrix.
     const left = matrixUtils.to2DMatrix(Array.from(this), order);
     const right = [

--- a/lib/jsdom/living/geometry/DOMMatrix.webidl
+++ b/lib/jsdom/living/geometry/DOMMatrix.webidl
@@ -1,3 +1,5 @@
+// https://www.w3.org/TR/geometry-1/#dommatrix
+
 [Constructor(optional (DOMString or sequence<unrestricted double>) init),
  Exposed=(Window,Worker),
  Serializable,

--- a/lib/jsdom/living/geometry/DOMMatrix.webidl
+++ b/lib/jsdom/living/geometry/DOMMatrix.webidl
@@ -1,0 +1,69 @@
+[Constructor(optional (DOMString or sequence<unrestricted double>) init),
+ Exposed=(Window,Worker),
+ Serializable,
+ LegacyWindowAlias=(SVGMatrix,WebKitCSSMatrix)]
+interface DOMMatrix : DOMMatrixReadOnly {
+    [NewObject] static DOMMatrix fromMatrix(optional DOMMatrixInit other);
+    [NewObject] static DOMMatrix fromFloat32Array(Float32Array array32);
+    [NewObject] static DOMMatrix fromFloat64Array(Float64Array array64);
+
+    // Mutable transform methods
+    DOMMatrix multiplySelf(optional DOMMatrixInit other);
+    DOMMatrix preMultiplySelf(optional DOMMatrixInit other);
+    DOMMatrix translateSelf(optional unrestricted double tx = 0,
+                            optional unrestricted double ty = 0,
+                            optional unrestricted double tz = 0);
+    DOMMatrix scaleSelf(optional unrestricted double scaleX = 1,
+                        optional unrestricted double scaleY,
+                        optional unrestricted double scaleZ = 1,
+                        optional unrestricted double originX = 0,
+                        optional unrestricted double originY = 0,
+                        optional unrestricted double originZ = 0);
+    DOMMatrix scale3dSelf(optional unrestricted double scale = 1,
+                          optional unrestricted double originX = 0,
+                          optional unrestricted double originY = 0,
+                          optional unrestricted double originZ = 0);
+    DOMMatrix rotateSelf(optional unrestricted double rotX = 0,
+                         optional unrestricted double rotY,
+                         optional unrestricted double rotZ);
+    DOMMatrix rotateFromVectorSelf(optional unrestricted double x = 0,
+                                   optional unrestricted double y = 0);
+    DOMMatrix rotateAxisAngleSelf(optional unrestricted double x = 0,
+                                  optional unrestricted double y = 0,
+                                  optional unrestricted double z = 0,
+                                  optional unrestricted double angle = 0);
+    DOMMatrix skewXSelf(optional unrestricted double sx = 0);
+    DOMMatrix skewYSelf(optional unrestricted double sy = 0);
+    DOMMatrix invertSelf();
+
+    [Exposed=Window] DOMMatrix setMatrixValue(DOMString transformList);
+};
+
+dictionary DOMMatrix2DInit {
+    unrestricted double a;
+    unrestricted double b;
+    unrestricted double c;
+    unrestricted double d;
+    unrestricted double e;
+    unrestricted double f;
+    unrestricted double m11;
+    unrestricted double m12;
+    unrestricted double m21;
+    unrestricted double m22;
+    unrestricted double m41;
+    unrestricted double m42;
+};
+
+dictionary DOMMatrixInit : DOMMatrix2DInit {
+    unrestricted double m13 = 0;
+    unrestricted double m14 = 0;
+    unrestricted double m23 = 0;
+    unrestricted double m24 = 0;
+    unrestricted double m31 = 0;
+    unrestricted double m32 = 0;
+    unrestricted double m33 = 1;
+    unrestricted double m34 = 0;
+    unrestricted double m43 = 0;
+    unrestricted double m44 = 1;
+    boolean is2D;
+};

--- a/lib/jsdom/living/geometry/DOMMatrixReadOnly-impl.js
+++ b/lib/jsdom/living/geometry/DOMMatrixReadOnly-impl.js
@@ -1,0 +1,451 @@
+/* eslint-disable no-use-before-define */
+"use strict";
+const DOMException = require("domexception");
+const {
+  matrix3dArrayProperties,
+  matrix2dArrayProperties
+} = require("../helpers/geometry/matrix");
+const {
+  validateDOMMatrixInit,
+  arrayFromDOMMatrixInit
+} = require("../helpers/geometry/dommatrix-init");
+
+class DOMMatrixReadOnlyImpl {
+  constructor(constructorArgs) {
+    let [matrixInit] = constructorArgs;
+
+    if (typeof matrixInit === "undefined") {
+      matrixInit = [1, 0, 0, 1, 0, 0];
+    }
+
+    if (typeof matrixInit === "string") {
+      matrixInit = this.parseDomString(matrixInit);
+      throw new Error(`Matrix as DOMString not implemented.`);
+    }
+
+    /**
+     * Note: An underscore indicates that the property is defined by a property accessor.
+     * These properties produce side effects upon getting or setting.
+     * To prevent a ton of property accessors, only those that produce side effects are defined as property accessors.
+     */
+    this.m11 = 0;
+    this.m12 = 0;
+    this._m13 = 0;
+    this._m14 = 0;
+    this.m21 = 0;
+    this.m22 = 0;
+    this._m23 = 0;
+    this._m24 = 0;
+    this._m31 = 0;
+    this._m32 = 0;
+    this._m33 = 0;
+    this._m34 = 0;
+    this.m41 = 0;
+    this.m42 = 0;
+    this._m43 = 0;
+    this._m44 = 0;
+    this._is2D = false;
+
+
+    if (matrixInit.length === 6) {
+      this._initialize2dMatrix(matrixInit);
+    } else if (matrixInit.length === 16) {
+      this._initialize3dMatrix(matrixInit);
+    } else {
+      throw new TypeError(`Invalid length for constructor init, expected 6 or 16, but received ${matrixInit.length}`);
+    }
+  }
+
+  parseDomString(domstring) {
+    // Not implemented
+  }
+
+  _initialize2dMatrix(init) {
+    matrix2dArrayProperties.forEach((prop, idx) => {
+      this[prop] = init[idx];
+    });
+
+    this.m33 = 1;
+    this.m44 = 1;
+    this._is2D = true;
+  }
+
+  _initialize3dMatrix(init) {
+    matrix3dArrayProperties.forEach((prop, idx) => {
+      this[prop] = init[idx];
+    });
+  }
+
+  _getCurrentMatrix() {
+    if (this.is2D) {
+      return matrix2dArrayProperties.map(prop => this[prop]);
+    }
+
+    return matrix3dArrayProperties.map(prop => this[prop]);
+  }
+
+  _updatePropsFromMatrix(matrix) {
+    matrix3dArrayProperties.forEach((prop, idx) => {
+      this[prop] = matrix[idx];
+    });
+  }
+
+  * [Symbol.iterator]() {
+    for (const i of matrix3dArrayProperties.map(prop => this[prop])) {
+      yield i;
+    }
+  }
+
+  get a() {
+    return this.m11;
+  }
+
+  set a(value) {
+    this.m11 = value;
+  }
+
+  get b() {
+    return this.m12;
+  }
+
+  set b(value) {
+    this.m12 = value;
+  }
+
+  get c() {
+    return this.m21;
+  }
+
+  set c(value) {
+    this.m21 = value;
+  }
+
+  get d() {
+    return this.m22;
+  }
+
+  set d(value) {
+    this.m22 = value;
+  }
+
+  get e() {
+    return this.m41;
+  }
+
+  set e(value) {
+    this.m41 = value;
+  }
+
+  get f() {
+    return this.m42;
+  }
+
+  set f(value) {
+    this.m42 = value;
+  }
+
+  get m13() {
+    return this._m13;
+  }
+
+  set m13(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m13 = value;
+  }
+
+  get m14() {
+    return this._m14;
+  }
+
+  set m14(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m14 = value;
+  }
+
+  get m23() {
+    return this._m23;
+  }
+
+  set m23(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m23 = value;
+  }
+
+  get m24() {
+    return this._m24;
+  }
+
+  set m24(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m24 = value;
+  }
+
+  get m31() {
+    return this._m31;
+  }
+
+  set m31(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m31 = value;
+  }
+
+  get m32() {
+    return this._m32;
+  }
+
+  set m32(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m32 = value;
+  }
+
+  get m33() {
+    return this._m33;
+  }
+
+  set m33(value) {
+    if (value !== 1) {
+      this.is2D = false;
+    }
+    this._m33 = value;
+  }
+
+
+  get m34() {
+    return this._m34;
+  }
+
+  set m34(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m34 = value;
+  }
+
+  get m43() {
+    return this._m43;
+  }
+
+  set m43(value) {
+    if (value !== 0) {
+      this.is2D = false;
+    }
+    this._m43 = value;
+  }
+
+  get m44() {
+    return this._m44;
+  }
+
+  set m44(value) {
+    if (value !== 1) {
+      this.is2D = false;
+    }
+    this._m44 = value;
+  }
+
+  get is2D() {
+    return this._is2D;
+  }
+
+  set is2D(value) {
+    if (value === true && !this._is2D) {
+      // see note https://www.w3.org/TR/geometry-1/#matrix-is-2d
+      return;
+    }
+    this._is2D = Boolean(value);
+  }
+
+  get isIdentity() {
+    const hasRequiredZeroProps = [
+      "m12", "m13", "m14", "m21", "m23", "m24",
+      "m31", "m32", "m34", "m41", "m42", "m43"
+    ].every(prop => this[prop] === 0);
+
+    const hasRequiredIdentityProps = ["m11", "m22", "m33", "m44"].every(prop => this[prop] === 1);
+
+    return hasRequiredZeroProps && hasRequiredIdentityProps;
+  }
+
+  static fromMatrix(other) {
+    const matrixInitialization = validateDOMMatrixInit(other);
+    const initializationArray = arrayFromDOMMatrixInit(matrixInitialization);
+
+    return new DOMMatrixReadOnlyImpl([initializationArray]);
+  }
+
+  static fromFloat32Array(array32) {
+    return new DOMMatrixReadOnlyImpl([Array.from(array32)]);
+  }
+
+  static fromFloat64Array(array64) {
+    return new DOMMatrixReadOnlyImpl([Array.from(array64)]);
+  }
+
+  translate(tX = 0, tY = 0, tZ = 0) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.translateSelf(tX, tY, tZ);
+
+    return m;
+  }
+
+  scale(scaleX = 1, scaleY, scaleZ = 1, originX = 0, originY = 0, originZ = 0) {
+    if (typeof scaleY === "undefined") {
+      scaleY = scaleX;
+    }
+
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.scaleSelf(scaleX, scaleY, scaleZ, originX, originY, originZ);
+
+    return m;
+  }
+
+  scaleNonUniform(scaleX = 1, scaleY = 1) {
+    // Deprecated: https://www.w3.org/TR/geometry-1/#dom-dommatrixreadonly-scalenonuniform
+
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.scaleSelf(scaleX, scaleY);
+
+    return m;
+  }
+
+  scale3d(scale = 1, originX = 0, originY = 0, originZ = 0) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.scale3dSelf(scale, originX, originY, originZ);
+
+    return m;
+  }
+
+  rotate(rotX = 0, rotY, rotZ) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.rotateSelf(rotX, rotY, rotZ);
+
+    return m;
+  }
+
+  rotateFromVector(x = 0, y = 0) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.rotateFromVectorSelf(x, y);
+
+    return m;
+  }
+
+  rotateAxisAngle(x = 0, y = 0, z = 0, angle = 0) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.rotateAxisAngleSelf(x, y, z, angle);
+
+    return m;
+  }
+
+  skewX(sX = 0) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.skewXSelf(sX);
+
+    return m;
+  }
+
+  skewY(sY = 0) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.skewYSelf(sY);
+
+    return m;
+  }
+
+  multiply(other) {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.multiplySelf(other);
+
+    return m;
+  }
+
+  flipX() {
+    const m = DOMMatrix.create([this._getCurrentMatrix()]);
+
+    m.multiplySelf(DOMMatrix.create([[-1, 0, 0, 1, 0, 0]]).toJSON());
+
+    return m;
+  }
+
+  flipY() {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.multiplySelf(DOMMatrix.createImpl([[1, 0, 0, -1, 0, 0]]).toJSON());
+
+    return m;
+  }
+
+  inverse() {
+    const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
+
+    m.invertSelf();
+
+    return m;
+  }
+
+  // transformPoint(point) {
+  //   throw new Error(`Transform Point is not implemented`);
+  // }
+
+  toFloat32Array() {
+    return new Float32Array(this._getCurrentMatrix());
+  }
+
+  toFloat64Array() {
+    return new Float64Array(this._getCurrentMatrix());
+  }
+
+  toJSON() {
+    return [
+      "a", "b", "c", "d", "e", "f",
+      "m11", "m12", "m13", "m14",
+      "m21", "m22", "m23", "m24",
+      "m31", "m32", "m33", "m34",
+      "m41", "m42", "m43", "m44",
+      "is2D", "isIdentity"
+    ].reduce((domMatrixInit, prop) => {
+      domMatrixInit[prop] = this[prop];
+      return domMatrixInit;
+    }, {});
+  }
+
+  toString() {
+    const matrix = this._getCurrentMatrix();
+
+    if (matrix.some(x =>
+      isNaN(x) ||
+      x === Infinity ||
+      x === -Infinity)) {
+      throw new DOMException("Matrix contains non-finite values.", "InvalidStateError");
+    }
+
+    if (this.is2D) {
+      return `matrix(${matrix.join(", ")})`;
+    }
+
+    return `matrix3d(${matrix.join(", ")})`;
+  }
+}
+
+module.exports.implementation = DOMMatrixReadOnlyImpl;
+const DOMMatrix = require("../generated/DOMMatrix");

--- a/lib/jsdom/living/geometry/DOMMatrixReadOnly-impl.js
+++ b/lib/jsdom/living/geometry/DOMMatrixReadOnly-impl.js
@@ -9,18 +9,24 @@ const {
   validateDOMMatrixInit,
   arrayFromDOMMatrixInit
 } = require("../helpers/geometry/dommatrix-init");
+const { parseDOMStringToMatrixFunctions } = require("../helpers/geometry/matrixDomStringParser");
 
 class DOMMatrixReadOnlyImpl {
-  constructor(constructorArgs) {
+  constructor(constructorArgs = []) {
     let [matrixInit] = constructorArgs;
 
-    if (typeof matrixInit === "undefined") {
+    if (
+      typeof matrixInit === "undefined" ||
+      matrixInit === "" ||
+      matrixInit === "none"
+    ) {
       matrixInit = [1, 0, 0, 1, 0, 0];
-    }
-
-    if (typeof matrixInit === "string") {
-      matrixInit = this.parseDomString(matrixInit);
-      throw new Error(`Matrix as DOMString not implemented.`);
+    } else if (typeof matrixInit === "string") {
+      try {
+        matrixInit = this.parseDomString(matrixInit);
+      } catch (e) {
+        throw new DOMException(`Failed to construct ${this.constructor.name}: failed to parse ${matrixInit}`, "SyntaxError");
+      }
     }
 
     /**
@@ -57,7 +63,69 @@ class DOMMatrixReadOnlyImpl {
   }
 
   parseDomString(domstring) {
-    // Not implemented
+    const matrixFns = parseDOMStringToMatrixFunctions(domstring);
+    const baseMatrix = DOMMatrix.createImpl([]);
+
+    matrixFns.forEach(([fnName, fnArgs]) => {
+      switch (fnName) {
+        case "matrix3d":
+        case "matrix":
+          baseMatrix.multiplySelf(DOMMatrix.createImpl([fnArgs]));
+          break;
+        case "translate3d":
+        case "translate":
+        case "translateX":
+          baseMatrix.translateSelf(...fnArgs);
+          break;
+        case "translateY":
+          baseMatrix.translateSelf(0, fnArgs[0]);
+          break;
+        case "translateZ":
+          baseMatrix.translateSelf(0, 0, fnArgs[0]);
+          break;
+        case "scale3d":
+          baseMatrix.scaleSelf(...fnArgs);
+          break;
+        case "scale":
+          baseMatrix.scaleSelf(fnArgs[0], fnArgs[1], 1);
+          break;
+        case "scaleX":
+          baseMatrix.scaleSelf(fnArgs[0], 1, 1);
+          break;
+        case "scaleY":
+          baseMatrix.scaleSelf(1, fnArgs[0]);
+          break;
+        case "scaleZ":
+          baseMatrix.scaleSelf(1, 1, fnArgs[0]);
+          break;
+        case "rotate3d":
+          baseMatrix.rotateAxisAngleSelf(...fnArgs);
+          break;
+        case "rotate":
+        case "rotateZ":
+          baseMatrix.rotateAxisAngleSelf(0, 0, 1, fnArgs[0]);
+          break;
+        case "rotateX":
+          baseMatrix.rotateAxisAngleSelf(1, 0, 0, fnArgs[0]);
+          break;
+        case "rotateY":
+          baseMatrix.rotateAxisAngleSelf(0, 1, 0, fnArgs[0]);
+          break;
+        case "perspective":
+          baseMatrix.perspectiveSelf(...fnArgs);
+          break;
+        case "skew":
+          baseMatrix.skewSelf(...fnArgs);
+          break;
+        case "skewX":
+          baseMatrix.skewX(...fnArgs);
+          break;
+        case "skewY":
+          baseMatrix.skewY(...fnArgs);
+          break;
+      }
+    });
+    return arrayFromDOMMatrixInit(baseMatrix);
   }
 
   _initialize2dMatrix(init) {
@@ -349,7 +417,6 @@ class DOMMatrixReadOnlyImpl {
 
   rotateAxisAngle(x = 0, y = 0, z = 0, angle = 0) {
     const m = DOMMatrix.createImpl([this._getCurrentMatrix()]);
-
     m.rotateAxisAngleSelf(x, y, z, angle);
 
     return m;

--- a/lib/jsdom/living/geometry/DOMMatrixReadOnly.webidl
+++ b/lib/jsdom/living/geometry/DOMMatrixReadOnly.webidl
@@ -1,0 +1,77 @@
+// https://www.w3.org/TR/geometry-1/#dommatrixreadonly
+
+[Constructor(optional (DOMString or sequence<unrestricted double>) init),
+ Exposed=(Window,Worker),
+ Serializable]
+interface DOMMatrixReadOnly {
+    [NewObject] static DOMMatrixReadOnlyImpl fromMatrix(optional DOMMatrixInit other);
+    [NewObject] static DOMMatrixReadOnlyImpl fromFloat32Array(Float32Array array32);
+    [NewObject] static DOMMatrixReadOnlyImpl fromFloat64Array(Float64Array array64);
+
+    // These attributes are simple aliases for certain elements of the 4x4 matrix
+    readonly attribute unrestricted double a;
+    readonly attribute unrestricted double b;
+    readonly attribute unrestricted double c;
+    readonly attribute unrestricted double d;
+    readonly attribute unrestricted double e;
+    readonly attribute unrestricted double f;
+
+    readonly attribute unrestricted double m11;
+    readonly attribute unrestricted double m12;
+    readonly attribute unrestricted double m13;
+    readonly attribute unrestricted double m14;
+    readonly attribute unrestricted double m21;
+    readonly attribute unrestricted double m22;
+    readonly attribute unrestricted double m23;
+    readonly attribute unrestricted double m24;
+    readonly attribute unrestricted double m31;
+    readonly attribute unrestricted double m32;
+    readonly attribute unrestricted double m33;
+    readonly attribute unrestricted double m34;
+    readonly attribute unrestricted double m41;
+    readonly attribute unrestricted double m42;
+    readonly attribute unrestricted double m43;
+    readonly attribute unrestricted double m44;
+
+    readonly attribute boolean is2D;
+    readonly attribute boolean isIdentity;
+
+    // Immutable transform methods
+    [NewObject] DOMMatrix translate(optional unrestricted double tx = 0,
+                                    optional unrestricted double ty = 0,
+                                    optional unrestricted double tz = 0);
+    [NewObject] DOMMatrix scale(optional unrestricted double scaleX = 1,
+                                optional unrestricted double scaleY,
+                                optional unrestricted double scaleZ = 1,
+                                optional unrestricted double originX = 0,
+                                optional unrestricted double originY = 0,
+                                optional unrestricted double originZ = 0);
+    [NewObject] DOMMatrix scaleNonUniform(optional unrestricted double scaleX = 1,
+                                          optional unrestricted double scaleY = 1);
+    [NewObject] DOMMatrix scale3d(optional unrestricted double scale = 1,
+                                  optional unrestricted double originX = 0,
+                                  optional unrestricted double originY = 0,
+                                  optional unrestricted double originZ = 0);
+    [NewObject] DOMMatrix rotate(optional unrestricted double rotX = 0,
+                                 optional unrestricted double rotY,
+                                 optional unrestricted double rotZ);
+    [NewObject] DOMMatrix rotateFromVector(optional unrestricted double x = 0,
+                                           optional unrestricted double y = 0);
+    [NewObject] DOMMatrix rotateAxisAngle(optional unrestricted double x = 0,
+                                          optional unrestricted double y = 0,
+                                          optional unrestricted double z = 0,
+                                          optional unrestricted double angle = 0);
+    [NewObject] DOMMatrix skewX(optional unrestricted double sx = 0);
+    [NewObject] DOMMatrix skewY(optional unrestricted double sy = 0);
+    [NewObject] DOMMatrix multiply(optional DOMMatrixInit other);
+    [NewObject] DOMMatrix flipX();
+    [NewObject] DOMMatrix flipY();
+    [NewObject] DOMMatrix inverse();
+
+    [NewObject] DOMPoint transformPoint(optional DOMPointInit point);
+    [NewObject] Float32Array toFloat32Array();
+    [NewObject] Float64Array toFloat64Array();
+
+    [Exposed=Window] stringifier;
+    [Default] object toJSON();
+};

--- a/lib/jsdom/living/geometry/DOMPoint-impl.js
+++ b/lib/jsdom/living/geometry/DOMPoint-impl.js
@@ -1,0 +1,11 @@
+"use strict";
+
+class DOMPoint extends DOMPointReadOnly {
+  constructor(x = 0, y = 0, z = 0, w = 0) {
+    super(x, y, z, w);
+  }
+
+  static fromPoint({ x, y, z, w }) {
+    return new DOMPoint(x, y, z, w);
+  }
+}

--- a/lib/jsdom/living/geometry/DOMPoint.webidl
+++ b/lib/jsdom/living/geometry/DOMPoint.webidl
@@ -1,0 +1,22 @@
+// https://www.w3.org/TR/geometry-1/#dompoint
+
+[Constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
+             optional unrestricted double z = 0, optional unrestricted double w = 1),
+ Exposed=(Window,Worker),
+ Serializable,
+ LegacyWindowAlias=SVGPoint]
+interface DOMPoint : DOMPointReadOnly {
+    [NewObject] static DOMPoint fromPoint(optional DOMPointInit other);
+
+    inherit attribute unrestricted double x;
+    inherit attribute unrestricted double y;
+    inherit attribute unrestricted double z;
+    inherit attribute unrestricted double w;
+};
+
+dictionary DOMPointInit {
+    unrestricted double x = 0;
+    unrestricted double y = 0;
+    unrestricted double z = 0;
+    unrestricted double w = 1;
+};

--- a/lib/jsdom/living/geometry/DOMPointReadOnly-impl.js
+++ b/lib/jsdom/living/geometry/DOMPointReadOnly-impl.js
@@ -1,0 +1,34 @@
+"use strict";
+
+class DOMPointReadOnly {
+  constructor(x = 0, y = 0, z = 0, w = 0) {
+    this._x = x;
+    this._y = y;
+    this._z = z;
+    this._w = w;
+  }
+
+  get x() {
+    return this._x;
+  }
+
+  get y() {
+    return this._y;
+  }
+
+  get z() {
+    return this._z;
+  }
+
+  get w() {
+    return this._w;
+  }
+
+  static fromPoint({ x, y, z, w }) {
+    return new DOMPointReadOnly(x, y, z, w);
+  }
+
+  matrixTransform(matrix) {
+    return matrix;
+  }
+}

--- a/lib/jsdom/living/geometry/DOMPointReadOnly.webidl
+++ b/lib/jsdom/living/geometry/DOMPointReadOnly.webidl
@@ -1,0 +1,18 @@
+// https://www.w3.org/TR/geometry-1/#dompointreadonly
+
+[Constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
+             optional unrestricted double z = 0, optional unrestricted double w = 1),
+ Exposed=(Window,Worker),
+ Serializable]
+interface DOMPointReadOnly {
+    [NewObject] static DOMPointReadOnly fromPoint(optional DOMPointInit other);
+
+    readonly attribute unrestricted double x;
+    readonly attribute unrestricted double y;
+    readonly attribute unrestricted double z;
+    readonly attribute unrestricted double w;
+
+    DOMPoint matrixTransform(optional DOMMatrixInit matrix);
+
+    [Default] object toJSON();
+};

--- a/lib/jsdom/living/helpers/geometry/dommatrix-init.js
+++ b/lib/jsdom/living/helpers/geometry/dommatrix-init.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const { matrix2dArrayProperties, matrix3dArrayProperties } = require("./matrix");
+
+const aliasedProperties = [
+  ["a", "m11", 1],
+  ["b", "m12", 0],
+  ["c", "m21", 0],
+  ["d", "m22", 1],
+  ["e", "m41", 0],
+  ["f", "m42", 0]
+];
+
+// Properties that are required to be zero for a valid 2D Matrix
+const matrix2dZeroProps = [
+  "m13", "m14", "m23", "m24",
+  "m31", "m32", "m34", "m43"
+];
+
+// Properties that are required to be one for a valid 2D matrix
+const matrix2dOneProps = ["m33", "m44"];
+
+
+function hasProp(o, prop) {
+  return Object.prototype.hasOwnProperty.call(o, prop);
+}
+
+function propertyIsTrue(o, prop) {
+  return hasProp(o, prop) && Boolean(o[prop]);
+}
+
+// If both alias and actual properties are present, they must be equal.
+function validateAliasedProps(init) {
+  aliasedProperties.forEach(([alias, prop]) => {
+    if (
+      hasProp(init, alias) &&
+      hasProp(init, prop) &&
+      init[alias] !== init[prop]
+    ) {
+      throw new TypeError(`Invalid Matrix initialization object.`);
+    }
+  });
+}
+
+function isValid2dMatrix(init) {
+  return !(matrix2dZeroProps.some(x => hasProp(init, x) && init[x] !== 0) ||
+    matrix2dOneProps.some(x => hasProp(init, x) && init[x] !== 1));
+}
+
+function getDOMMatrixDimension(init) {
+  if (hasProp(init, "id2D") && !is2D) {
+    return false;
+  }
+
+  const valid2DMatrix = isValid2dMatrix(init);
+
+  if (propertyIsTrue(init, "is2D") && !valid2DMatrix) {
+    throw new TypeError(`Two Dimensional Matrix Initialization is in an invalid state.`);
+  }
+
+  return valid2DMatrix;
+}
+
+function fixupDOMMatrixInit(init) {
+  const fixedInit = Object.assign({}, init);
+
+  aliasedProperties.forEach(([alias, property, defaultValue]) => {
+    fixedInit[property] = init[alias] || defaultValue;
+  });
+
+  return fixedInit;
+}
+
+exports.validateDOMMatrixInit = function (init) {
+  validateAliasedProps(init);
+  init = fixupDOMMatrixInit(init);
+
+  init.is2D = getDOMMatrixDimension(init);
+
+  return init;
+};
+
+exports.arrayFromDOMMatrixInit = function (init) {
+  if (init.is2D) {
+    return matrix2dArrayProperties.map(x => init[x]);
+  }
+
+  return matrix3dArrayProperties.map(x => init[x]);
+};

--- a/lib/jsdom/living/helpers/geometry/dommatrix-init.js
+++ b/lib/jsdom/living/helpers/geometry/dommatrix-init.js
@@ -48,7 +48,7 @@ function isValid2dMatrix(init) {
 }
 
 function getDOMMatrixDimension(init) {
-  if (hasProp(init, "id2D") && !is2D) {
+  if (hasProp(init, "id2D") && !init.is2D) {
     return false;
   }
 

--- a/lib/jsdom/living/helpers/geometry/matrix.js
+++ b/lib/jsdom/living/helpers/geometry/matrix.js
@@ -52,11 +52,13 @@ exports.matrixUtils = {
   },
   normalizeVector(x, y, z) {
     const magnitude = this.getVector3Magnitude(x, y, z);
-    return {
-      x: x / magnitude,
-      y: y / magnitude,
-      z: z / magnitude
-    };
+    return magnitude === 0 ?
+      { x, y, z } :
+      {
+        x: x / magnitude,
+        y: y / magnitude,
+        z: z / magnitude
+      };
   },
   toRadians(degrees) {
     return degrees * Math.PI / 180;

--- a/lib/jsdom/living/helpers/geometry/matrix.js
+++ b/lib/jsdom/living/helpers/geometry/matrix.js
@@ -1,0 +1,64 @@
+"use strict";
+
+exports.matrix3dArrayProperties = [
+  "m11", "m12", "m13", "m14",
+  "m21", "m22", "m23", "m24",
+  "m31", "m32", "m33", "m34",
+  "m41", "m42", "m43", "m44"
+];
+
+exports.matrix2dArrayProperties =
+  ["m11", "m12", "m21", "m22", "m41", "m42"];
+
+exports.matrixUtils = {
+  to2DMatrix(m, order) {
+    const m2d = [];
+    for (let row = 0; row < order; row += 1) {
+      m2d[row] = [];
+      for (let col = 0; col < order; col += 1) {
+        const idx = col + order * row;
+        m2d[row][col] = m[idx];
+      }
+    }
+
+    return m2d;
+  },
+  to1DMatrix(m2d) {
+    return m2d.reduce((m2, row) => m2.concat(row), []);
+  },
+  getPivotRow(matrix, column) {
+    let max = 0;
+    let pivot = column;
+
+    for (let row = column; row < matrix.length; row += 1) {
+      const element = Math.abs(matrix[row][column]);
+      if (max < element) {
+        max = element;
+        pivot = row;
+      }
+    }
+
+    return pivot;
+  },
+  swapRows(matrix, a, b) {
+    const t = matrix[a];
+    matrix[a] = matrix[b];
+    matrix[b] = t;
+  },
+  getVector3Magnitude(x, y, z) {
+    return Math.sqrt(Math.pow(x, 2) +
+      Math.pow(y, 2) +
+      Math.pow(z, 2));
+  },
+  normalizeVector(x, y, z) {
+    const magnitude = this.getVector3Magnitude(x, y, z);
+    return {
+      x: x / magnitude,
+      y: y / magnitude,
+      z: z / magnitude
+    };
+  },
+  toRadians(degrees) {
+    return degrees * Math.PI / 180;
+  }
+};

--- a/lib/jsdom/living/helpers/geometry/matrixDomStringParser.js
+++ b/lib/jsdom/living/helpers/geometry/matrixDomStringParser.js
@@ -1,8 +1,397 @@
 "use strict";
+/**
+ * Expected symbols when parsing dom string -> transform function
+ */
+const SYMBOL = {
+  number: /\d/,
+  char: /\D/,
+  lparen: /\(/,
+  rparen: /\)/,
+  whitespace: /\s/,
+  radixPoint: /\./,
+  comma: /,/,
+  commentOpen: /\/\*/,
+  commentClose: /\*\//
+};
 
-// https://www.w3.org/TR/css-transforms-1/#typedef-transform-function
-// https://drafts.csswg.org/css-transforms-2/#svg-three-dimensional-functions
-const transformFns = {
-  matrix3d : [],
-  
+/**
+ * A very slim css-parser for extracting functions from a css dom string
+ */
+class CssFunctionParser {
+  constructor(domString) {
+    this.buffer = domString;
+    this.index = 0;
+  }
+
+  is(symbol, lookahead = 0) {
+    return symbol.test(this.buffer.slice(this.index, this.index + 1 + lookahead));
+  }
+
+  get currentChar() {
+    return this.buffer[this.index];
+  }
+
+  get peek() {
+    return this.buffer[this.index + 1];
+  }
+
+  advance() {
+    this.index += 1;
+
+    if (this.index > this.buffer.length) {
+      throw new RangeError(`Advanced beyond the buffer length`);
+    }
+
+    return this.currentChar;
+  }
+
+  skipWhiteSpace() {
+    while (this.is(SYMBOL.whitespace)) {
+      this.advance();
+    }
+  }
+
+  skipComment() {
+    if (this.is(SYMBOL.commentOpen, 1)) {
+      while (this.index < this.buffer.length) {
+        this.advance();
+        if (this.is(SYMBOL.commentClose, 1)) {
+          // clear closing comments
+          this.advance();
+          this.advance();
+          break;
+        }
+      }
+    }
+  }
+
+  getFunction() {
+    let buffer = "";
+
+    while (!this.is(SYMBOL.lparen)) {
+      buffer += this.currentChar;
+      this.advance();
+    }
+
+    // discard lparen
+    this.advance();
+
+    return buffer;
+  }
+
+  getParams() {
+    let buffer = "";
+    const params = [];
+
+    while (!this.is(SYMBOL.rparen)) {
+      if (
+        !this.is(SYMBOL.whitespace) &&
+        !this.is(SYMBOL.comma)
+      ) {
+        buffer += this.currentChar;
+      } else if (buffer.length > 0) {
+        params.push(buffer);
+        buffer = "";
+      }
+
+      this.advance();
+    }
+
+    // clear remaining buffer
+    if (buffer.length > 0) {
+      params.push(buffer);
+    }
+
+    // discard rparen
+    this.advance();
+
+    return params;
+  }
+
+  parse() {
+    const functions = [];
+
+    while (this.index < this.buffer.length - 1) {
+      this.skipWhiteSpace();
+      this.skipComment();
+
+      const transformFunction = this.getFunction();
+      const transformParams = this.getParams();
+
+      functions.push([transformFunction, transformParams]);
+    }
+
+    return functions;
+  }
+}
+
+function validateParameterLength(expectedLength, params, fnName = "") {
+  const isValidLength = Array.isArray(expectedLength) ?
+    params.length >= expectedLength[0] && params.length <= expectedLength[1] :
+    params.length === expectedLength;
+
+  if (!isValidLength) {
+    throw new TypeError(`Received invalid number of parameters for function ${fnName}, got ${params.length} expected ${expectedLength}`);
+  }
+}
+
+// https://drafts.csswg.org/css-transforms-1/#typedef-transform-function
+// https://drafts.csswg.org/css-transforms-2/#three-d-transform-functions
+const transformFunctionNames = [
+  "matrix3d",
+  "matrix",
+  "translate3d",
+  "translate",
+  "translateX",
+  "translateY",
+  "translateZ",
+  "scale3d",
+  "scale",
+  "scaleX",
+  "scaleY",
+  "scaleZ",
+  "rotate3d",
+  "rotate",
+  "rotateX",
+  "rotateY",
+  "rotateZ",
+  "perspective",
+  "skew",
+  "skewX",
+  "skewY"
+];
+// https://www.w3.org/TR/css-values-4/#absolute-length
+const absoluteLengths = ["cm", "mm", "Q", "in", "pc", "pt", "px"];
+const LENGTH_CONVERTERS = {
+  cm(x) {
+    return this.in(x) / 2.54;
+  },
+  mm(x) {
+    return this.cm(x) / 10;
+  },
+  Q(x) {
+    return this.cm(x) / 40;
+  },
+  in(x) {
+    return x * 96;
+  },
+  pc(x) {
+    return this.in(x) / 6;
+  },
+  pt(x) {
+    return this.in(x) / 72;
+  },
+  px(x) {
+    return x;
+  }
+};
+
+// https://drafts.csswg.org/css-values-3/#angles
+const angleUnits = ["deg", "grad", "rad", "turn"];
+const ANGLE_CONVERTERS = {
+  deg(x) {
+    return x;
+  },
+  grad(x) {
+    return this.turn(x) / 400;
+  },
+  rad(x) {
+    return x * (180 / Math.PI);
+  },
+  turn(x) {
+    return x * 360;
+  }
+};
+
+const paramConverter = {
+  _rules: {
+    number(x) {
+      return (SYMBOL.radixPoint.test(x) || !isNaN(x)) && x !== null;
+    },
+    angleUnit(x) {
+      return angleUnits.includes(x);
+    },
+    absoluteLengthUnit(x) {
+      return absoluteLengths.includes(x);
+    }
+  },
+  _validate(rules, param) {
+    rules.forEach(matcher => {
+      if (!matcher(param)) {
+        throw new TypeError(`Failed to validate a parameter, ${rules} ${param}`);
+      }
+    });
+  },
+  _getUnitParam(paramString) {
+    let quantity = "";
+    let unit = "";
+
+    if (typeof paramString !== "string") {
+      throw new TypeError();
+    }
+
+    for (const next of paramString) {
+      if (this._rules.number(next) && unit.length === 0) {
+        quantity += next;
+      } else {
+        unit += next;
+      }
+    }
+
+    if (
+      quantity.length === 0
+    ) {
+      throw new TypeError();
+    }
+
+    return [quantity, unit];
+  },
+  number(param) {
+    const { number } = this._rules;
+    this._validate([number], param);
+
+    return Number(param);
+  },
+  lengthPercentage(param) {
+    const { number, absoluteLengthUnit } = this._rules;
+    const [length, unit] = this._getUnitParam(param);
+    this._validate([number], length);
+    this._validate([absoluteLengthUnit], unit);
+
+    return LENGTH_CONVERTERS[unit](Number(length));
+  },
+  angle(param) {
+    const { number, angleUnit } = this._rules;
+    const [length, unit] = this._getUnitParam(param);
+
+    this._validate([number], length);
+    // All transform functions expect 0 or angle type
+    if (Number(length) !== 0) {
+      this._validate([angleUnit], unit);
+    }
+
+    return ANGLE_CONVERTERS[unit || "deg"](Number(length));
+  }
+};
+
+// https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions
+// https://drafts.csswg.org/css-transforms-2/#three-d-transform-functions
+
+// Contains the definitions for valid parameters per transform function.
+// Preforms conversion of parameters to expected values.
+const transformFnParameterValidation = {
+  matrix3d: (...params) => {
+    validateParameterLength(16, params, "matrix3d");
+    return params.map(paramConverter.number.bind(paramConverter));
+  },
+  matrix: (...params) => {
+    validateParameterLength(6, params, "matrix");
+    return params.map(paramConverter.number.bind(paramConverter));
+  },
+  translate3d: (...params) => {
+    validateParameterLength(3, params, "translate3d");
+    return [
+      paramConverter.lengthPercentage(params[0]),
+      paramConverter.lengthPercentage(params[1]),
+      paramConverter.lengthPercentage(params[2])
+    ];
+  },
+  translate: (...params) => {
+    validateParameterLength([1, 2], params, "translate");
+    return [
+      paramConverter.lengthPercentage(params[0]),
+      paramConverter.lengthPercentage(params[1])
+    ];
+  },
+  translateX: (...params) => {
+    validateParameterLength(1, params, "translateX");
+    return params.map(paramConverter.lengthPercentage.bind(paramConverter));
+  },
+  translateY: (...params) => {
+    validateParameterLength(1, params, "translateY");
+    return params.map(paramConverter.lengthPercentage.bind(paramConverter));
+  },
+  translateZ: (...params) => {
+    validateParameterLength(1, params, "translateZ");
+    return params.map(paramConverter.lengthPercentage.bind(paramConverter));
+  },
+  scale3d: (...params) => {
+    validateParameterLength(3, params, "scale3d");
+    return params.map(paramConverter.number.bind(paramConverter));
+  },
+  scale: (...params) => {
+    validateParameterLength([1, 2], params, "scale");
+    return params.map(paramConverter.number.bind(paramConverter));
+  },
+  scaleX: (...params) => {
+    validateParameterLength(1, params, "scaleX");
+    return params.map(paramConverter.number.bind(paramConverter));
+  },
+  scaleY: (...params) => {
+    validateParameterLength(1, params, "scaleY");
+    return params.map(paramConverter.number.bind(paramConverter));
+  },
+  scaleZ: (...params) => {
+    validateParameterLength(1, params, "scaleX");
+    return params.map(paramConverter.number.bind(paramConverter));
+  },
+  rotate3d: (...params) => {
+    validateParameterLength(4, params, "rotate3d");
+    return [
+      ...params.slice(0, 3).map(paramConverter.number.bind(paramConverter)),
+      paramConverter.angle(params[3])
+    ];
+  },
+  rotate: (...params) => {
+    validateParameterLength(1, params, "rotate");
+    return params.map(paramConverter.angle.bind(paramConverter));
+  },
+  rotateX: (...params) => {
+    validateParameterLength(1, params, "rotateX");
+    return params.map(paramConverter.angle.bind(paramConverter));
+  },
+  rotateY: (...params) => {
+    validateParameterLength(1, params, "rotateY");
+    return params.map(paramConverter.angle.bind(paramConverter));
+  },
+  rotateZ: (...params) => {
+    validateParameterLength(1, params, "rotateZ");
+    return params.map(paramConverter.angle.bind(paramConverter));
+  },
+  perspective: (...params) => {
+    validateParameterLength(1, params, "perspective");
+    return params.map(paramConverter.lengthPercentage.bind(paramConverter));
+  },
+  skew: (...params) => {
+    validateParameterLength([1, 2], params, "skew");
+    return params.map(paramConverter.angle.bind(paramConverter));
+  },
+  skewX: (...params) => {
+    validateParameterLength(1, params, "skewX");
+    return params.map(paramConverter.angle.bind(paramConverter));
+  },
+  skewY: (...params) => {
+    validateParameterLength(1, params, "skewY");
+    return params.map(paramConverter.angle.bind(paramConverter));
+  }
+};
+
+function validateTransformFunction([fnName, fnParams]) {
+  if (!transformFunctionNames.includes(fnName)) {
+    throw new TypeError(`invalid transform function ${fnName}`);
+  }
+
+  const expectedParams = transformFnParameterValidation[fnName](...fnParams);
+
+  return [fnName, expectedParams];
+}
+
+exports.parseDOMStringToMatrixFunctions = function (domString) {
+  try {
+    const fnList = new CssFunctionParser(domString).parse();
+
+    return fnList.map(validateTransformFunction);
+  } catch (e) {
+    throw new TypeError(`Failed to parse DOMString ${e.stack}`);
+  }
 };

--- a/lib/jsdom/living/helpers/geometry/matrixDomStringParser.js
+++ b/lib/jsdom/living/helpers/geometry/matrixDomStringParser.js
@@ -1,0 +1,8 @@
+"use strict";
+
+// https://www.w3.org/TR/css-transforms-1/#typedef-transform-function
+// https://drafts.csswg.org/css-transforms-2/#svg-three-dimensional-functions
+const transformFns = {
+  matrix3d : [],
+  
+};

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -92,3 +92,6 @@ exports.URL = require("whatwg-url").URL;
 exports.URLSearchParams = require("whatwg-url").URLSearchParams;
 
 exports.Headers = require("./generated/Headers").interface;
+
+exports.DOMMatrixReadOnly = require("./generated/DOMMatrixReadOnly").interface;
+exports.DOMMatrix = require("./generated/DOMMatrix").interface;

--- a/scripts/webidl/convert.js
+++ b/scripts/webidl/convert.js
@@ -30,6 +30,7 @@ addDir("../../lib/jsdom/living/mutation-observer");
 addDir("../../lib/jsdom/living/navigator");
 addDir("../../lib/jsdom/living/nodes");
 addDir("../../lib/jsdom/living/svg");
+addDir("../../lib/jsdom/living/geometry");
 addDir("../../lib/jsdom/living/traversal");
 addDir("../../lib/jsdom/living/websockets");
 addDir("../../lib/jsdom/living/webstorage");

--- a/test/web-platform-tests/to-upstream/geometry/dommatrix.html
+++ b/test/web-platform-tests/to-upstream/geometry/dommatrix.html
@@ -16,7 +16,7 @@
     dma = dma instanceof DOMMatrix ? dma : DOMMatrix.fromMatrix(dma);
     dmb = dmb instanceof DOMMatrix ? dmb : DOMMatrix.fromMatrix(dmb);
 
-    assert_array_approx_equals(arrayFromDm(dma), arrayFromDm(dmb), 0.00000000001);
+    assert_array_approx_equals(arrayFromDm(dma), arrayFromDm(dmb), 0.000001);
   }
 
   test(() => {
@@ -303,4 +303,636 @@
     assert_false(dm.is2D);
     assert_false(dm.is2D);
   }, "unsuccessfull inverse");
+
+  test(() => {
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("translate(2px, 2px)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 2,
+        f: 2,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 2,
+        m42: 2,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - translate");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("translateX(10pc)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 160,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 160,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - translateX");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("translateY(33.2pt)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 44.266666412353516,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 44.266666412353516,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - translateY");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("translateZ(54.1pc)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 865.6,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - translateZ");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("scale3d(1, 2, 3)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 2,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 2,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 3,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - scale3d");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("scale(2.5)"), {
+        a: 2.5,
+        b: 0,
+        c: 0,
+        d: 2.5,
+        e: 0,
+        f: 0,
+        m11: 2.5,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 2.5,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - scale, 1 param");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("scale(3.4, 5.6)"), {
+        a: 3.4,
+        b: 0,
+        c: 0,
+        d: 5.6,
+        e: 0,
+        f: 0,
+        m11: 3.4,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 5.6,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - scale, 2 param");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("scaleX(99.99)"), {
+        a: 99.99,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 99.99,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - scaleX");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("scaleY(42.24)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 42.24,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 42.24,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - scaleY");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("scaleZ(1337)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1337,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - scaleZ");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("rotate3d(2,3,4,5deg)"), {
+        a: 0.9967195673204703,
+        b: 0.0655249643374812,
+        c: -0.06395035665130694,
+        d: 0.9973756538563763,
+        e: 0,
+        f: 0,
+        m11: 0.9967195673204703,
+        m12: 0.0655249643374812,
+        m13: -0.04750350691334605,
+        m14: 0,
+        m21: -0.06395035665130694,
+        m22: 0.9973756538563763,
+        m23: 0.03394343793337129,
+        m24: 0,
+        m31: 0.04960298382824506,
+        m32: -0.030794222561022776,
+        m33: 0.9982941750066445,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - rotate3d, deg");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("rotate3d(2,3,4,5rad)"), {
+        a: 0.38246740126140194,
+        b: -0.5640632461817592,
+        c: 0.8604788935762862,
+        d: 0.5059739210091216,
+        e: 0,
+        f: 0,
+        m11: 0.38246740126140194,
+        m12: -0.5640632461817592,
+        m13: 0.7318137340056183,
+        m14: 0,
+        m21: 0.8604788935762862,
+        m22: 0.5059739210091216,
+        m23: -0.05971988754498425,
+        m24: 0,
+        m31: -0.33659287081291556,
+        m32: 0.6525511823340384,
+        m33: 0.678883048655929,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - rotate3d, rad");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("rotateX(32.5deg)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 0.8433914458128857,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 0.8433914458128857,
+        m23: 0.5372996083468239,
+        m24: 0,
+        m31: 0,
+        m32: -0.5372996083468239,
+        m33: 0.8433914458128857,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - rotateX");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("rotateY(54.7turn)"), {
+        a: -0.30901699437497704,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: -0.30901699437497704,
+        m12: 0,
+        m13: 0.951056516295144,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: -0.951056516295144,
+        m32: 0,
+        m33: -0.30901699437497704,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - rotateY");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("rotateZ(43110rad)"), {
+        a: 0.48397273984362715,
+        b: 0.8750830743925132,
+        c: -0.8750830743925132,
+        d: 0.48397273984362715,
+        e: 0,
+        f: 0,
+        m11: 0.48397273984362715,
+        m12: 0.8750830743925132,
+        m13: 0,
+        m14: 0,
+        m21: -0.8750830743925132,
+        m22: 0.48397273984362715,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - rotateZ");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("perspective(200px)"), {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: -0.005,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - perspective");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("skew(200deg)"), {
+        a: 1,
+        b: 0,
+        c: 0.3639702342662023,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0.3639702342662023,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - skew, 1 param");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("skew(200deg, 43rad)"), {
+        a: 1,
+        b: -1.4983873388551476,
+        c: 0.3639702342662023,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: -1.4983873388551476,
+        m13: 0,
+        m14: 0,
+        m21: 0.3639702342662023,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - skew, 2 params");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("skewX(2turn)"), {
+        a: 1,
+        b: 0,
+        c: -4.898587196589413e-16,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: -4.898587196589413e-16,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - skewX");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("skewY(2turn)"), {
+        a: 1,
+        b: -4.898587196589413e-16,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: -4.898587196589413e-16,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: false
+      });
+    }, "DOMString - skewY");
+    test(() => {
+      domMatricesApproxEqual(new DOMMatrix("skew(50deg) perspective(45px) translate(4px, 4px) scale3d(4, 8, 10) rotate3d(8.2, 3.4, 5.6, 10.10rad)"), {
+        a: 2.3417802350529544,
+        b: 0.9370438153327196,
+        c: -2.523949213106225,
+        d: -4.749747330944418,
+        e: 8.76701437037684,
+        f: 4,
+        m11: 2.3417802350529544,
+        m12: 0.9370438153327196,
+        m13: 9.447131743890601,
+        m14: -0.20993626097534673,
+        m21: -2.523949213106225,
+        m22: -4.749747330944418,
+        m23: -1.805972368866603,
+        m24: 0.040132719308146735,
+        m31: 9.749023014122645,
+        m32: 6.368818507410388,
+        m33: -2.736816693983152,
+        m34: 0.060818148755181156,
+        m41: 8.76701437037684,
+        m42: 4,
+        m43: 0,
+        m44: 1,
+        is2D: false,
+        isIdentity: false
+      });
+    }, "DOMString - chaining");
+    test(() => {
+      const identity = {
+        a: 1,
+        b: 0,
+        c: 0,
+        d: 1,
+        e: 0,
+        f: 0,
+        m11: 1,
+        m12: 0,
+        m13: 0,
+        m14: 0,
+        m21: 0,
+        m22: 1,
+        m23: 0,
+        m24: 0,
+        m31: 0,
+        m32: 0,
+        m33: 1,
+        m34: 0,
+        m41: 0,
+        m42: 0,
+        m43: 0,
+        m44: 1,
+        is2D: true,
+        isIdentity: true
+      };
+
+      domMatricesApproxEqual(new DOMMatrix("none"), identity);
+      domMatricesApproxEqual(new DOMMatrix(""), identity);
+    }, "DOMString - none");
+    test(() => {
+      assert_throws("SyntaxError", () => {
+        const dm = new DOMMatrix("trans late(50)");
+      });
+      assert_throws("SyntaxError", () => {
+        const dm = new DOMMatrix("rotateX(50px)");
+      });
+    }, "DOMString - parse error");
+  }, "DOMString Tests");
+
+
 </script>

--- a/test/web-platform-tests/to-upstream/geometry/dommatrix.html
+++ b/test/web-platform-tests/to-upstream/geometry/dommatrix.html
@@ -1,0 +1,306 @@
+<!DOCTYPE HTML>
+<title>DOMMatrixReadOnly interface</title>
+<link rel="author" title="David Campion" href="mailto:me@davecampion.com">
+<link rel="help" href="https://www.w3.org/TR/geometry-1/#dommatrixreadonly">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+  "use strict";
+  function arrayFromDm(dm) {
+    return ["m11", "m12", "m13", "m14", "m21", "m22", "m23", "m24", "m31", "m32", "m33", "m34", "m41", "m42", "m43", "m44"].map(x => dm[x]);
+  }
+
+  function domMatricesApproxEqual(dma, dmb) {
+    dma = dma instanceof DOMMatrix ? dma : DOMMatrix.fromMatrix(dma);
+    dmb = dmb instanceof DOMMatrix ? dmb : DOMMatrix.fromMatrix(dmb);
+
+    assert_array_approx_equals(arrayFromDm(dma), arrayFromDm(dmb), 0.00000000001);
+  }
+
+  test(() => {
+    const dmA = new DOMMatrix([2, 2, 2, 2, 2, 2]);
+    const dmB = new DOMMatrix([2, 2, 2, 2, 2, 2]);
+    const expectedResult = new DOMMatrix([8, 8, 8, 8, 10, 10]);
+
+    assert_object_equals(dmA.multiplySelf(dmB).toJSON(), expectedResult.toJSON());
+  }, "Multiply Self 2D");
+
+  test(() => {
+    const dmA = new DOMMatrix([
+      1, 2, 3, 4,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+    ]);
+    const dmB = new DOMMatrix([
+      1, 5, 9, 13,
+      2, 6, 10, 14,
+      3, 7, 11, 15,
+      4, 8, 12, 16
+    ]);
+    const expectedResult = new DOMMatrix([
+      276, 304, 332, 360,
+      304, 336, 368, 400,
+      332, 368, 404, 440,
+      360, 400, 440, 480
+    ]);
+    assert_object_equals(dmA.multiplySelf(dmB).toJSON(), expectedResult.toJSON());
+  }, "Multiply self 3d");
+
+  test(() => {
+    const dmA = new DOMMatrix([
+      1, 5, 9, 13,
+      2, 6, 10, 14,
+      3, 7, 11, 15,
+      4, 8, 12, 16
+    ]);
+    const dmB = new DOMMatrix([
+      1, 2, 3, 4,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+    ]);
+    const expectedResult = new DOMMatrix([
+      276, 304, 332, 360,
+      304, 336, 368, 400,
+      332, 368, 404, 440,
+      360, 400, 440, 480
+    ]);
+
+    assert_object_equals(dmA.preMultiplySelf(dmB).toJSON(), expectedResult.toJSON());
+  }, "preMultiplySelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 2, 3, 4,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+    ]);
+    const expectedResult = new DOMMatrix([
+      1, 2, 3, 4,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      3813, 4414, 5015, 5616
+    ]);
+
+    dm.translateSelf(100, 200, 300);
+
+    assert_object_equals(dm.toJSON(), expectedResult.toJSON());
+  }, "translateSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+    const expectedResult = new DOMMatrix([
+      77, 0, 0, 0,
+      0, 88, 0, 0,
+      0, 0, 99, 0,
+      0, 0, 0, 1
+    ]);
+
+    dm.scaleSelf(77, 88, 99);
+
+    assert_object_equals(dm.toJSON(), expectedResult.toJSON());
+  }, "scaleSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+    const expectedResult = new DOMMatrix([
+      6, 0, 0, 0,
+      0, 7, 0, 0,
+      0, 0, 8, 0,
+      -50, -120, -210, 1
+    ]);
+
+    dm.scaleSelf(6, 7, 8, 10, 20, 30);
+
+    assert_object_equals(dm.toJSON(), expectedResult.toJSON());
+  }, "scaleSelf with origins");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 5, 9, 13,
+      2, 6, 10, 14,
+      3, 7, 11, 15,
+      4, 8, 12, 16
+    ]);
+
+    const expectedResult = new DOMMatrix([
+      20, 100, 180, 260,
+      40, 120, 200, 280,
+      60, 140, 220, 300,
+      4, 8, 12, 16
+    ]);
+
+    dm.scale3dSelf(20);
+
+    assert_object_equals(dm.toJSON(), expectedResult.toJSON());
+  }, "scale3dSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 5, 9, 13,
+      2, 6, 10, 14,
+      3, 7, 11, 15,
+      4, 8, 12, 16
+    ]);
+
+    const expectedResult = new DOMMatrix([
+      20, 100, 180, 260,
+      40, 120, 200, 280,
+      60, 140, 220, 300,
+      -3454, -12874, -22294, -31714
+    ]);
+
+    dm.scale3dSelf(20, 89, 12, 23);
+
+    assert_object_equals(dm.toJSON(), expectedResult.toJSON());
+  }, "scale3dSelf with origins");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+    const expectedResult = new DOMMatrix([
+      0.8654978445076765, 0.03022385072365709, -0.49999999999999994, 0,
+      0.13811109742723254, 0.9450883508630621, 0.29619813272602386, 0,
+      0.4814964235796683, -0.3254143941351886, 0.8137976813493738,
+      0, 0, 0, 0, 1
+    ]);
+
+    dm.rotateSelf(20, 30, 2);
+
+    domMatricesApproxEqual(dm, expectedResult);
+  }, "rotateSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 2, 3, 4,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+    ]);
+
+    const expectedResult = new DOMMatrix([
+      4.6, 6.000000000000001, 7.4, 8.8,
+      2.2, 1.9999999999999996, 1.7999999999999998, 1.5999999999999996,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+    ]);
+
+    dm.rotateFromVectorSelf(3, 4);
+
+    domMatricesApproxEqual(dm, expectedResult);
+
+  }, "rotateFromVectorSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 5, 9, 13,
+      2, 6, 10, 14,
+      3, 7, 11, 15,
+      4, 8, 12, 16
+    ]);
+
+    const expectedResult = new DOMMatrix([
+      0.5021803117274577, 2.671956022740467, 4.841731733753477, 7.011507444766486,
+      2.039564308493662, 3.5501760370414877, 5.060787765589314, 6.5713994941371405,
+      3.0964483470634674, 9.500363209822943, 15.90427807258242, 22.308192935341896,
+      4, 8, 12, 16
+    ]);
+    dm.rotateAxisAngleSelf(2.3, 7, 9, 85);
+
+    domMatricesApproxEqual(dm, expectedResult);
+
+  }, "rotateAxisAngleSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+
+    const expectedResult = new DOMMatrix([
+      1, 0, 0, 0,
+      0.17632698070846498, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+
+    dm.skewXSelf(10);
+    domMatricesApproxEqual(dm, expectedResult);
+  }, "skewXSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 2, 3, 4,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+    ]);
+
+    const expectedResult = new DOMMatrix([
+      1.7615355016222511, 2.913842601946701, 4.066149702271152, 5.218456802595602,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+  ]);
+
+    dm.skewYSelf(8.66);
+    domMatricesApproxEqual(dm, expectedResult);
+  }, "skewYSelf");
+
+  test(() => {
+    const dm = new DOMMatrix([0.2, 0.3, 0.4, 0.5, 0.6, 0.7]);
+
+    const expectedResult = new DOMMatrix([
+      -25.000000000000014, 15.000000000000007, 0, 0,
+      20.00000000000001, -10.000000000000005, 0, 0,
+      0, 0, 1, 0,
+      1.0000000000000013, -2.0000000000000013, 0, 1
+    ]);
+
+    dm.invertSelf();
+
+    domMatricesApproxEqual(dm, expectedResult);
+  }, "successful inverse");
+
+  test(() => {
+    const dm = new DOMMatrix([
+      1, 1, 1, 1,
+      1, 1, 1, 1,
+      1, 1, 1, 1,
+      1, 1, 1, 1
+    ]);
+
+    const expectedResult = new DOMMatrix([
+      NaN, NaN, NaN, NaN,
+      NaN, NaN, NaN, NaN,
+      NaN, NaN, NaN, NaN,
+      NaN, NaN, NaN, NaN
+    ]);
+
+    dm.invertSelf();
+
+    assert_array_equals(arrayFromDm(dm), arrayFromDm(expectedResult));
+    assert_false(dm.is2D);
+    assert_false(dm.is2D);
+  }, "unsuccessfull inverse");
+</script>

--- a/test/web-platform-tests/to-upstream/geometry/dommatrixreadonly.html
+++ b/test/web-platform-tests/to-upstream/geometry/dommatrixreadonly.html
@@ -19,7 +19,6 @@
     assert_equals(domMatrixReadOnly.d, 1);
     assert_equals(domMatrixReadOnly.e, 0);
     assert_equals(domMatrixReadOnly.f, 0);
-
   }, "Default Constructor");
 
   test(() => {
@@ -56,12 +55,36 @@
     assert_equals(domMatrixReadOnly.m44, 4);
   }, "3d Matrix Constructor");
 
-  // Todo: Implement support for DOMString Constructor.
-  // test(() => {
-  //   const domMatrixReadOnly = new DOMMatrixReadOnly("matrix(1,2,3,4,5,6)");
-  //
-  //   assert_equals(...)
-  // }, "DOMString Constructor");
+  test(() => {
+    const domMatrixReadOnly = new DOMMatrixReadOnly("matrix(1,2,3,4,5,6)");
+
+    assert_object_equals(domMatrixReadOnly.toJSON(), {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+      f: 6,
+      m11: 1,
+      m12: 2,
+      m13: 0,
+      m14: 0,
+      m21: 3,
+      m22: 4,
+      m23: 0,
+      m24: 0,
+      m31: 0,
+      m32: 0,
+      m33: 1,
+      m34: 0,
+      m41: 5,
+      m42: 6,
+      m43: 0,
+      m44: 1,
+      is2D: true,
+      isIdentity: false
+    });
+  }, "DOMString Constructor");
 
   test(() => {
     assert_throws(new TypeError(), () => {
@@ -129,7 +152,7 @@
     assert_equals(domMatrixReadOnly.m42, 0);
     assert_equals(domMatrixReadOnly.m43, 0);
     assert_equals(domMatrixReadOnly.m44, 1);
-  });
+  }, "Valid Matrix Initialization");
 
   test(() => {
     assert_throws(new TypeError(), () => {
@@ -141,7 +164,6 @@
       const invalid = Object.assign({}, matrixInit, { m13: 1 });
       DOMMatrixReadOnly.fromMatrix(invalid);
     });
-
   }, "Invalid 2d state");
 
   test(() => {
@@ -317,41 +339,41 @@
   const domMatrixTransform = new DOMMatrixReadOnly();
   test(() => {
     assert_true(domMatrixTransform.translate() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.translate instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.scale() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.scale instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.scaleNonUniform() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.scaleNonUniform instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.scale3d() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.scale3d instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.rotate() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.rotate instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.rotateFromVector() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.rotateFromVector instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.rotateAxisAngle() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.rotateAxisAngle instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.skewX() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.skewX instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.skewY() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.skewY instanceof DOMMatrix");
 
   test(() => {
     assert_true(domMatrixTransform.multiply() instanceof DOMMatrix);
-  });
+  }, "DOMMatrixReadonly.multiply instanceof DOMMatrix");
 </script>

--- a/test/web-platform-tests/to-upstream/geometry/dommatrixreadonly.html
+++ b/test/web-platform-tests/to-upstream/geometry/dommatrixreadonly.html
@@ -1,0 +1,357 @@
+<!DOCTYPE HTML>
+<title>DOMMatrixReadOnly interface</title>
+<link rel="author" title="David Campion" href="mailto:me@davecampion.com">
+<link rel="help" href="https://www.w3.org/TR/geometry-1/#dommatrixreadonly">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+  "use strict";
+
+  test(() => {
+    const domMatrixReadOnly = new DOMMatrixReadOnly();
+
+    assert_true(domMatrixReadOnly.is2D);
+    assert_equals(domMatrixReadOnly.a, 1);
+    assert_equals(domMatrixReadOnly.b, 0);
+    assert_equals(domMatrixReadOnly.c, 0);
+    assert_equals(domMatrixReadOnly.d, 1);
+    assert_equals(domMatrixReadOnly.e, 0);
+    assert_equals(domMatrixReadOnly.f, 0);
+
+  }, "Default Constructor");
+
+  test(() => {
+    const domMatrixReadOnly = new DOMMatrixReadOnly([1, 1, 1, 1, 1, 1]);
+
+    assert_true(domMatrixReadOnly.is2D);
+    assert_equals(domMatrixReadOnly.a, 1);
+    assert_equals(domMatrixReadOnly.b, 1);
+    assert_equals(domMatrixReadOnly.c, 1);
+    assert_equals(domMatrixReadOnly.d, 1);
+    assert_equals(domMatrixReadOnly.e, 1);
+    assert_equals(domMatrixReadOnly.f, 1);
+  }, "2d Matrix constructor");
+
+  test(() => {
+    const domMatrixReadOnly = new DOMMatrixReadOnly([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4]);
+
+    assert_false(domMatrixReadOnly.is2D);
+    assert_equals(domMatrixReadOnly.m11, 1);
+    assert_equals(domMatrixReadOnly.m12, 1);
+    assert_equals(domMatrixReadOnly.m13, 1);
+    assert_equals(domMatrixReadOnly.m14, 1);
+    assert_equals(domMatrixReadOnly.m21, 2);
+    assert_equals(domMatrixReadOnly.m22, 2);
+    assert_equals(domMatrixReadOnly.m23, 2);
+    assert_equals(domMatrixReadOnly.m24, 2);
+    assert_equals(domMatrixReadOnly.m31, 3);
+    assert_equals(domMatrixReadOnly.m32, 3);
+    assert_equals(domMatrixReadOnly.m33, 3);
+    assert_equals(domMatrixReadOnly.m34, 3);
+    assert_equals(domMatrixReadOnly.m41, 4);
+    assert_equals(domMatrixReadOnly.m42, 4);
+    assert_equals(domMatrixReadOnly.m43, 4);
+    assert_equals(domMatrixReadOnly.m44, 4);
+  }, "3d Matrix Constructor");
+
+  // Todo: Implement support for DOMString Constructor.
+  // test(() => {
+  //   const domMatrixReadOnly = new DOMMatrixReadOnly("matrix(1,2,3,4,5,6)");
+  //
+  //   assert_equals(...)
+  // }, "DOMString Constructor");
+
+  test(() => {
+    assert_throws(new TypeError(), () => {
+      // eslint-disable-next-line no-new
+      new DOMMatrixReadOnly([1, 2, 5]);
+    });
+  }, "Invalid constructor");
+
+  test(() => {
+    const isIdentity = new DOMMatrixReadOnly([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+    const isntIdentity = new DOMMatrixReadOnly([0, 0, 0, 1, 1, 0]);
+
+    assert_true(isIdentity.isIdentity);
+    assert_false(isntIdentity.isIdentity);
+  }, "isIdentity");
+
+  const matrixInit = {
+    m11: 1,
+    m12: 0,
+    m13: 0,
+    m14: 0,
+    m21: 0,
+    m22: 1,
+    m23: 0,
+    m24: 0,
+    m31: 0,
+    m32: 0,
+    m33: 1,
+    m34: 0,
+    m41: 0,
+    m42: 0,
+    m43: 0,
+    m44: 1,
+    is2D: true
+  };
+
+  test(() => {
+    const validMatrixInit = Object.assign({}, matrixInit);
+    const domMatrixReadOnly = DOMMatrixReadOnly.fromMatrix(validMatrixInit);
+    assert_equals(domMatrixReadOnly.a, 1);
+    assert_equals(domMatrixReadOnly.b, 0);
+    assert_equals(domMatrixReadOnly.c, 0);
+    assert_equals(domMatrixReadOnly.d, 1);
+    assert_equals(domMatrixReadOnly.e, 0);
+    assert_equals(domMatrixReadOnly.f, 0);
+
+    assert_equals(domMatrixReadOnly.m11, 1);
+    assert_equals(domMatrixReadOnly.m12, 0);
+    assert_equals(domMatrixReadOnly.m13, 0);
+    assert_equals(domMatrixReadOnly.m14, 0);
+    assert_equals(domMatrixReadOnly.m21, 0);
+    assert_equals(domMatrixReadOnly.m22, 1);
+    assert_equals(domMatrixReadOnly.m23, 0);
+    assert_equals(domMatrixReadOnly.m24, 0);
+    assert_equals(domMatrixReadOnly.m31, 0);
+    assert_equals(domMatrixReadOnly.m32, 0);
+    assert_equals(domMatrixReadOnly.m33, 1);
+    assert_equals(domMatrixReadOnly.m34, 0);
+    assert_equals(domMatrixReadOnly.m41, 0);
+    assert_equals(domMatrixReadOnly.m42, 0);
+    assert_equals(domMatrixReadOnly.m43, 0);
+    assert_equals(domMatrixReadOnly.m44, 1);
+  });
+
+  test(() => {
+    assert_throws(new TypeError(), () => {
+      const invalid = Object.assign({}, matrixInit, { m33: 0 });
+      DOMMatrixReadOnly.fromMatrix(invalid);
+    });
+
+    assert_throws(new TypeError(), () => {
+      const invalid = Object.assign({}, matrixInit, { m13: 1 });
+      DOMMatrixReadOnly.fromMatrix(invalid);
+    });
+
+  }, "Invalid 2d state");
+
+  test(() => {
+    const matrix = Object.assign({}, matrixInit);
+    delete matrix.is2D;
+
+    matrix.m34 = 1;
+
+    const dm = DOMMatrixReadOnly.fromMatrix(matrix);
+
+    assert_false(dm.is2D);
+
+  }, "Non specified dimension conversion");
+
+  test(() => {
+    const f32arr = new Float32Array([0.25, 0.654, 0.158, 0.1, 0.001, 1.0]);
+    const dmRo = DOMMatrixReadOnly.fromFloat32Array(f32arr);
+
+    assert_equals(dmRo.a, f32arr[0]);
+    assert_equals(dmRo.b, f32arr[1]);
+    assert_equals(dmRo.c, f32arr[2]);
+    assert_equals(dmRo.d, f32arr[3]);
+    assert_equals(dmRo.e, f32arr[4]);
+    assert_equals(dmRo.f, f32arr[5]);
+  }, "fromFloat32Array");
+
+  test(() => {
+    const f64arr = new Float32Array([0.25, 0.654, 0.158, 0.1, 0.001, 1.0]);
+    const dmRo = DOMMatrixReadOnly.fromFloat32Array(f64arr);
+
+    assert_equals(dmRo.a, f64arr[0]);
+    assert_equals(dmRo.b, f64arr[1]);
+    assert_equals(dmRo.c, f64arr[2]);
+    assert_equals(dmRo.d, f64arr[3]);
+    assert_equals(dmRo.e, f64arr[4]);
+    assert_equals(dmRo.f, f64arr[5]);
+  }, "fromFloat64Array");
+
+  test(() => {
+    const f32arr = new Float32Array([0.25, 0.654, 0.158, 0.1, 0.001, 1.0]);
+    const dmRo = new DOMMatrixReadOnly([0.25, 0.654, 0.158, 0.1, 0.001, 1.0]);
+    const convertedArr = dmRo.toFloat32Array();
+
+    assert_array_equals(convertedArr, f32arr);
+  }, "toFloat32Array");
+
+  test(() => {
+    const f64arr = new Float64Array([0.325, 0.123, 0.87, 0.234, 0.654, 0.123]);
+    const dmRo = new DOMMatrixReadOnly(Array.from(f64arr));
+    const convertedArr = dmRo.toFloat64Array();
+
+    assert_array_equals(convertedArr, f64arr);
+
+  }, "toFloat64Array");
+
+  test(() => {
+    const expectedResult = {
+      a: 1,
+      b: 0,
+      c: 0,
+      d: 1,
+      e: 0,
+      f: 0,
+      m11: 1,
+      m12: 0,
+      m13: 0,
+      m14: 0,
+      m21: 0,
+      m22: 1,
+      m23: 0,
+      m24: 0,
+      m31: 0,
+      m32: 0,
+      m33: 1,
+      m34: 0,
+      m41: 0,
+      m42: 0,
+      m43: 0,
+      m44: 1,
+      is2D: false,
+      isIdentity: true
+    };
+    const dmRo = new DOMMatrixReadOnly([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+
+    assert_object_equals(dmRo.toJSON(), expectedResult);
+  }, "toJSON");
+
+  test(() => {
+    assert_equals(String(new DOMMatrixReadOnly([1, 1, 0, 0, 1, 0])), "matrix(1, 1, 0, 0, 1, 0)");
+
+    assert_equals(String(new DOMMatrixReadOnly([
+      1, 2, 3, 4,
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16
+    ])), "matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)");
+  }, "toString");
+
+  test(() => {
+    const dmRo = new DOMMatrixReadOnly();
+    const expectedResult = {
+      a: -1,
+      b: 0,
+      c: 0,
+      d: 1,
+      e: 0,
+      f: 0,
+      m11: -1,
+      m12: 0,
+      m13: 0,
+      m14: 0,
+      m21: 0,
+      m22: 1,
+      m23: 0,
+      m24: 0,
+      m31: 0,
+      m32: 0,
+      m33: 1,
+      m34: 0,
+      m41: 0,
+      m42: 0,
+      m43: 0,
+      m44: 1,
+      is2D: true,
+      isIdentity: false
+    };
+
+    assert_object_equals(dmRo.flipX().toJSON(), expectedResult);
+  }, "flipX");
+
+  test(() => {
+    const dmRo = new DOMMatrixReadOnly();
+    const expectedResult = {
+      a: 1,
+      b: 0,
+      c: 0,
+      d: -1,
+      e: 0,
+      f: 0,
+      m11: 1,
+      m12: 0,
+      m13: 0,
+      m14: 0,
+      m21: 0,
+      m22: -1,
+      m23: 0,
+      m24: 0,
+      m31: 0,
+      m32: 0,
+      m33: 1,
+      m34: 0,
+      m41: 0,
+      m42: 0,
+      m43: 0,
+      m44: 1,
+      is2D: true,
+      isIdentity: false
+    };
+
+    assert_object_equals(dmRo.flipY().toJSON(), expectedResult);
+
+  }, "flipY");
+
+
+  // These tests should just assert that the returned value is an instance of DOMMatrix
+  // Actual implementation tests exist in DOMMatrix wpts
+
+  const domMatrixTransform = new DOMMatrixReadOnly();
+  test(() => {
+    assert_true(domMatrixTransform.translate() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.scale() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.scaleNonUniform() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.scale3d() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.rotate() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.rotateFromVector() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.rotateAxisAngle() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.skewX() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.skewY() instanceof DOMMatrix);
+  });
+
+  test(() => {
+    assert_true(domMatrixTransform.multiply() instanceof DOMMatrix);
+  });
+</script>


### PR DESCRIPTION
Couple of notes: 

Sorry that this PR is long, my desire is to start expanding jsdom's support for geometry and svg. A lot of that begins with DOMMatrix, and I didn't see a better way to spread this initial PR out.

Most of the lone additions come from the tests -- they're extensive, but I'd like to expand some of the coverage even further in future PR's. 

A utility for extracting CSS functions from string for initializing matrices via DOMStrings was introduced. It's crucial to add unit tests for this as well, but I wanted to prevent this PR from gaining even more lines out of the gate.

I've annotated what specifications certain aspects of the matrix calculations come from where I thought appropriate.