### PR TITLE
fix: Focusing focused dispatching FocusEvent

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -45,6 +45,10 @@ class HTMLOrSVGElementImpl {
 
     const previous = this._ownerDocument._lastFocusedElement;
 
+    if (previous === this) {
+      return;
+    }
+
     focusing.fireFocusEventWithTargetAdjustment("blur", previous, this);
     this._ownerDocument._lastFocusedElement = this;
     focusing.fireFocusEventWithTargetAdjustment("focus", this, previous);

--- a/test/web-platform-tests/to-upstream/html/interaction/focus-managment/focusing-focused-noop.html
+++ b/test/web-platform-tests/to-upstream/html/interaction/focus-managment/focusing-focused-noop.html
@@ -3,10 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Focus events fire at correct targets in correct order in simple case</title>
-  <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
-  <link rel="help" href="https://html.spec.whatwg.org/#focus-update-steps">
-  <link rel="help" href="https://html.spec.whatwg.org/#focus-chain">
-  <meta name="flags" content="dom">
+  <link rel="help" href="https://html.spec.whatwg.org/#focusing-steps">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/test/web-platform-tests/to-upstream/html/interaction/focus-managment/focusing-focused-noop.html
+++ b/test/web-platform-tests/to-upstream/html/interaction/focus-managment/focusing-focused-noop.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Focus events fire at correct targets in correct order in simple case</title>
+  <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+  <link rel="help" href="https://html.spec.whatwg.org/#focus-update-steps">
+  <link rel="help" href="https://html.spec.whatwg.org/#focus-chain">
+  <meta name="flags" content="dom">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="container"></div>
+  <script>
+"use strict";
+test(() => {
+  // cleanup
+  const container = document.getElementById("container");
+  container.innerHTML = "";
+  document.activeElement.blur();
+
+  const input = document.createElement("button");
+  let handleFocusCallCount = 0;
+  input.addEventListener("focus", () => {
+    handleFocusCallCount += 1;
+  });
+  let handleBlurCallCount = 0;
+  input.addEventListener("blur", () => {
+    handleBlurCallCount += 1;
+  });
+
+  container.appendChild(input);
+
+  input.focus();
+  document.activeElement.focus();
+
+  assert_equals(handleBlurCallCount, 0);
+  assert_equals(handleFocusCallCount, 1);
+}, "focusing a focused element does not dispatch focus events");
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #2621 

Implements

> If new focus target is the currently focused area of a top-level browsing context, then return.

-- https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps