### PR TITLE
setTimeout leaks memory significantly

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -638,6 +638,7 @@ function startTimer(window, startFn, stopFn, timerId, callback, ms, timerStorage
     } catch (e) {
       reportException(window, e, window.location.href);
     }
+    delete timerStorage[timerId];
   };
 
   const res = startFn(callback, ms);


### PR DESCRIPTION
### Basic info:

- **Node.js version:** v13.1.0
- **jsdom version:** 13.2.0

### Minimal reproduction case

```js
const jsdom=require("jsdom");
	const { JSDOM }=jsdom;

	var options={
		url:"http://gg.com",
		pretendToBeVisual:true,
		includeNodeLocations: true,
		resources:'usable',
		runScripts:'dangerously',
		beforeParse:function(window){}
	}
	dom=new JSDOM('<script>function test1(){ var t=setTimeout(function(){ test1() },1); }; for(var i=0;i<1000;i++) test1(); </script>',options);
// best to run with: node --inspect test.js
// the leak is obvious on chrome://inspect
```

<!--
Please create a minimal repro. Any reports involving third party libraries
will be closed, as we cannot debug third-party library interactions for you.

Please do not use syntax that is not supported in Node.js, such as JSX or
`import` statements. If we cannot run the code in Node.js, we will close the
issue, as we cannot debug whatever toolchain you are using.
-->

### How does similar code behave in browsers?

No leak

I use jsdom to emulate http://adventure.land 's gameplay, so the emulation needs to go on as long as possible, I've been hunting a memory leak for 2 days, since the game can run on the browser for weeks, I'm pretty sure the code itself doesn't have a memory leak

I believe the `setTimeout` implementation has a leak, above code easily causes the process to crash in a minute - inside `test1()` - if you allocate some variables too, I believe they are also preserved as the timeout prevents them from being garbage collected

**Off topic:** (As I don't want to create another issue) The JS performance is super low inside jsdom, is this expected - I haven't attempted to benchmark things yet
