### PR TITLE
Add missing abort (#2685)

### DIFF
--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -307,6 +307,9 @@ function createClient(xhr) {
     } catch (e) {
       const client = new EventEmitter();
       process.nextTick(() => client.emit("error", e));
+      client.abort = () => {
+        // do nothing
+      };
       return client;
     }
   }


### PR DESCRIPTION
Apparently there is one path with missing implementation of `XMLHttpRequest.abort`, which may cause errors as reported in #2685 