### PR TITLE
Fix fromURL API to not include hash fragment in fetch request

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -110,8 +110,13 @@ class JSDOM {
 
   static fromURL(url, options = {}) {
     return Promise.resolve().then(() => {
+      // Remove the hash while sending this through the research loader fetch().
+      // It gets added back a few lines down when constructing the JSDOM object.
       const parsedURL = new URL(url);
-      url = parsedURL.origin + parsedURL.pathname + parsedURL.search;
+      const originalHash = parsedURL.hash;
+      parsedURL.hash = "";
+      url = parsedURL.href;
+
       options = normalizeFromURLOptions(options);
 
       const resourceLoader = resourcesToResourceLoader(options.resources);
@@ -129,7 +134,7 @@ class JSDOM {
         const res = req.response;
 
         options = Object.assign(options, {
-          url: req.href + parsedURL.hash,
+          url: req.href + originalHash,
           contentType: res.headers["content-type"],
           referrer: req.getHeader("referer")
         });

--- a/lib/api.js
+++ b/lib/api.js
@@ -111,7 +111,7 @@ class JSDOM {
   static fromURL(url, options = {}) {
     return Promise.resolve().then(() => {
       const parsedURL = new URL(url);
-      url = parsedURL.href;
+      url = parsedURL.origin + parsedURL.pathname + parsedURL.search;
       options = normalizeFromURLOptions(options);
 
       const resourceLoader = resourcesToResourceLoader(options.resources);

--- a/test/api/from-url.js
+++ b/test/api/from-url.js
@@ -156,6 +156,22 @@ describe("API: JSDOM.fromURL()", { skipIfBrowser: true }, () => {
         });
       });
 
+      it("should preserve full request URL", () => {
+        const url = simpleServer(200, { "Content-Type": "text/html" });
+        const path = "t";
+        const search = "?a=1";
+        const fragment = "#fragment";
+        const fullURL = url + path + search + fragment;
+
+        return JSDOM.fromURL(fullURL).then(dom => {
+          assert.strictEqual(dom.window.document.URL, fullURL);
+          assert.strictEqual(dom.window.location.href, fullURL);
+          assert.strictEqual(dom.window.location.pathname, "/" + path);
+          assert.strictEqual(dom.window.location.search, search);
+          assert.strictEqual(dom.window.location.hash, fragment);
+        });
+      });
+
       it("should use the ultimate response URL after a redirect", () => {
         const [requestURL, responseURL] = redirectServer("<p>Hello</p>", { "Content-Type": "text/html" });
 


### PR DESCRIPTION
Since browsers don't include hash when making http requests to the
server, do the same here. parsedURL.href was including hash (fragment).

This also fixes duplicate hash as parsedURL.href was concatenated
with parsedURL.hash and passed to JSDOM constructor and that resulted
in duplicate hash in actual document.

Resolves #2696