### PR TITLE
feat(window): getComputedStyle inherits visibility

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -504,46 +504,57 @@ function Window(options) {
     const { forEach, indexOf } = Array.prototype;
     const { style } = elt;
 
-    function setPropertiesFromRule(rule) {
+    function matches(rule, element) {
       if (!rule.selectorText) {
-        return;
+        return false;
       }
 
       const cssSelectorSplitRe = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
       const selectors = rule.selectorText.split(cssSelectorSplitRe);
-      let matched = false;
 
       for (const selectorText of selectors) {
-        if (selectorText !== "" && selectorText !== "," && !matched && matchesDontThrow(elt, selectorText)) {
-          matched = true;
-          forEach.call(rule.style, property => {
-            declaration.setProperty(
-              property,
-              rule.style.getPropertyValue(property),
-              rule.style.getPropertyPriority(property)
-            );
-          });
+        if (selectorText !== "" && selectorText !== "," && matchesDontThrow(element, selectorText)) {
+          return true;
         }
       }
+
+      return false;
     }
 
-    function readStylesFromStyleSheet(sheet) {
-      forEach.call(sheet.cssRules, rule => {
-        if (rule.media) {
-          if (indexOf.call(rule.media, "screen") !== -1) {
-            forEach.call(rule.cssRules, setPropertiesFromRule);
-          }
-        } else {
-          setPropertiesFromRule(rule);
-        }
-      });
+    function setPropertiesFromRule(rule) {
+      if (matches(rule, elt)) {
+        forEach.call(rule.style, property => {
+          declaration.setProperty(
+            property,
+            rule.style.getPropertyValue(property),
+            rule.style.getPropertyPriority(property)
+          );
+        });
+      }
     }
 
     if (!parsedDefaultStyleSheet) {
       parsedDefaultStyleSheet = cssom.parse(defaultStyleSheet);
     }
-    readStylesFromStyleSheet(parsedDefaultStyleSheet);
-    forEach.call(elt.ownerDocument.styleSheets, readStylesFromStyleSheet);
+
+    function forEachSheetRuleOfElement(element, handleRule) {
+      function handleSheet(sheet) {
+        forEach.call(sheet.cssRules, rule => {
+          if (rule.media) {
+            if (indexOf.call(rule.media, "screen") !== -1) {
+              forEach.call(rule.cssRules, handleRule);
+            }
+          } else {
+            handleRule(rule);
+          }
+        });
+      }
+
+      handleSheet(parsedDefaultStyleSheet);
+      forEach.call(element.ownerDocument.styleSheets, handleSheet);
+    }
+
+    forEachSheetRuleOfElement(elt, setPropertiesFromRule);
 
     forEach.call(style, property => {
       declaration.setProperty(property, style.getPropertyValue(property), style.getPropertyPriority(property));

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -29,7 +29,8 @@ const createAbortSignal = require("../living/generated/AbortSignal").createInter
 const reportException = require("../living/helpers/runtime-script-errors");
 const { fireAnEvent } = require("../living/helpers/events");
 const SessionHistory = require("../living/window/SessionHistory");
-const { forEachSheetRuleOfElement, getResolvedValue, matches, properties } = require("../living/helpers/style-rules");
+const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented } =
+  require("../living/helpers/style-rules");
 
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
@@ -500,22 +501,18 @@ function Window(options) {
     const { forEach } = Array.prototype;
     const { style } = elt;
 
-    function setPropertiesFromRule(rule) {
-      if (matches(rule, elt)) {
-        forEach.call(rule.style, property => {
-          declaration.setProperty(
-            property,
-            rule.style.getPropertyValue(property),
-            rule.style.getPropertyPriority(property)
-          );
-        });
-      }
-    }
-
-    forEachSheetRuleOfElement(elt, setPropertiesFromRule);
+    forEachMatchingSheetRuleOfElement(elt, rule => {
+      forEach.call(rule.style, property => {
+        declaration.setProperty(
+          property,
+          rule.style.getPropertyValue(property),
+          rule.style.getPropertyPriority(property)
+        );
+      });
+    });
 
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
-    const declarations = Object.keys(properties);
+    const declarations = Object.keys(propertiesWithResolvedValueImplemented);
     forEach.call(declarations, property => {
       declaration.setProperty(property, getResolvedValue(elt, property));
     });

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -9,7 +9,6 @@ const Element = require("../living/generated/Element");
 const EventTarget = require("../living/generated/EventTarget");
 const PageTransitionEvent = require("../living/generated/PageTransitionEvent");
 const namedPropertiesWindow = require("../living/named-properties-window");
-const cssom = require("cssom");
 const postMessage = require("../living/post-message");
 const DOMException = require("domexception");
 const { btoa, atob } = require("abab");
@@ -28,15 +27,12 @@ const Storage = require("../living/generated/Storage");
 const createAbortController = require("../living/generated/AbortController").createInterface;
 const createAbortSignal = require("../living/generated/AbortSignal").createInterface;
 const reportException = require("../living/helpers/runtime-script-errors");
-const { matchesDontThrow } = require("../living/helpers/selectors");
 const { fireAnEvent } = require("../living/helpers/events");
 const SessionHistory = require("../living/window/SessionHistory");
+const { forEachSheetRuleOfElement, getResolvedValue, matches, properties } = require("../living/helpers/style-rules");
 
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
-
-const defaultStyleSheet = require("./default-stylesheet");
-let parsedDefaultStyleSheet;
 
 // NB: the require() must be after assigning `module.exports` because this require() is circular
 // TODO: this above note might not even be true anymore... figure out the cycle and document it, or clean up.
@@ -501,25 +497,8 @@ function Window(options) {
     elt = Element.convert(elt);
 
     const declaration = new CSSStyleDeclaration();
-    const { forEach, indexOf } = Array.prototype;
+    const { forEach } = Array.prototype;
     const { style } = elt;
-
-    function matches(rule, element) {
-      if (!rule.selectorText) {
-        return false;
-      }
-
-      const cssSelectorSplitRe = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
-      const selectors = rule.selectorText.split(cssSelectorSplitRe);
-
-      for (const selectorText of selectors) {
-        if (selectorText !== "" && selectorText !== "," && matchesDontThrow(element, selectorText)) {
-          return true;
-        }
-      }
-
-      return false;
-    }
 
     function setPropertiesFromRule(rule) {
       if (matches(rule, elt)) {
@@ -533,113 +512,7 @@ function Window(options) {
       }
     }
 
-    if (!parsedDefaultStyleSheet) {
-      parsedDefaultStyleSheet = cssom.parse(defaultStyleSheet);
-    }
-
-    function forEachSheetRuleOfElement(element, handleRule) {
-      function handleSheet(sheet) {
-        forEach.call(sheet.cssRules, rule => {
-          if (rule.media) {
-            if (indexOf.call(rule.media, "screen") !== -1) {
-              forEach.call(rule.cssRules, handleRule);
-            }
-          } else {
-            handleRule(rule);
-          }
-        });
-      }
-
-      handleSheet(parsedDefaultStyleSheet);
-      forEach.call(element.ownerDocument.styleSheets, handleSheet);
-    }
-
     forEachSheetRuleOfElement(elt, setPropertiesFromRule);
-
-    /**
-     * properties for which `getResolvedValue` is implemented which is less than
-     * every supported property according to step 5
-     * @type Record<string, { inherited: boolean; initial: unknown; computedValue: 'as-specified' }>
-     */
-    const properties = {
-      visibility: {
-        inherited: true,
-        initial: "visible",
-        computedValue: "as-specified"
-      }
-    };
-
-    /**
-     * Naive implementation of https://www.w3.org/TR/CSS2/cascade.html#cascade
-     * based on the previous behavior of getComputedStyle
-     * Does not implement https://www.w3.org/TR/CSS2/cascade.html#specificity
-     * or rather specificity is only implemented by the order in which the matching
-     * rules appear. The last rule is the most specific while the first rule is
-     * the least specific.
-     * @param {Element} element
-     * @param {string} property
-     */
-    function getCascadedPropertyValue(element, property) {
-      let value = "";
-
-      forEachSheetRuleOfElement(elt, rule => {
-        if (matches(rule, element)) {
-          value = rule.style.getPropertyValue(property);
-        }
-      });
-
-      return value;
-    }
-
-    /**
-     * https://www.w3.org/TR/CSS2/cascade.html#specified-value
-     *
-     * @param {Element} element
-     * @param {string} property
-     */
-    function getSpecifiedValue(element, property) {
-      const cascade = getCascadedPropertyValue(element, property);
-
-      // 1.
-      if (cascade !== "") {
-        return cascade;
-      }
-
-      const { initial, inherited } = properties[property];
-      // 2
-      if (inherited === true && element.parentElement !== null) {
-        return getComputedValue(element.parentElement, property);
-      }
-
-      // 3
-      return initial;
-    }
-
-    /**
-     * https://drafts.csswg.org/css-cascade-4/#computed-value
-     * @param {Element} element
-     * @param {string} property
-     */
-    function getComputedValue(element, property) {
-      const { computedValue } = properties[property];
-      if (computedValue === "as-specified") {
-        return getSpecifiedValue(element, property);
-      }
-
-      throw new TypeError(`Unrecognized computed value instruction '${computedValue}'`);
-    }
-
-    /**
-     * https://drafts.csswg.org/cssom/#resolved-value
-     * Only implements `visibility`
-     * @param {Element} element
-     * @param {string} property
-     */
-    function getResolvedValue(element, property) {
-      // determined for special case properties none of which are implemented here
-      // so we skip to "any other property: The resolved value is the computed value."
-      return getComputedValue(element, property);
-    }
 
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
     const declarations = Object.keys(properties);

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -556,6 +556,97 @@ function Window(options) {
 
     forEachSheetRuleOfElement(elt, setPropertiesFromRule);
 
+    /**
+     * properties for which `getResolvedValue` is implemented which is less than
+     * every supported property according to step 5
+     * @type Record<string, { inherited: boolean; initial: unknown; computedValue: 'as-specified' }>
+     */
+    const properties = {
+      visibility: {
+        inherited: true,
+        initial: "visible",
+        computedValue: "as-specified"
+      }
+    };
+
+    /**
+     * Naive implementation of https://www.w3.org/TR/CSS2/cascade.html#cascade
+     * based on the previous behavior of getComputedStyle
+     * Does not implement https://www.w3.org/TR/CSS2/cascade.html#specificity
+     * or rather specificity is only implemented by the order in which the matching
+     * rules appear. The last rule is the most specific while the first rule is
+     * the least specific.
+     * @param {Element} element
+     * @param {string} property
+     */
+    function getCascadedPropertyValue(element, property) {
+      let value = "";
+
+      forEachSheetRuleOfElement(elt, rule => {
+        if (matches(rule, element)) {
+          value = rule.style.getPropertyValue(property);
+        }
+      });
+
+      return value;
+    }
+
+    /**
+     * https://www.w3.org/TR/CSS2/cascade.html#specified-value
+     *
+     * @param {Element} element
+     * @param {string} property
+     */
+    function getSpecifiedValue(element, property) {
+      const cascade = getCascadedPropertyValue(element, property);
+
+      // 1.
+      if (cascade !== "") {
+        return cascade;
+      }
+
+      const { initial, inherited } = properties[property];
+      // 2
+      if (inherited === true && element.parentElement !== null) {
+        return getComputedValue(element.parentElement, property);
+      }
+
+      // 3
+      return initial;
+    }
+
+    /**
+     * https://drafts.csswg.org/css-cascade-4/#computed-value
+     * @param {Element} element
+     * @param {string} property
+     */
+    function getComputedValue(element, property) {
+      const { computedValue } = properties[property];
+      if (computedValue === "as-specified") {
+        return getSpecifiedValue(element, property);
+      }
+
+      throw new TypeError(`Unrecognized computed value instruction '${computedValue}'`);
+    }
+
+    /**
+     * https://drafts.csswg.org/cssom/#resolved-value
+     * Only implements `visibility`
+     * @param {Element} element
+     * @param {string} property
+     */
+    function getResolvedValue(element, property) {
+      // determined for special case properties none of which are implemented here
+      // so we skip to "any other property: The resolved value is the computed value."
+      return getComputedValue(element, property);
+    }
+
+    // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
+    const declarations = Object.keys(properties);
+    forEach.call(declarations, property => {
+      declaration.setProperty(property, getResolvedValue(elt, property));
+    });
+
     forEach.call(style, property => {
       declaration.setProperty(property, style.getPropertyValue(property), style.getPropertyPriority(property));
     });

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -7,10 +7,12 @@ const { forEach, indexOf } = Array.prototype;
 
 let parsedDefaultStyleSheet;
 
-// properties for which `getResolvedValue` is implemented which is less than
-// every supported property according to step 5
-// https://drafts.csswg.org/css2/propidx.html
-const properties = {
+// Properties for which getResolvedValue is implemented. This is less than
+// every supported property.
+// https://drafts.csswg.org/indexes/#properties
+exports.propertiesWithResolvedValueImplemented = {
+  __proto__: null,
+
   // https://drafts.csswg.org/css2/visufx.html#visibility
   visibility: {
     inherited: true,
@@ -19,15 +21,17 @@ const properties = {
   }
 };
 
-function forEachSheetRuleOfElement(element, handleRule) {
+exports.forEachMatchingSheetRuleOfElement = (element, handleRule) => {
   function handleSheet(sheet) {
     forEach.call(sheet.cssRules, rule => {
-      if (rule.media) {
-        if (indexOf.call(rule.media, "screen") !== -1) {
-          forEach.call(rule.cssRules, handleRule);
+      if (matches(rule, element)) {
+        if (rule.media) {
+          if (indexOf.call(rule.media, "screen") !== -1) {
+            forEach.call(rule.cssRules, handleRule);
+          }
+        } else {
+          handleRule(rule);
         }
-      } else {
-        handleRule(rule);
       }
     });
   }
@@ -38,7 +42,7 @@ function forEachSheetRuleOfElement(element, handleRule) {
 
   handleSheet(parsedDefaultStyleSheet);
   forEach.call(element.ownerDocument.styleSheets, handleSheet);
-}
+};
 
 function matches(rule, element) {
   if (!rule.selectorText) {
@@ -62,18 +66,16 @@ function matches(rule, element) {
 }
 
 // Naive implementation of https://drafts.csswg.org/css-cascade-4/#cascading
-// based on the previous behavior of getComputedStyle
-// Does not implement https://drafts.csswg.org/css-cascade-4/#cascade-specificity
+// based on the previous jsdom implementation of getComputedStyle.
+// Does not implement https://drafts.csswg.org/css-cascade-4/#cascade-specificity,
 // or rather specificity is only implemented by the order in which the matching
 // rules appear. The last rule is the most specific while the first rule is
 // the least specific.
 function getCascadedPropertyValue(element, property) {
   let value = "";
 
-  forEachSheetRuleOfElement(element, rule => {
-    if (matches(rule, element)) {
-      value = rule.style.getPropertyValue(property);
-    }
+  exports.forEachMatchingSheetRuleOfElement(element, rule => {
+    value = rule.style.getPropertyValue(property);
   });
 
   return value;
@@ -88,8 +90,8 @@ function getSpecifiedValue(element, property) {
   }
 
   // Defaulting
-  const { initial, inherited } = properties[property];
-  if (inherited === true && element.parentElement !== null) {
+  const { initial, inherited } = exports.propertiesWithResolvedValueImplemented[property];
+  if (inherited && element.parentElement !== null) {
     return getComputedValue(element.parentElement, property);
   }
 
@@ -98,23 +100,19 @@ function getSpecifiedValue(element, property) {
 }
 
 // https://drafts.csswg.org/css-cascade-4/#computed-value
-// @param {Element} element
-// @param {string} property
 function getComputedValue(element, property) {
-  const { computedValue } = properties[property];
+  const { computedValue } = exports.propertiesWithResolvedValueImplemented[property];
   if (computedValue === "as-specified") {
     return getSpecifiedValue(element, property);
   }
 
-  throw new TypeError(`Unrecognized computed value instruction '${computedValue}'`);
+  throw new TypeError(`Internal error: unrecognized computed value instruction '${computedValue}'`);
 }
 
 // https://drafts.csswg.org/cssom/#resolved-value
 // Only implements `visibility`
-function getResolvedValue(element, property) {
-  // determined for special case properties none of which are implemented here
-  // so we skip to "any other property: The resolved value is the computed value."
+exports.getResolvedValue = (element, property) => {
+  // Determined for special case properties, none of which are implemented here.
+  // So we skip to "any other property: The resolved value is the computed value."
   return getComputedValue(element, property);
-}
-
-module.exports = { forEachSheetRuleOfElement, getResolvedValue, matches, properties };
+};

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -10,6 +10,7 @@ let parsedDefaultStyleSheet;
 // properties for which `getResolvedValue` is implemented which is less than
 // every supported property according to step 5
 const properties = {
+  // https://drafts.csswg.org/css2/visufx.html#visibility
   visibility: {
     inherited: true,
     initial: "visible",

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -63,9 +63,9 @@ function matches(rule, element) {
 }
 
 /**
- * Naive implementation of https://www.w3.org/TR/CSS2/cascade.html#cascade
+ * Naive implementation of https://drafts.csswg.org/css-cascade-4/#cascading
  * based on the previous behavior of getComputedStyle
- * Does not implement https://www.w3.org/TR/CSS2/cascade.html#specificity
+ * Does not implement https://drafts.csswg.org/css-cascade-4/#cascade-specificity
  * or rather specificity is only implemented by the order in which the matching
  * rules appear. The last rule is the most specific while the first rule is
  * the least specific.
@@ -85,7 +85,7 @@ function getCascadedPropertyValue(element, property) {
 }
 
 /**
- * https://www.w3.org/TR/CSS2/cascade.html#specified-value
+ * https://drafts.csswg.org/css-cascade-4/#specified-value
  *
  * @param {Element} element
  * @param {string} property
@@ -93,18 +93,17 @@ function getCascadedPropertyValue(element, property) {
 function getSpecifiedValue(element, property) {
   const cascade = getCascadedPropertyValue(element, property);
 
-  // 1.
   if (cascade !== "") {
     return cascade;
   }
 
+  // Defaulting
   const { initial, inherited } = properties[property];
-  // 2
   if (inherited === true && element.parentElement !== null) {
     return getComputedValue(element.parentElement, property);
   }
 
-  // 3
+  // root element without parent element or inherited property
   return initial;
 }
 

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -9,6 +9,7 @@ let parsedDefaultStyleSheet;
 
 // properties for which `getResolvedValue` is implemented which is less than
 // every supported property according to step 5
+// https://drafts.csswg.org/css2/propidx.html
 const properties = {
   // https://drafts.csswg.org/css2/visufx.html#visibility
   visibility: {

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -24,14 +24,16 @@ exports.propertiesWithResolvedValueImplemented = {
 exports.forEachMatchingSheetRuleOfElement = (element, handleRule) => {
   function handleSheet(sheet) {
     forEach.call(sheet.cssRules, rule => {
-      if (matches(rule, element)) {
-        if (rule.media) {
-          if (indexOf.call(rule.media, "screen") !== -1) {
-            forEach.call(rule.cssRules, handleRule);
-          }
-        } else {
-          handleRule(rule);
+      if (rule.media) {
+        if (indexOf.call(rule.media, "screen") !== -1) {
+          forEach.call(rule.cssRules, innerRule => {
+            if (matches(innerRule, element)) {
+              handleRule(innerRule);
+            }
+          });
         }
+      } else if (matches(rule, element)) {
+        handleRule(rule);
       }
     });
   }

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -7,11 +7,8 @@ const { forEach, indexOf } = Array.prototype;
 
 let parsedDefaultStyleSheet;
 
-/**
- * properties for which `getResolvedValue` is implemented which is less than
- * every supported property according to step 5
- * @type Record<string, { inherited: boolean; initial: unknown; computedValue: 'as-specified' }>
- */
+// properties for which `getResolvedValue` is implemented which is less than
+// every supported property according to step 5
 const properties = {
   visibility: {
     inherited: true,
@@ -62,16 +59,12 @@ function matches(rule, element) {
   return false;
 }
 
-/**
- * Naive implementation of https://drafts.csswg.org/css-cascade-4/#cascading
- * based on the previous behavior of getComputedStyle
- * Does not implement https://drafts.csswg.org/css-cascade-4/#cascade-specificity
- * or rather specificity is only implemented by the order in which the matching
- * rules appear. The last rule is the most specific while the first rule is
- * the least specific.
- * @param {Element} element
- * @param {string} property
- */
+// Naive implementation of https://drafts.csswg.org/css-cascade-4/#cascading
+// based on the previous behavior of getComputedStyle
+// Does not implement https://drafts.csswg.org/css-cascade-4/#cascade-specificity
+// or rather specificity is only implemented by the order in which the matching
+// rules appear. The last rule is the most specific while the first rule is
+// the least specific.
 function getCascadedPropertyValue(element, property) {
   let value = "";
 
@@ -84,12 +77,7 @@ function getCascadedPropertyValue(element, property) {
   return value;
 }
 
-/**
- * https://drafts.csswg.org/css-cascade-4/#specified-value
- *
- * @param {Element} element
- * @param {string} property
- */
+// https://drafts.csswg.org/css-cascade-4/#specified-value
 function getSpecifiedValue(element, property) {
   const cascade = getCascadedPropertyValue(element, property);
 
@@ -107,11 +95,9 @@ function getSpecifiedValue(element, property) {
   return initial;
 }
 
-/**
- * https://drafts.csswg.org/css-cascade-4/#computed-value
- * @param {Element} element
- * @param {string} property
- */
+// https://drafts.csswg.org/css-cascade-4/#computed-value
+// @param {Element} element
+// @param {string} property
 function getComputedValue(element, property) {
   const { computedValue } = properties[property];
   if (computedValue === "as-specified") {
@@ -121,12 +107,8 @@ function getComputedValue(element, property) {
   throw new TypeError(`Unrecognized computed value instruction '${computedValue}'`);
 }
 
-/**
- * https://drafts.csswg.org/cssom/#resolved-value
- * Only implements `visibility`
- * @param {Element} element
- * @param {string} property
- */
+// https://drafts.csswg.org/cssom/#resolved-value
+// Only implements `visibility`
 function getResolvedValue(element, property) {
   // determined for special case properties none of which are implemented here
   // so we skip to "any other property: The resolved value is the computed value."

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -1,0 +1,137 @@
+"use strict";
+const cssom = require("cssom");
+const defaultStyleSheet = require("../../browser/default-stylesheet");
+const { matchesDontThrow } = require("./selectors");
+
+const { forEach, indexOf } = Array.prototype;
+
+let parsedDefaultStyleSheet;
+
+/**
+ * properties for which `getResolvedValue` is implemented which is less than
+ * every supported property according to step 5
+ * @type Record<string, { inherited: boolean; initial: unknown; computedValue: 'as-specified' }>
+ */
+const properties = {
+  visibility: {
+    inherited: true,
+    initial: "visible",
+    computedValue: "as-specified"
+  }
+};
+
+function forEachSheetRuleOfElement(element, handleRule) {
+  function handleSheet(sheet) {
+    forEach.call(sheet.cssRules, rule => {
+      if (rule.media) {
+        if (indexOf.call(rule.media, "screen") !== -1) {
+          forEach.call(rule.cssRules, handleRule);
+        }
+      } else {
+        handleRule(rule);
+      }
+    });
+  }
+
+  if (!parsedDefaultStyleSheet) {
+    parsedDefaultStyleSheet = cssom.parse(defaultStyleSheet);
+  }
+
+  handleSheet(parsedDefaultStyleSheet);
+  forEach.call(element.ownerDocument.styleSheets, handleSheet);
+}
+
+function matches(rule, element) {
+  if (!rule.selectorText) {
+    return false;
+  }
+
+  const cssSelectorSplitRe = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
+  const selectors = rule.selectorText.split(cssSelectorSplitRe);
+
+  for (const selectorText of selectors) {
+    if (
+      selectorText !== "" &&
+      selectorText !== "," &&
+      matchesDontThrow(element, selectorText)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Naive implementation of https://www.w3.org/TR/CSS2/cascade.html#cascade
+ * based on the previous behavior of getComputedStyle
+ * Does not implement https://www.w3.org/TR/CSS2/cascade.html#specificity
+ * or rather specificity is only implemented by the order in which the matching
+ * rules appear. The last rule is the most specific while the first rule is
+ * the least specific.
+ * @param {Element} element
+ * @param {string} property
+ */
+function getCascadedPropertyValue(element, property) {
+  let value = "";
+
+  forEachSheetRuleOfElement(element, rule => {
+    if (matches(rule, element)) {
+      value = rule.style.getPropertyValue(property);
+    }
+  });
+
+  return value;
+}
+
+/**
+ * https://www.w3.org/TR/CSS2/cascade.html#specified-value
+ *
+ * @param {Element} element
+ * @param {string} property
+ */
+function getSpecifiedValue(element, property) {
+  const cascade = getCascadedPropertyValue(element, property);
+
+  // 1.
+  if (cascade !== "") {
+    return cascade;
+  }
+
+  const { initial, inherited } = properties[property];
+  // 2
+  if (inherited === true && element.parentElement !== null) {
+    return getComputedValue(element.parentElement, property);
+  }
+
+  // 3
+  return initial;
+}
+
+/**
+ * https://drafts.csswg.org/css-cascade-4/#computed-value
+ * @param {Element} element
+ * @param {string} property
+ */
+function getComputedValue(element, property) {
+  const { computedValue } = properties[property];
+  if (computedValue === "as-specified") {
+    return getSpecifiedValue(element, property);
+  }
+
+  throw new TypeError(`Unrecognized computed value instruction '${computedValue}'`);
+}
+
+/**
+ * https://drafts.csswg.org/cssom/#resolved-value
+ * Only implements `visibility`
+ * @param {Element} element
+ * @param {string} property
+ */
+function getResolvedValue(element, property) {
+  // determined for special case properties none of which are implemented here
+  // so we skip to "any other property: The resolved value is the computed value."
+  return getComputedValue(element, property);
+}
+
+module.exports = { forEachSheetRuleOfElement, getResolvedValue, matches, properties };

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-visibility-inheritance.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-visibility-inheritance.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Computed visibility is inherited</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- Test for https://github.com/jsdom/jsdom/issues/2616 -->
+
+<style>
+  #parent {
+    visibility: hidden;
+  }
+</style>
+
+<body>
+  <div id="parent">
+      <div id="child">Hello, Dave!</div>
+  </div>
+</body>
+
+<script>
+"use strict";
+
+test(() => {
+  const element = document.querySelector("#parent");
+  assert_equals(getComputedStyle(element).visibility, "hidden");
+}, "Sanity check: getComputedStyle returns apparent visibility");
+
+test(() => {
+  const element = document.querySelector("#child");
+  assert_equals(getComputedStyle(element).visibility, "hidden");
+}, "Children inherit visibility from their parents");
+</script>

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-visibility-override.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-visibility-override.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Inherited visibility can be overridden</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #parent {
+    visibility: hidden;
+  }
+  #child {
+    visibility: visible;
+  }
+</style>
+
+<body>
+  <div id="parent">
+      <div id="child">Hello, Dave!</div>
+  </div>
+</body>
+
+<script>
+"use strict";
+
+test(() => {
+  const element = document.querySelector("#parent");
+  assert_equals(getComputedStyle(element).visibility, "hidden");
+}, "Sanity check: Parent is actually visibly hidden");
+
+test(() => {
+  const element = document.querySelector("#child");
+  assert_equals(getComputedStyle(element).visibility, "visible");
+}, "computed visibility can be visible even if the parent is not");
+</script>


### PR DESCRIPTION
Closes #2616 

Missing behavior:
* https://drafts.csswg.org/css-cascade-4/#cascading
* https://drafts.csswg.org/css-cascade-4/#defaulting-keywords

I would recommend reviewing the first commit separately since it only includes refactoring to make the later inheritance implementation easier.

This lays the ground work for `getComputedStyle` respecting style inheritance as well as initial values. To fully implement [`getComputedStyle`](https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle) we need to implement proper specificity (code comment has a remark about this) and port https://www.w3.org/TR/CSS2/propidx.html into code.

I'd like to follow-up with implementing specificity. I'm mostly interested in visibility since it affects accessibility (`display` isn't inherited anyway and there's no layout in jsdom so `offsetParent` etc is not possible). For work on accessibility queries knowing if an element is rendered is paramount. `getComputedStyle` not supporting inheritance is a major blocker in that regard. If other work has already started to support visibility I'm happy to help.