### PR TITLE
Avoid aborting promises without abort method

### DIFF
--- a/lib/jsdom/browser/resources/request-manager.js
+++ b/lib/jsdom/browser/resources/request-manager.js
@@ -22,7 +22,9 @@ module.exports = class RequestManager {
 
   close() {
     for (const openedRequest of this.openedRequests) {
-      openedRequest.abort();
+      if (typeof openedRequest.abort === "function") {
+        openedRequest.abort();
+      }
     }
     this.openedRequests = [];
   }


### PR DESCRIPTION
The ResourceLoader.fetch method is documented to return a promise, so assuming that promise will always have an abort method is in violation of the documentation and breaks for e.g. data URIs.  Only call abort when available (duck-typing).

Fixes https://github.com/jsdom/jsdom/issues/2667.