### PR TITLE
Do not attempt to fetch images in no-BC documents

### DIFF
--- a/lib/jsdom/living/nodes/HTMLImageElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLImageElement-impl.js
@@ -5,45 +5,9 @@ const { Canvas, reflectURLAttribute } = require("../../utils");
 
 class HTMLImageElementImpl extends HTMLElementImpl {
   _attrModified(name, value, oldVal) {
-    if (name === "src" && value !== oldVal) {
-      const document = this._ownerDocument;
-      if (Canvas) {
-        let error;
-        if (!this._image) {
-          this._image = new Canvas.Image();
-          // Install an error handler that just remembers the error. It is then
-          // thrown in the callback of resourceLoader.fetch() below.
-          this._image.onerror = function (err) {
-            error = err;
-          };
-        }
-        this._currentSrc = null;
-        if (this.hasAttributeNS(null, "src")) {
-          const resourceLoader = document._resourceLoader;
-          let request;
-
-          const onLoadImage = data => {
-            const { response } = request;
-
-            if (response && response.statusCode !== undefined && response.statusCode !== 200) {
-              throw new Error("Status code: " + response.statusCode);
-            }
-            error = null;
-            this._image.src = data;
-            if (error) {
-              throw new Error(error);
-            }
-            this._currentSrc = value;
-          };
-
-          request = resourceLoader.fetch(this.src, {
-            element: this,
-            onLoad: onLoadImage
-          });
-        } else {
-          this._image.src = "";
-        }
-      }
+    // TODO: handle crossorigin
+    if (name === "src" || ((name === "srcset" || name === "width" || name === "sizes") && value !== oldVal)) {
+      this._updateTheImageData();
     }
 
     super._attrModified(name, value, oldVal);
@@ -121,6 +85,55 @@ class HTMLImageElementImpl extends HTMLElementImpl {
 
   set longDesc(value) {
     this.setAttributeNS(null, "longdesc", value);
+  }
+
+  _updateTheImageData() {
+    const document = this._ownerDocument;
+
+    if (!document._defaultView) {
+      return;
+    }
+
+    if (!Canvas) {
+      return;
+    }
+
+    let error;
+    if (!this._image) {
+      this._image = new Canvas.Image();
+      // Install an error handler that just remembers the error. It is then
+      // thrown in the callback of resourceLoader.fetch() below.
+      this._image.onerror = function (err) {
+        error = err;
+      };
+    }
+    this._currentSrc = null;
+    const srcAttributeValue = this.getAttributeNS(null, "src");
+    if (srcAttributeValue !== null && srcAttributeValue !== "") {
+      const resourceLoader = document._resourceLoader;
+      let request;
+
+      const onLoadImage = data => {
+        const { response } = request;
+
+        if (response && response.statusCode !== undefined && response.statusCode !== 200) {
+          throw new Error("Status code: " + response.statusCode);
+        }
+        error = null;
+        this._image.src = data;
+        if (error) {
+          throw new Error(error);
+        }
+        this._currentSrc = srcAttributeValue;
+      };
+
+      request = resourceLoader.fetch(this.src, {
+        element: this,
+        onLoad: onLoadImage
+      });
+    } else {
+      this._image.src = "";
+    }
   }
 }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -493,6 +493,35 @@ currentTime.html: [timeout, Loading metadata is not implemented]
 
 ---
 
+DIR: html/semantics/embedded-content/the-img-element
+
+404-response-with-actual-image-data.html: [fail-with-canvas, ResourceLoader seems to assume 404s are bad]
+Image-constructor.html: [fail-with-canvas, wrong-Realm Function, https://github.com/jsdom/jsdom/issues/2727]
+adoption.html: [timeout, Unknown]
+available-images-onload.html: [needs-canvas]
+current-pixel-density/**: [fail-with-canvas, Unimplemented]
+data-url.html: [needs-canvas]
+decode/**: [timeout, Unimplemented]
+delay-load-event-detached.html: [needs-canvas]
+delay-load-event.html: [timeout, Unknown]
+environment-changes/**: [timeout, Unimplemented]
+historical-progress-event.window.html: [needs-canvas]
+img.complete.html: [timeout, Unknown]
+invalid-src.html: [timeout, Resource loader doesn't catch bad URLs at the right point in the process]
+nonexistent-image.html: [needs-canvas]
+not-rendered-dimension-getter.html: [needs-canvas]
+null-image-source.html: [timeout, Unknown]
+relevant-mutations.html: [timeout, Unknown]
+sizes/**: [timeout, Unimplemented]
+srcset/**: [timeout, Unimplemented]
+update-media.html: [timeout, Unimplemented]
+update-src-complete.html: [timeout, Unknown]
+update-the-image-data/fail-to-resolve.html: [timeout, Resource loader doesn't catch bad URLs at the right point in the process]
+update-the-source-set.html: [timeout, Unimplemented]
+usemap-casing.html: [fail-with-canvas, Can't seem to handle onload = () => ...]
+
+---
+
 DIR: html/semantics/forms/attributes-common-to-form-controls
 
 dirname-ltr.html: [timeout, Unknown]


### PR DESCRIPTION
Closes #2701. This also enables the img element tests, with new infrastructure for selectively running them only when the canvas package is installed.