### PR TITLE
feat(getComputedStyles): Improve performance

### DIFF
--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -47,24 +47,7 @@ exports.forEachMatchingSheetRuleOfElement = (element, handleRule) => {
 };
 
 function matches(rule, element) {
-  if (!rule.selectorText) {
-    return false;
-  }
-
-  const cssSelectorSplitRe = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
-  const selectors = rule.selectorText.split(cssSelectorSplitRe);
-
-  for (const selectorText of selectors) {
-    if (
-      selectorText !== "" &&
-      selectorText !== "," &&
-      matchesDontThrow(element, selectorText)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  return matchesDontThrow(element, rule.selectorText);
 }
 
 // Naive implementation of https://drafts.csswg.org/css-cascade-4/#cascading


### PR DESCRIPTION
`nwsapi` seems to be able to handle multiple selectors. 

Ran `yarn workspace @material-ui/core test` (on https://github.com/mui-org/material-ui/tree/a98abed2fce2fafe16f3c459d1a0de838e5736d2) 6 times with `node@v12.11.1` on Ubuntu 18.04.3 LTS.

median c3f0f2756bdbb20e235473728b562e04a67a6555: 30s
median PR: 26s

Not every test relies on `getComputedStyles` (more like 30-40% of them).