### PR TITLE
feat: Rename `HTMLOrSVGElement` to `HTMLOrForeignElement`

### DIFF
--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -4,7 +4,7 @@ const ElementImpl = require("./Element-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
 const ElementCSSInlineStyleImpl = require("./ElementCSSInlineStyle-impl").implementation;
 const GlobalEventHandlersImpl = require("./GlobalEventHandlers-impl").implementation;
-const HTMLOrSVGElementImpl = require("./HTMLOrSVGElement-impl").implementation;
+const HTMLOrForeignElementImpl = require("./HTMLOrForeignElement-impl").implementation;
 const { firstChildWithLocalName } = require("../helpers/traversal");
 const { isDisabled } = require("../helpers/form-controls");
 const { fireAnEvent } = require("../helpers/events");
@@ -12,7 +12,7 @@ const { fireAnEvent } = require("../helpers/events");
 class HTMLElementImpl extends ElementImpl {
   constructor(args, privateData) {
     super(args, privateData);
-    this._initHTMLOrSVGElement();
+    this._initHTMLOrForeignElement();
     this._initElementCSSInlineStyle();
     this._initGlobalEvents();
 
@@ -151,7 +151,7 @@ class HTMLElementImpl extends ElementImpl {
 
 mixin(HTMLElementImpl.prototype, ElementCSSInlineStyleImpl.prototype);
 mixin(HTMLElementImpl.prototype, GlobalEventHandlersImpl.prototype);
-mixin(HTMLElementImpl.prototype, HTMLOrSVGElementImpl.prototype);
+mixin(HTMLElementImpl.prototype, HTMLOrForeignElementImpl.prototype);
 
 module.exports = {
   implementation: HTMLElementImpl

--- a/lib/jsdom/living/nodes/HTMLElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLElement.webidl
@@ -25,7 +25,7 @@ interface HTMLElement : Element {
 HTMLElement includes GlobalEventHandlers;
 // HTMLElement includes DocumentAndElementEventHandlers;
 HTMLElement includes ElementContentEditable;
-HTMLElement includes HTMLOrSVGElement;
+HTMLElement includes HTMLOrForeignElement;
 
 // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
 partial interface HTMLElement {

--- a/lib/jsdom/living/nodes/HTMLOrForeignElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrForeignElement-impl.js
@@ -4,8 +4,8 @@ const conversions = require("webidl-conversions");
 const focusing = require("../helpers/focusing");
 const DOMStringMap = require("../generated/DOMStringMap");
 
-class HTMLOrSVGElementImpl {
-  _initHTMLOrSVGElement() {
+class HTMLOrForeignElement {
+  _initHTMLOrForeignElement() {
     this._tabIndex = 0;
     this._dataset = DOMStringMap.createImpl([], { element: this });
   }
@@ -53,4 +53,4 @@ class HTMLOrSVGElementImpl {
   }
 }
 
-exports.implementation = HTMLOrSVGElementImpl;
+exports.implementation = HTMLOrForeignElement;

--- a/lib/jsdom/living/nodes/HTMLOrForeignElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLOrForeignElement.webidl
@@ -1,4 +1,4 @@
-interface mixin HTMLOrSVGElement {
+interface mixin HTMLOrForeignElement {
   [SameObject] readonly attribute DOMStringMap dataset;
 // TODO: Shouldn't be directly [Reflect]ed
   [Reflect] attribute DOMString nonce; // intentionally no [CEReactions]

--- a/lib/jsdom/living/nodes/SVGElement-impl.js
+++ b/lib/jsdom/living/nodes/SVGElement-impl.js
@@ -7,12 +7,12 @@ const SVGAnimatedString = require("../generated/SVGAnimatedString");
 const ElementImpl = require("./Element-impl").implementation;
 const ElementCSSInlineStyleImpl = require("./ElementCSSInlineStyle-impl").implementation;
 const GlobalEventHandlersImpl = require("./GlobalEventHandlers-impl").implementation;
-const HTMLOrSVGElementImpl = require("./HTMLOrSVGElement-impl").implementation;
+const HTMLOrForeignElementImpl = require("./HTMLOrForeignElement-impl").implementation;
 
 class SVGElementImpl extends ElementImpl {
   constructor(args, privateData) {
     super(args, privateData);
-    this._initHTMLOrSVGElement();
+    this._initHTMLOrForeignElement();
     this._initElementCSSInlineStyle();
     this._initGlobalEvents();
   }
@@ -59,6 +59,6 @@ SVGElementImpl.attributeRegistry = new Map();
 
 mixin(SVGElementImpl.prototype, ElementCSSInlineStyleImpl.prototype);
 mixin(SVGElementImpl.prototype, GlobalEventHandlersImpl.prototype);
-mixin(SVGElementImpl.prototype, HTMLOrSVGElementImpl.prototype);
+mixin(SVGElementImpl.prototype, HTMLOrForeignElementImpl.prototype);
 
 exports.implementation = SVGElementImpl;

--- a/lib/jsdom/living/nodes/SVGElement.webidl
+++ b/lib/jsdom/living/nodes/SVGElement.webidl
@@ -11,4 +11,4 @@ interface SVGElement : Element {
 SVGElement includes GlobalEventHandlers;
 // SVGElement includes DocumentAndElementEventHandlers;
 // SVGElement includes SVGElementInstance;
-SVGElement includes HTMLOrSVGElement;
+SVGElement includes HTMLOrForeignElement;


### PR DESCRIPTION
See https://github.com/whatwg/html/issues/4702 for details.

---

This has already been implemented in all major browsers:
- Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=835571
- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1571487
- Safari: https://bugs.webkit.org/show_bug.cgi?id=200470