### PR TITLE
feat(getComputedStyle): Implement cascade

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -501,6 +501,10 @@ function Window(options) {
     const { forEach } = Array.prototype;
     const { style } = elt;
 
+
+    // every property set from this block is not spec-compliant. Only properties
+    // in `properties` implement the specified algorithm. Remove this block once
+    // all css properties are implemented
     forEachMatchingSheetRuleOfElement(elt, rule => {
       forEach.call(rule.style, property => {
         declaration.setProperty(
@@ -510,15 +514,14 @@ function Window(options) {
         );
       });
     });
+    forEach.call(style, property => {
+      declaration.setProperty(property, style.getPropertyValue(property), style.getPropertyPriority(property));
+    });
 
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
     const declarations = Object.keys(propertiesWithResolvedValueImplemented);
     forEach.call(declarations, property => {
       declaration.setProperty(property, getResolvedValue(elt, property));
-    });
-
-    forEach.call(style, property => {
-      declaration.setProperty(property, style.getPropertyValue(property), style.getPropertyPriority(property));
     });
 
     return declaration;

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -85,6 +85,24 @@ function compareSpecificityAsc(a, b) {
 }
 
 /**
+ * An enumerable list of properties declared in a given declaration
+ * @param {CSSStyleDeclaration} declaration
+ * @returns {Array<{ name: string, value: string, importance: Priority }>}
+ */
+function propertiesOf(declaration) {
+  return Array.from({ length: declaration.length }, (_, index) => {
+    // const name = declaration.item(index);
+    const name = declaration[index];
+
+    return {
+      name,
+      value: declaration.getPropertyValue(name),
+      importance: declaration.getPropertyPriority(name)
+    };
+  });
+}
+
+/**
  * https://drafts.csswg.org/css-cascade-4/#cascade
  * @param {Element} element
  */
@@ -168,24 +186,6 @@ function computeCascadedDeclaration(element) {
       origin: "author",
       specificity: [Number.POSITIVE_INFINITY]
     });
-
-  /**
-   * An enumerable list of properties declared in a given declaration
-   * @param {CSSStyleDeclaration} declaration
-   * @returns {Array<{ name: string, value: string, importance: Priority }>}
-   */
-  function propertiesOf(declaration) {
-    return Array.from({ length: declaration.length }, (_, index) => {
-      // const name = declaration.item(index);
-      const name = declaration[index];
-
-      return {
-        name,
-        value: declaration.getPropertyValue(name),
-        importance: declaration.getPropertyPriority(name)
-      };
-    });
-  }
 
   const cascadedDeclaration = declarations
     // flatten declarations to declared values

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -191,6 +191,8 @@ function computeCascadedDeclaration(element) {
     .concat({
       declaration: element.style,
       origin: "author",
+      // "(such as the contents of a style attribute) are considered to have a specificity higher than any selector"
+      // https://drafts.csswg.org/css-cascade-4/#cascade-specificity
       specificity: [Number.POSITIVE_INFINITY]
     });
 

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -39,9 +39,14 @@ function getSelectors(rule) {
 }
 
 /**
+ * [A, B, C] as defined in https://drafts.csswg.org/selectors/#specificity-rules
+ * @typedef {[number, number, number]} Specificity
+ */
+
+/**
  * https://drafts.csswg.org/selectors/#specificity-rules
  * @param {string} selectorText -
- * @returns {number[]}
+ * @returns {Specificity}
  */
 function calculateSpecificity(selectorText) {
   let tokens = [];
@@ -57,9 +62,9 @@ function calculateSpecificity(selectorText) {
     return type === "attribute" && name === "id";
   }).length;
   // "count the number of class selectors, attributes selectors, and pseudo-classes in the selector (= B)"
-  const b = tokens.filter(({ type }) => {
+  const b = tokens.filter(({ type, name }) => {
     // attribute includes class selectors
-    return type === "attribute" || type === "pseudo";
+    return (type === "attribute" && name !== "id") || type === "pseudo";
   }).length;
   // "count the number of type selectors and pseudo-elements in the selector (= C)"
   const c = tokens.filter(({ type }) => {
@@ -74,6 +79,11 @@ function calculateSpecificity(selectorText) {
   return [a, b, c];
 }
 
+/**
+ * @param {Specificity} a
+ * @param {Specificity} b
+ * @returns {number}
+ */
 function compareSpecificityAsc(a, b) {
   if (a[0] !== b[0]) {
     return a[0] - b[0];
@@ -165,12 +175,9 @@ function computeCascadedDeclaration(element) {
       //  "the specificity in effect is that of the most specific selector in the list that matches"
       const highestSpecificity = matchingSelectors
         .map(selector => {
-          return { selector, specificity: calculateSpecificity(selector) };
+          return calculateSpecificity(selector);
         })
         .sort(compareSpecificityAsc)
-        .map(({ specificity }) => {
-          return specificity;
-        })
         .pop();
 
       return {

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -1,18 +1,26 @@
 "use strict";
 const cssom = require("cssom");
+const { CSSStyleDeclaration } = require("cssstyle");
 const defaultStyleSheet = require("../../browser/default-stylesheet");
 const { matchesDontThrow } = require("./selectors");
+const CSSwhat = require("css-what");
 
 const { forEach, indexOf } = Array.prototype;
 
 let parsedDefaultStyleSheet;
 
-// Properties for which getResolvedValue is implemented. This is less than
-// every supported property.
-// https://drafts.csswg.org/indexes/#properties
+
+// properties for which `getResolvedValue` is implemented which is less than
+// every supported property according to step 5
+// https://drafts.csswg.org/css2/propidx.html
 exports.propertiesWithResolvedValueImplemented = {
   __proto__: null,
-
+  "text-align": {
+    inherited: true,
+    initial: "start",
+    // match-parent not implemented
+    computedValue: "as-specified"
+  },
   // https://drafts.csswg.org/css2/visufx.html#visibility
   visibility: {
     inherited: true,
@@ -20,6 +28,219 @@ exports.propertiesWithResolvedValueImplemented = {
     computedValue: "as-specified"
   }
 };
+
+/**
+ * @param {CSSStyleRule} rule
+ * @returns {string[]}
+ */
+function getSelectors(rule) {
+  const cssSelectorSplitRe = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
+  return rule.selectorText.split(cssSelectorSplitRe);
+}
+
+/**
+ * https://drafts.csswg.org/selectors/#specificity-rules
+ * @param {string} selectorText -
+ * @returns {number[]}
+ */
+function calculateSpecificity(selectorText) {
+  let tokens = [];
+  try {
+    [tokens] = CSSwhat.parse(selectorText.trim());
+  } catch (error) {
+    // TODO: silence?
+    throw new TypeError(`Failed to parse selector '${selectorText}'`);
+  }
+
+  // "count the number of ID selectors in the selector (= A)"
+  const a = tokens.filter(({ type, name }) => {
+    return type === "attribute" && name === "id";
+  }).length;
+  // "count the number of class selectors, attributes selectors, and pseudo-classes in the selector (= B)"
+  const b = tokens.filter(({ type }) => {
+    // attribute includes class selectors
+    return type === "attribute" || type === "pseudo";
+  }).length;
+  // "count the number of type selectors and pseudo-elements in the selector (= C)"
+  const c = tokens.filter(({ type }) => {
+    return (
+      type === "tag" ||
+      // "The universal selector is a special type selector"
+      type === "universal" ||
+      type === "pseudo-element"
+    );
+  }).length;
+
+  return [a, b, c];
+}
+
+function compareSpecificityAsc(a, b) {
+  if (a[0] !== b[0]) {
+    return a[0] - b[0];
+  }
+  if (a[1] !== b[1]) {
+    return a[1] - b[1];
+  }
+  return a[2] - b[2];
+}
+
+/**
+ * https://drafts.csswg.org/css-cascade-4/#cascade
+ * @param {Element} element
+ */
+function computeCascadedDeclaration(element) {
+  if (!parsedDefaultStyleSheet) {
+    parsedDefaultStyleSheet = cssom.parse(defaultStyleSheet);
+  }
+  /**
+   * @type {CSSStyleSheet}
+   */
+  const userAgentSheet = parsedDefaultStyleSheet;
+
+  /**
+   * @param {CSSStyleSheet} sheet
+   * @returns {CSSStyleRule[]}
+   */
+  function rulesOf(sheet) {
+    const rules = [];
+
+    forEach.call(sheet.cssRules, rule => {
+      if (rule.media) {
+        if (indexOf.call(rule.media, "screen") !== -1) {
+          forEach.call(rule.cssRules, innerRule => {
+            if (matches(innerRule, element)) {
+              rules.push(innerRule);
+            }
+          });
+        }
+      } else if (matches(rule, element)) {
+        rules.push(rule);
+      }
+    });
+
+    return rules;
+  }
+
+  // Add origin to all applicable rules
+  const rules = rulesOf(userAgentSheet).map(rule => {
+    return { rule, origin: "user-agent" };
+  });
+
+  if (element.isConnected) {
+    for (const sheet of element.ownerDocument.styleSheets) {
+      rules.push(...rulesOf(sheet).map(rule => {
+        return { rule, origin: "author" };
+      }));
+    }
+  }
+
+  // filter matching rules and determine their specificity
+  const declarations = rules
+    .map(({ rule, origin }) => {
+      const matchingSelectors = getSelectors(rule).filter(selector => {
+        return matchesDontThrow(element, selector);
+      });
+      if (matchingSelectors.length === 0) {
+        return null;
+      }
+
+      //  "the specificity in effect is that of the most specific selector in the list that matches"
+      const highestSpecificity = matchingSelectors
+        .map(selector => {
+          return { selector, specificity: calculateSpecificity(selector) };
+        })
+        .sort(compareSpecificityAsc)
+        .map(({ specificity }) => {
+          return specificity;
+        })
+        .pop();
+
+      return {
+        declaration: rule.style,
+        origin,
+        specificity: highestSpecificity
+      };
+    })
+    // filter the entries where we returned `null` for rules that don't match
+    .filter(Boolean)
+    .concat({
+      declaration: element.style,
+      origin: "author",
+      specificity: [Number.POSITIVE_INFINITY]
+    });
+
+  /**
+   * An enumerable list of properties declared in a given declaration
+   * @param {CSSStyleDeclaration} declaration
+   * @returns {Array<{ name: string, value: string, importance: Priority }>}
+   */
+  function propertiesOf(declaration) {
+    return Array.from({ length: declaration.length }, (_, index) => {
+      // const name = declaration.item(index);
+      const name = declaration[index];
+
+      return {
+        name,
+        value: declaration.getPropertyValue(name),
+        importance: declaration.getPropertyPriority(name)
+      };
+    });
+  }
+
+  const cascadedDeclaration = declarations
+    // flatten declarations to declared values
+    .map(({ declaration, origin, specificity }) => {
+      return propertiesOf(declaration).map(property => {
+        return { property, origin, specificity };
+      });
+    })
+    .reduce((flattened, partial) => {
+      return flattened.concat(partial);
+    }, [])
+    // prepare for sort (sort() should do as little as possible)
+    .map(({ property, origin, specificity }) => {
+      const important = property.importance === "important";
+      // https://drafts.csswg.org/css-cascade-4/#cascade-origin
+      const order = [
+        false, // 0, not used
+        false, // 1, TODO: Transition declarations
+        important && origin === "user-agent", // 2
+        important && origin === "user", // 3
+        important && origin === "author", // 4
+        false, // 5, TODO: Animation declarations
+        !important && origin === "author", // 6
+        !important && origin === "user", // 7
+        true // 8, any
+      ].findIndex(Boolean);
+
+      return {
+        property,
+        order: [order, ...specificity]
+      };
+    })
+    .sort((a, b) => {
+      // the last item in this order will win
+      if (a.order[0] !== b.order[0]) {
+        // Origin and Importance: the lower number wins so sort descending
+        return b.order[0] - a.order[0];
+      }
+      // higher specificity wins so sort ascending
+      return compareSpecificityAsc(a.order.slice(1), b.order.slice(1));
+    })
+    // now we got them ordered by importance, origin, specificity
+    // just apply them by this order and the squashed result is our declaration
+    .reduce((declaration, { property }) => {
+      declaration.setProperty(
+        property.name,
+        property.value,
+        property.importance
+      );
+
+      return declaration;
+    }, new CSSStyleDeclaration());
+
+  return cascadedDeclaration;
+}
 
 exports.forEachMatchingSheetRuleOfElement = (element, handleRule) => {
   function handleSheet(sheet) {
@@ -67,20 +288,11 @@ function matches(rule, element) {
   return false;
 }
 
-// Naive implementation of https://drafts.csswg.org/css-cascade-4/#cascading
-// based on the previous jsdom implementation of getComputedStyle.
-// Does not implement https://drafts.csswg.org/css-cascade-4/#cascade-specificity,
-// or rather specificity is only implemented by the order in which the matching
-// rules appear. The last rule is the most specific while the first rule is
-// the least specific.
+// https://drafts.csswg.org/css-cascade-4/#cascading
 function getCascadedPropertyValue(element, property) {
-  let value = "";
-
-  exports.forEachMatchingSheetRuleOfElement(element, rule => {
-    value = rule.style.getPropertyValue(property);
-  });
-
-  return value;
+  // TODO do this once per getComputedStyle
+  const cascade = computeCascadedDeclaration(element);
+  return cascade.getPropertyValue(property);
 }
 
 // https://drafts.csswg.org/css-cascade-4/#specified-value
@@ -93,7 +305,7 @@ function getSpecifiedValue(element, property) {
 
   // Defaulting
   const { initial, inherited } = exports.propertiesWithResolvedValueImplemented[property];
-  if (inherited && element.parentElement !== null) {
+  if (inherited === true && element.parentElement !== null) {
     return getComputedValue(element.parentElement, property);
   }
 
@@ -112,9 +324,9 @@ function getComputedValue(element, property) {
 }
 
 // https://drafts.csswg.org/cssom/#resolved-value
-// Only implements `visibility`
+// Only implements `text-align`, `visibility`
 exports.getResolvedValue = (element, property) => {
-  // Determined for special case properties, none of which are implemented here.
-  // So we skip to "any other property: The resolved value is the computed value."
+  // determined for special case properties none of which are implemented here
+  // so we skip to "any other property: The resolved value is the computed value."
   return getComputedValue(element, property);
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "acorn": "^7.1.0",
     "acorn-globals": "^4.3.2",
     "array-equal": "^1.0.0",
+    "css-what": "^3.2.0",
     "cssom": "^0.4.1",
     "cssstyle": "^2.0.0",
     "data-urls": "^1.1.0",

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-cascade.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-cascade.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Inherited visibility can be overridden</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  button span {
+    /* precaution once we check if text-align can even apply to inline containers */
+    display: block;
+  }
+
+  em {
+    text-align: right;
+  }
+
+  .left-align {
+    text-align: left;
+  }
+
+  .important-right-align {
+    text-align: right !important;
+  }
+</style>
+
+<body>
+  <div id="initial"></div>
+  <button id="parent">
+    <span id="child-inherit"></span>
+    <span id="style-inline" style="text-align: end">
+      Hello, World!
+      <span id="inherit-inline"></span>
+    </span>
+    <em id="tag-selector"></em>
+    <span class="left-align" id="class-selector"></span>
+    <span
+      class="important-right-align"
+      style="text-align: left;"
+      id="important-author-over-author"
+    ></span>
+    <input
+      type="file"
+      id="important-author-rule"
+      style="text-align: left !important;"
+    />
+    <span class="left-align" style="text-align: right;" id="inline-over-sheet"></span>
+  </button>
+</body>
+
+<script>
+  "use strict";
+  /*
+  test(() => {
+    const element = document.querySelector("#initial");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "start"
+    );
+  }, "initial value");
+
+  test(() => {
+    const element = document.querySelector("#parent");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "center"
+    );
+  }, "user agent declaration");
+
+  test(() => {
+    const element = document.querySelector("#child-inherit");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "center"
+    );
+  }, "inherits");
+
+  test(() => {
+    const element = document.querySelector("#style-inline");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "end"
+    );
+  }, "inline styles are considered");
+
+  test(() => {
+    const element = document.querySelector("#inherit-inline");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "end"
+    );
+  }, "inline styles get inherited");
+
+  test(() => {
+    const element = document.querySelector("#tag-selector");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "right"
+    );
+  }, "tag selectors work");
+
+  test(() => {
+    const element = document.querySelector("#class-selector");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "left"
+    );
+  }, "class rules are more specific than tag rules"); */
+
+  test(() => {
+    const element = document.querySelector("#important-author-over-author");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "right"
+    );
+  }, "import author > author");
+
+  test(() => {
+    const element = document.querySelector("#important-author-rule");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "start"
+    );
+  }, "import user agent > important author");
+
+  test(() => {
+    const element = document.querySelector("#inline-over-sheet");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "right"
+    );
+  }, "inline style > sheet style");
+
+
+</script>

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-specificity.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-specificity.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Inherited visibility can be overridden</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #foo > #test1 {
+    text-align: left;
+  }
+
+  #test1 {
+    text-align: right;
+  }
+
+  #test2.center {
+    text-align: center;
+  }
+
+  #test2 {
+    text-align: left;
+  }
+
+  .test3--left.test3--right {
+    text-align: right;
+  }
+
+  .test3--left {
+    text-align: left;
+  }
+
+  .test4--left {
+    text-align: left;
+  }
+
+  .test4--right {
+    text-align: right;
+  }
+
+  #test5[data-align="right"] {
+    text-align: right;
+  }
+
+  #test5 {
+    text-align: left;
+  }
+</style>
+
+<body>
+  <div id="foo">
+    <div id="test1"></div>
+  </div>
+  <div id="test2" class="center"></div>
+  <div id="test3" class="test3--left test3--right"></div>
+  <div id="test4" class="test4--left test4--right"></div>
+  <div id="test5" data-align="right"></div>
+</body>
+
+<script>
+  "use strict";
+
+  test(() => {
+    const element = document.querySelector("#test1");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "left"
+    );
+  }, "2 ids vs 1 id selector");
+
+  test(() => {
+    const element = document.querySelector("#test2");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "center"
+    );
+  }, "1 id vs 1 id + classname");
+
+  test(() => {
+    const element = document.querySelector("#test3");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "right"
+    );
+  }, "1 vs 2 classnames");
+
+  test(() => {
+    const element = document.querySelector("#test4");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "right"
+    );
+  }, "1 vs 1 classnames");
+
+  test(() => {
+    const element = document.querySelector("#test5");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "right"
+    );
+  }, "id vs attrs");
+</script>

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-specificity.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-specificity.html
@@ -44,6 +44,14 @@
   #test5 {
     text-align: left;
   }
+
+  #test6.specific {
+    text-align: left;
+  }
+
+  #test6.very.specific, #test6 {
+    text-align: right;
+  }
 </style>
 
 <body>
@@ -54,6 +62,7 @@
   <div id="test3" class="test3--left test3--right"></div>
   <div id="test4" class="test4--left test4--right"></div>
   <div id="test5" data-align="right"></div>
+  <div id="test6" class="very specific"></div>
 </body>
 
 <script>
@@ -98,4 +107,12 @@
       "right"
     );
   }, "id vs attrs");
+
+  test(() => {
+    const element = document.querySelector("#test6");
+    assert_equals(
+      getComputedStyle(element).getPropertyValue("text-align"),
+      "right"
+    );
+  }, "highest specificity of matching");
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,6 +1068,11 @@ crypto-browserify@^3.0.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-what@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.2.0.tgz#0ce44ada45f97bcbbec450563a23ef04ee2572ef"
+  integrity sha512-lukqnlbswsPmDZ5+ViDBCcrk+1fyPBA+ZoHSAQhRuEeXBKUb3Lj2kcTwMqoiFrJAnEeO9u3Oc8X617SUm3apYQ==
+
 cssom@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.1.tgz#b24111d236b6dbd00cdfacb5ab67a20473381fe3"


### PR DESCRIPTION
I couldn't find a good web-platform-test (those test tend to require property specific implementations) that only tested cascade. I ended up writing tests that only require proper cascade implementation. I added `text-align` to the properties that are fully supported by `getComputedStyle` since it has a wide range of values while being very close being computed "as-specified". This should include more tests but I started to just copy implementation into test so I'd like  some additional pair of eyes that can spot some stress cases.

I'll remove the jsdocs once this is accepted. I'm used to vscodes autocomplete for which these are extremely helpful but I understand that they are dangerous if no compiler verifies them.

Specificity calculation requires a css selector parser. Before using `css-what` I tried [`scalpel`](https://www.npmjs.com/package/scalpel) and [`css-selector-parser`](https://www.npmjs.com/package/css-selector-parser) neither of which can handle whitespace or non-ASCII characters (which breaks web-platform-tests).

Follow-up on #2668