### PR TITLE
Fixed issue with invalid input types not defaulting to 'text'.

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -32,6 +32,13 @@ const {
 
 const filesSymbol = Symbol("files");
 
+// https://html.spec.whatwg.org/multipage/input.html#attr-input-type
+const inputAllowedTypes = new Set([
+  "hidden", "text", "search", "tel", "url", "email", "password", "datetime", "date",
+  "month", "week", "time", "datetime-local", "number", "range", "color", "checkbox", "radio",
+  "file", "submit", "image", "reset", "button"
+]);
+
 const selectAllowedTypes = new Set([
   "text", "search", "tel", "url", "password", "email", "date", "month", "week",
   "time", "datetime-local", "color", "file", "number"
@@ -415,8 +422,9 @@ class HTMLInputElementImpl extends HTMLElementImpl {
   }
 
   get type() {
-    const type = this.getAttributeNS(null, "type");
-    return type ? type.toLowerCase() : "text";
+    const typeAttribute = this.getAttributeNS(null, "type");
+    const type = typeAttribute && typeAttribute.toLowerCase();
+    return inputAllowedTypes.has(type) ? type : "text";
   }
 
   set type(type) {

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-input-element/default-type.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-input-element/default-type.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Input default type</title>
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/input.html#attr-input-type"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input id="no-type" />
+<input id="valid-type" type="password" />
+<input id="invalid-type" type="foo" />
+
+<script>
+  "use strict";
+
+  test(() => {
+    const input = document.getElementById("no-type");
+    assert_true(input.type === "text");
+  }, "No input type defaults to text");
+
+  test(() => {
+    const input = document.getElementById("valid-type");
+    assert_true(input.type === "password");
+  }, "Sets valid input type");
+
+  test(() => {
+    const input = document.getElementById("invalid-type");
+    assert_true(input.type === "text");
+  }, "Sets invalid input types to text");
+</script>


### PR DESCRIPTION
A bug was raised in https://github.com/testing-library/react-testing-library/issues/532 caused by JSDOM not defaulting invalid input types to `"text"`.

The spec states: https://html.spec.whatwg.org/multipage/input.html#attr-input-type
>The missing value default and the invalid value default are the Text state.

Hopefully I've made the right changes in the right places and the tests are sufficient.