### PR TITLE
Fix XML template content owner document

### DIFF
--- a/lib/jsdom/browser/parser/xml.js
+++ b/lib/jsdom/browser/parser/xml.js
@@ -41,49 +41,57 @@ function createDocumentType(ownerDocument, name, publicId, systemId) {
   return DocumentType.createImpl([], { ownerDocument, name, publicId, systemId });
 }
 
-function appendChild(parent, child) {
-  // Template elements do not have children but instead store their content in a separate hierarchy.
-  if (parent.tagName === "template" && parent.namespaceURI === HTML_NS) {
-    parent._templateContents._insert(child, null);
-  } else {
-    parent._insert(child, null);
-  }
+function isHTMLTemplateElement(element) {
+  return element.tagName === "template" && element.namespaceURI === HTML_NS;
 }
 
-function createParser(rootNode, ownerDocument, saxesOptions) {
+function createParser(rootNode, saxesOptions) {
   const parser = new SaxesParser(saxesOptions);
   const openStack = [rootNode];
+
+  function getOwnerDocument() {
+    const currentElement = openStack[openStack.length - 1];
+
+    return isHTMLTemplateElement(currentElement) ?
+      currentElement._templateContents._ownerDocument :
+      currentElement._ownerDocument;
+  }
+
+  function appendChild(child) {
+    const parentElement = openStack[openStack.length - 1];
+
+    if (isHTMLTemplateElement(parentElement)) {
+      parentElement._templateContents._insert(child, null);
+    } else {
+      parentElement._insert(child, null);
+    }
+  }
 
   parser.ontext = saxesOptions.fragment ?
     // In a fragment, all text events produced by saxes must result in a text
     // node.
     data => {
-      appendChild(
-        openStack[openStack.length - 1],
-        Text.createImpl([], { data, ownerDocument })
-      );
+      const ownerDocument = getOwnerDocument();
+      appendChild(Text.createImpl([], { data, ownerDocument }));
     } :
     // When parsing a whole document, we must ignore those text nodes that are
     // produced outside the root element. Saxes produces events for them,
     // but DOM trees do not record text outside the root element.
     data => {
       if (openStack.length > 1) {
-        appendChild(
-          openStack[openStack.length - 1],
-          Text.createImpl([], { data, ownerDocument })
-        );
+        const ownerDocument = getOwnerDocument();
+        appendChild(Text.createImpl([], { data, ownerDocument }));
       }
     };
 
   parser.oncdata = data => {
-    appendChild(
-      openStack[openStack.length - 1],
-      CDATASection.createImpl([], { data, ownerDocument })
-    );
+    const ownerDocument = getOwnerDocument();
+    appendChild(CDATASection.createImpl([], { data, ownerDocument }));
   };
 
   parser.onopentag = tag => {
     const { local: tagLocal, uri: tagURI, prefix: tagPrefix, attributes: tagAttributes } = tag;
+    const ownerDocument = getOwnerDocument();
 
     const elem = ownerDocument._createElementWithCorrectElementInterface(tagLocal, tagURI);
 
@@ -104,10 +112,7 @@ function createParser(rootNode, ownerDocument, saxesOptions) {
       );
     }
 
-    appendChild(
-      openStack[openStack.length - 1],
-      elem
-    );
+    appendChild(elem);
     openStack.push(elem);
   };
 
@@ -120,24 +125,18 @@ function createParser(rootNode, ownerDocument, saxesOptions) {
   };
 
   parser.oncomment = data => {
-    appendChild(
-      openStack[openStack.length - 1],
-      Comment.createImpl([], { data, ownerDocument })
-    );
+    const ownerDocument = getOwnerDocument();
+    appendChild(Comment.createImpl([], { data, ownerDocument }));
   };
 
   parser.onprocessinginstruction = ({ target, body }) => {
-    appendChild(
-      openStack[openStack.length - 1],
-      ProcessingInstruction.createImpl([], { target, data: body, ownerDocument })
-    );
+    const ownerDocument = getOwnerDocument();
+    appendChild(ProcessingInstruction.createImpl([], { target, data: body, ownerDocument }));
   };
 
   parser.ondoctype = dt => {
-    appendChild(
-      openStack[openStack.length - 1],
-      parseDocType(ownerDocument, `<!doctype ${dt}>`)
-    );
+    const ownerDocument = getOwnerDocument();
+    appendChild(parseDocType(ownerDocument, `<!doctype ${dt}>`));
 
     const entityMatcher = /<!ENTITY ([^ ]+) "([^"]+)">/g;
     let result;
@@ -162,7 +161,7 @@ function parseFragment(markup, contextElement) {
 
   // Only parseFragment needs resolvePrefix per the saxes documentation:
   // https://github.com/lddubeau/saxes#parsing-xml-fragments
-  const parser = createParser(fragment, ownerDocument, {
+  const parser = createParser(fragment, {
     xmlns: true,
     fragment: true,
     resolvePrefix(prefix) {
@@ -177,7 +176,7 @@ function parseFragment(markup, contextElement) {
 }
 
 function parseIntoDocument(markup, ownerDocument) {
-  const parser = createParser(ownerDocument, ownerDocument, {
+  const parser = createParser(ownerDocument, {
     xmlns: true,
     fileName: ownerDocument.location && ownerDocument.location.href
   });

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -755,9 +755,6 @@ script-type-and-language-js.html: [fail, Our script execution timing is off; see
 
 DIR: html/semantics/scripting-1/the-template-element
 
-additions-to-parsing-xhtml-documents/node-document.html: [timeout, Templates in XHTML are totally messed up]
-additions-to-parsing-xhtml-documents/template-child-nodes.html: [timeout, Templates in XHTML are totally messed up]
-
 ---
 
 DIR: html/semantics/selectors


### PR DESCRIPTION
This PR fixes the `HTMLTemplateElement` parsing in the context of XML document by associating the elements to the right owner document.