### PR TITLE
feat: add support for `vm.compileFunction`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 8
   - 10
+  - 12
   - stable
 
 before_install:
@@ -20,7 +20,7 @@ branches:
 
 matrix:
   include:
-    - node_js: 8
+    - node_js: 10
       env: TEST_SUITE=node-canvas
       addons:
         apt:

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ const c = `
   return input * 2;
 `;
 
-const doubleFunction = dom.compileVMFunction(c, ['input'])
+const doubleFunction = dom.compileVMFunction(c, ["input"])
 
 doubleFunction(2); // 4
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This is turned off by default for performance reasons, but is safe to enable.
 
 Note that we strongly advise against trying to "execute scripts" by mashing together the jsdom and Node global environments (e.g. by doing `global.window = dom.window`), and then executing scripts or test code inside the Node global environment. Instead, you should treat jsdom like you would a browser, and run all scripts and tests that need access to a DOM inside the jsdom environment, using `window.eval` or `runScripts: "dangerously"`. This might require, for example, creating a browserify bundle to execute as a `<script>` element—just like you would in a browser.
 
-Finally, for advanced use cases you can use the `dom.runVMScript(script)` or `dom.compileFunction(code)` methods, documented below.
+Finally, for advanced use cases you can use the `dom.compileVMFunction(code)` method, documented below.
 
 ### Pretending to be a visual browser
 
@@ -309,40 +309,11 @@ console.log(dom.nodeLocation(imgEl));    // { startOffset: 13, endOffset: 32 }
 
 Note that this feature only works if you have set the `includeNodeLocations` option; node locations are off by default for performance reasons.
 
-### Running vm-created scripts with `runVMScript(script[, options])`
+### Compiling a function with `compileVMFunction(code[, params[, options]])`
 
-The built-in `vm` module of Node.js allows you to create `Script` instances, which can be compiled ahead of time and then run multiple times on a given "VM context". Behind the scenes, a jsdom `Window` is indeed a VM context. To get access to this ability, use the `runVMScript()` method:
-
-```js
-const { Script } = require("vm");
-
-const dom = new JSDOM(``, { runScripts: "outside-only" });
-const s = new Script(`
-  if (!this.ran) {
-    this.ran = 0;
-  }
-
-  ++this.ran;
-`);
-
-dom.runVMScript(s);
-dom.runVMScript(s);
-dom.runVMScript(s);
-
-dom.window.ran === 3;
-```
-
-This is somewhat-advanced functionality, and we advise sticking to normal DOM APIs (such as `window.eval()` or `document.createElement("script")`) unless you have very specific needs.
-
-`runVMScript()` also takes an `options` object as its second argument. See the [Node.js docs](https://nodejs.org/api/vm.html#vm_script_runincontext_contextifiedsandbox_options) for details. (This functionality does not work when [using jsdom in a web browser](#running-jsdom-inside-a-web-browser).)
-
-### Compiling a function with `compileFunction(code[, params[, options]])`
-
-The built-in `vm` module of Node.js allows you to compile functions ahead of time within a "VM Context", which can then run multiple times. Behind the scenes, a jsdom `Window` is indeed a VM context. To get access to this ability, use the `compileFunction()` method:
+The built-in `vm` module of Node.js allows you to compile functions ahead of time within a "VM Context", which can then run multiple times. Behind the scenes, a jsdom `Window` is indeed a VM context. To get access to this ability, use the `compileVMFunction()` method:
 
 ```js
-const { Script } = require("vm");
-
 const dom = new JSDOM(``, { runScripts: "outside-only" });
 const c = `
   if (!this.ran) {
@@ -352,7 +323,7 @@ const c = `
   ++this.ran;
 `;
 
-const compiledCode = dom.compileFunction(c)
+const compiledCode = dom.compileVMFunction(c)
 
 compiledCode();
 compiledCode();
@@ -361,7 +332,7 @@ compiledCode();
 dom.window.ran === 3;
 ```
 
-`compileFunction`, like `runVMScript` documented above, is advanced functionality, and you probably don't need to use it.
+This is somewhat-advanced functionality, and we advise sticking to normal DOM APIs (such as `window.eval()` or `document.createElement("script")`) unless you have very specific needs.
 
 `compileFunction()` also takes the `param` and `options` arguments. See the [Node.js docs](https://nodejs.org/api/vm.html#vm_vm_compilefunction_code_params_options) for details. (This functionality does not work when [using jsdom in a web browser](#running-jsdom-inside-a-web-browser).)
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,19 @@ compiledCode();
 dom.window.ran === 3;
 ```
 
+You can also pass arguments.
+
+```js
+const dom = new JSDOM(``, { runScripts: "outside-only" });
+const c = `
+  return input * 2;
+`;
+
+const doubleFunction = dom.compileVMFunction(c, ['input'])
+
+doubleFunction(2); // 4
+```
+
 This is somewhat-advanced functionality, and we advise sticking to normal DOM APIs (such as `window.eval()` or `document.createElement("script")`) unless you have very specific needs.
 
 `compileFunction()` also takes the `param` and `options` arguments. See the [Node.js docs](https://nodejs.org/api/vm.html#vm_vm_compilefunction_code_params_options) for details. (This functionality does not work when [using jsdom in a web browser](#running-jsdom-inside-a-web-browser).)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 jsdom is a pure-JavaScript implementation of many web standards, notably the WHATWG [DOM](https://dom.spec.whatwg.org/) and [HTML](https://html.spec.whatwg.org/multipage/) Standards, for use with Node.js. In general, the goal of the project is to emulate enough of a subset of a web browser to be useful for testing and scraping real-world web applications.
 
-The latest versions of jsdom require Node.js v8 or newer. (Versions of jsdom below v12 still work with Node.js v6, but are unsupported.)
+The latest versions of jsdom require Node.js v10.10 or newer. (Versions of jsdom below v16 still work with previous Node.js versions, but are unsupported.)
 
 ## Basic usage
 
@@ -311,19 +311,17 @@ Note that this feature only works if you have set the `includeNodeLocations` opt
 
 ### Compiling a function with `compileVMFunction(code[, params[, options]])`
 
-The built-in `vm` module of Node.js allows you to compile functions ahead of time within a "VM Context", which can then run multiple times. Behind the scenes, a jsdom `Window` is indeed a VM context. To get access to this ability, use the `compileVMFunction()` method:
+The built-in `vm` module of Node.js allows you to compile functions ahead of time within a "VM context", which can then run multiple times. Behind the scenes, a jsdom `Window` is indeed a VM context. To get access to this ability, use the `compileVMFunction()` method:
 
 ```js
 const dom = new JSDOM(``, { runScripts: "outside-only" });
-const c = `
+const compiledCode = dom.compileVMFunction(`
   if (!this.ran) {
     this.ran = 0;
   }
 
   ++this.ran;
-`;
-
-const compiledCode = dom.compileVMFunction(c)
+`);
 
 compiledCode();
 compiledCode();
@@ -347,7 +345,9 @@ doubleFunction(2); // 4
 
 This is somewhat-advanced functionality, and we advise sticking to normal DOM APIs (such as `window.eval()` or `document.createElement("script")`) unless you have very specific needs.
 
-`compileFunction()` also takes the `param` and `options` arguments. See the [Node.js docs](https://nodejs.org/api/vm.html#vm_vm_compilefunction_code_params_options) for details. (This functionality does not work when [using jsdom in a web browser](#running-jsdom-inside-a-web-browser).)
+`compileFunction()` also takes the `param` and `options` arguments. See the [Node.js docs](https://nodejs.org/api/vm.html#vm_vm_compilefunction_code_params_options) for details (although note that the `parsingContext` option cannot be supplied).
+
+Note that this functionality does not work when [using jsdom in a web browser](#running-jsdom-inside-a-web-browser).
 
 ### Reconfiguring the jsdom with `reconfigure(settings)`
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -80,7 +80,7 @@ class JSDOM {
     options = options || {};
 
     if (options.parsingContext) {
-      throw new TypeError("You cannot pass a parsing context to compileFunction");
+      throw new TypeError("You cannot pass a parsing context to compileVMFunction");
     }
 
     options.parsingContext = this[window];

--- a/lib/api.js
+++ b/lib/api.js
@@ -80,6 +80,27 @@ class JSDOM {
     return script.runInContext(this[window], options);
   }
 
+  compileFunction(code, params, options) {
+    if (!vm.isContext(this[window])) {
+      throw new TypeError("This jsdom was not configured to allow script running. " +
+        "Use the runScripts option during creation.");
+    }
+
+    if (!vm.compileFunction) {
+      throw new TypeError("The version of Node you're using does not support compileFunction, please upgrade");
+    }
+
+    options = options || {};
+
+    if (options.parsingContext) {
+      throw new TypeError("You cannot pass a parseing context to compileFunction");
+    }
+
+    options.parsingContext = this[window];
+
+    return vm.compileFunction(code, params || [], options);
+  }
+
   reconfigure(settings) {
     if ("windowTop" in settings) {
       this[window]._top = settings.windowTop;

--- a/lib/api.js
+++ b/lib/api.js
@@ -93,7 +93,7 @@ class JSDOM {
     options = options || {};
 
     if (options.parsingContext) {
-      throw new TypeError("You cannot pass a parseing context to compileFunction");
+      throw new TypeError("You cannot pass a parsing context to compileFunction");
     }
 
     options.parsingContext = this[window];

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,21 +71,19 @@ class JSDOM {
     return idlUtils.implForWrapper(node).sourceCodeLocation;
   }
 
-  compileVMFunction(code, params, options) {
+  compileVMFunction(code, params = [], options = {}) {
     if (!vm.isContext(this[window])) {
       throw new TypeError("This jsdom was not configured to allow script running. " +
         "Use the runScripts option during creation.");
     }
 
-    options = options || {};
-
     if (options.parsingContext) {
       throw new TypeError("You cannot pass a parsing context to compileVMFunction");
     }
 
-    options.parsingContext = this[window];
+    options = { ...options, parsingContext: this[window] };
 
-    return vm.compileFunction(code, params || [], options);
+    return vm.compileFunction(code, params, options);
   }
 
   reconfigure(settings) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,23 +71,10 @@ class JSDOM {
     return idlUtils.implForWrapper(node).sourceCodeLocation;
   }
 
-  runVMScript(script, options) {
+  compileVMFunction(code, params, options) {
     if (!vm.isContext(this[window])) {
       throw new TypeError("This jsdom was not configured to allow script running. " +
         "Use the runScripts option during creation.");
-    }
-
-    return script.runInContext(this[window], options);
-  }
-
-  compileFunction(code, params, options) {
-    if (!vm.isContext(this[window])) {
-      throw new TypeError("This jsdom was not configured to allow script running. " +
-        "Use the runScripts option during creation.");
-    }
-
-    if (!vm.compileFunction) {
-      throw new TypeError("The version of Node you're using does not support compileFunction, please upgrade");
     }
 
     options = options || {};

--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
   },
   "main": "./lib/api.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=10.10"
   }
 }

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -213,20 +213,20 @@ describe("API: JSDOM class's methods", () => {
 
     it("should allow passing through arguments", { skipIfBrowser: true }, () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
-      const c = 'return input * 2;'
+      const c = "return input * 2;";
 
-      const doubleFunction = dom.compileVMFunction(c, ['input'])
+      const doubleFunction = dom.compileVMFunction(c, ["input"]);
 
       assert.strictEqual(doubleFunction(2), 4);
     });
 
     it("should throw if passed a parsingContext", { skipIfBrowser: true }, () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
-      const c = 'return input * 2;'
+      const c = "return input * 2;";
 
       assert.throws(
-        () => dom.compileVMFunction(c, [], {parsingContext: vm.createContext()}),
-        'You cannot pass a parsing context to compileVMFunction'
+        () => dom.compileVMFunction(c, [], { parsingContext: vm.createContext() }),
+        "You cannot pass a parsing context to compileVMFunction"
       );
     });
   });

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -209,6 +209,15 @@ describe("API: JSDOM class's methods", () => {
 
       assert.strictEqual(threw, true);
     });
+
+    it("should allow passing through arguments", { skipIfBrowser: true }, () => {
+      const dom = new JSDOM(``, { runScripts: "outside-only" });
+      const c = 'return input * 2;'
+
+      const doubleFunction = dom.compileVMFunction(c, ['input'])
+
+      assert.strictEqual(doubleFunction(2), 4);
+    });
   });
 
   describe("reconfigure", () => {

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -136,14 +136,14 @@ describe("API: JSDOM class's methods", () => {
   });
 
   describe("compileVMFunction", () => {
-    it("should throw when runScripts is left as the default", () => {
+    it("should throw when runScripts is left as the default", { skipIfBrowser: true }, () => {
       const dom = new JSDOM();
       const code = "this.ran = true;";
 
       assert.throws(() => dom.compileVMFunction(code), TypeError);
     });
 
-    it("should work when runScripts is set to \"outside-only\"", () => {
+    it("should work when runScripts is set to \"outside-only\"", { skipIfBrowser: true }, () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "this.ran = true;";
 
@@ -156,7 +156,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(dom.window.ran, true);
     });
 
-    it("should work when runScripts is set to \"dangerously\"", () => {
+    it("should work when runScripts is set to \"dangerously\"", { skipIfBrowser: true }, () => {
       const dom = new JSDOM(``, { runScripts: "dangerously" });
       const code = "this.ran = true;";
 
@@ -169,7 +169,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(dom.window.ran, true);
     });
 
-    it("should return the result of the invocation", () => {
+    it("should return the result of the invocation", { skipIfBrowser: true }, () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "return 5;";
 
@@ -180,7 +180,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(result, 5);
     });
 
-    it("should work with the same script multiple times", () => {
+    it("should work with the same script multiple times", { skipIfBrowser: true }, () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "if (!this.ran) { this.ran = 0; } ++this.ran;";
 

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -135,75 +135,19 @@ describe("API: JSDOM class's methods", () => {
     });
   });
 
-  describe("runVMScript", () => {
-    it("should throw when runScripts is left as the default", () => {
-      const dom = new JSDOM();
-      const script = new vm.Script("this.ran = true;");
-
-      assert.throws(() => dom.runVMScript(script), TypeError);
-
-      assert.strictEqual(dom.window.ran, undefined);
-    });
-
-    it("should work when runScripts is set to \"outside-only\"", () => {
-      const dom = new JSDOM(``, { runScripts: "outside-only" });
-      const script = new vm.Script("this.ran = true;");
-
-      dom.runVMScript(script);
-
-      assert.strictEqual(dom.window.ran, true);
-    });
-
-    it("should work when runScripts is set to \"dangerously\"", () => {
-      const dom = new JSDOM(``, { runScripts: "dangerously" });
-      const script = new vm.Script("this.ran = true;");
-
-      dom.runVMScript(script);
-
-      assert.strictEqual(dom.window.ran, true);
-    });
-
-    it("should return the result of the evaluation", () => {
-      const dom = new JSDOM(``, { runScripts: "outside-only" });
-      const script = new vm.Script("5;");
-
-      const result = dom.runVMScript(script);
-
-      assert.strictEqual(result, 5);
-    });
-
-    it("should work with the same script multiple times", () => {
-      const dom = new JSDOM(``, { runScripts: "outside-only" });
-      const script = new vm.Script("if (!this.ran) { this.ran = 0; } ++this.ran;");
-
-      dom.runVMScript(script);
-      dom.runVMScript(script);
-      dom.runVMScript(script);
-
-      assert.strictEqual(dom.window.ran, 3);
-    });
-
-    it("should allow passing through options", { skipIfBrowser: true }, () => {
-      const dom = new JSDOM(``, { runScripts: "outside-only" });
-      const script = new vm.Script("while(true) {}");
-
-      assert.throws(() => dom.runVMScript(script, { timeout: 50 }), /Script execution timed out(?: after 50ms|\.)/);
-    });
-  });
-
-  describe("compileFunction", () => {
+  describe("compileVMFunction", () => {
     it("should throw when runScripts is left as the default", () => {
       const dom = new JSDOM();
       const code = "this.ran = true;";
 
-      assert.throws(() => dom.compileFunction(code), TypeError);
+      assert.throws(() => dom.compileVMFunction(code), TypeError);
     });
 
     it("should work when runScripts is set to \"outside-only\"", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "this.ran = true;";
 
-      const compiledFunction = dom.compileFunction(code);
+      const compiledFunction = dom.compileVMFunction(code);
 
       assert.strictEqual(dom.window.ran, undefined);
 
@@ -216,7 +160,7 @@ describe("API: JSDOM class's methods", () => {
       const dom = new JSDOM(``, { runScripts: "dangerously" });
       const code = "this.ran = true;";
 
-      const compiledFunction = dom.compileFunction(code);
+      const compiledFunction = dom.compileVMFunction(code);
 
       assert.strictEqual(dom.window.ran, undefined);
 
@@ -229,7 +173,7 @@ describe("API: JSDOM class's methods", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "return 5;";
 
-      const compiledFunction = dom.compileFunction(code);
+      const compiledFunction = dom.compileVMFunction(code);
 
       const result = compiledFunction();
 
@@ -240,7 +184,7 @@ describe("API: JSDOM class's methods", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "if (!this.ran) { this.ran = 0; } ++this.ran;";
 
-      const compiledFunction = dom.compileFunction(code);
+      const compiledFunction = dom.compileVMFunction(code);
 
       compiledFunction();
       compiledFunction();
@@ -253,7 +197,7 @@ describe("API: JSDOM class's methods", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "throw new Error('some error')";
 
-      const compiledFunction = dom.compileFunction(code, [], { filename: "fakeFileName.js" });
+      const compiledFunction = dom.compileVMFunction(code, [], { filename: "fakeFileName.js" });
 
       let threw = false;
 

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -1,5 +1,4 @@
 "use strict";
-const vm = require("vm");
 const { assert } = require("chai");
 const { describe, it } = require("mocha-sugar-free");
 

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -213,7 +213,7 @@ describe("API: JSDOM class's methods", () => {
     });
 
     it("should work when runScripts is set to \"dangerously\"", () => {
-      const dom = new JSDOM(``, { runScripts: "outside-only" });
+      const dom = new JSDOM(``, { runScripts: "dangerously" });
       const code = "this.ran = true;";
 
       const compiledFunction = dom.compileFunction(code);

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -1,4 +1,5 @@
 "use strict";
+const vm = require("vm");
 const { assert } = require("chai");
 const { describe, it } = require("mocha-sugar-free");
 
@@ -217,6 +218,16 @@ describe("API: JSDOM class's methods", () => {
       const doubleFunction = dom.compileVMFunction(c, ['input'])
 
       assert.strictEqual(doubleFunction(2), 4);
+    });
+
+    it("should throw if passed a parsingContext", { skipIfBrowser: true }, () => {
+      const dom = new JSDOM(``, { runScripts: "outside-only" });
+      const c = 'return input * 2;'
+
+      assert.throws(
+        () => dom.compileVMFunction(c, [], {parsingContext: vm.createContext()}),
+        'You cannot pass a parsing context to compileVMFunction'
+      );
     });
   });
 

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -135,15 +135,15 @@ describe("API: JSDOM class's methods", () => {
     });
   });
 
-  describe("compileVMFunction", () => {
-    it("should throw when runScripts is left as the default", { skipIfBrowser: true }, () => {
+  describe("compileVMFunction", { skipIfBrowser: true }, () => {
+    it("should throw when runScripts is left as the default", () => {
       const dom = new JSDOM();
       const code = "this.ran = true;";
 
       assert.throws(() => dom.compileVMFunction(code), TypeError);
     });
 
-    it("should work when runScripts is set to \"outside-only\"", { skipIfBrowser: true }, () => {
+    it("should work when runScripts is set to \"outside-only\"", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "this.ran = true;";
 
@@ -156,7 +156,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(dom.window.ran, true);
     });
 
-    it("should work when runScripts is set to \"dangerously\"", { skipIfBrowser: true }, () => {
+    it("should work when runScripts is set to \"dangerously\"", () => {
       const dom = new JSDOM(``, { runScripts: "dangerously" });
       const code = "this.ran = true;";
 
@@ -169,7 +169,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(dom.window.ran, true);
     });
 
-    it("should return the result of the invocation", { skipIfBrowser: true }, () => {
+    it("should return the result of the invocation", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "return 5;";
 
@@ -180,7 +180,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(result, 5);
     });
 
-    it("should work with the same script multiple times", { skipIfBrowser: true }, () => {
+    it("should work with the same script multiple times", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "if (!this.ran) { this.ran = 0; } ++this.ran;";
 
@@ -193,7 +193,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(dom.window.ran, 3);
     });
 
-    it("should allow passing through options", { skipIfBrowser: true }, () => {
+    it("should allow passing through options", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const code = "throw new Error('some error')";
 
@@ -211,7 +211,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(threw, true);
     });
 
-    it("should allow passing through arguments", { skipIfBrowser: true }, () => {
+    it("should allow passing through arguments", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const c = "return input * 2;";
 
@@ -220,7 +220,7 @@ describe("API: JSDOM class's methods", () => {
       assert.strictEqual(doubleFunction(2), 4);
     });
 
-    it("should throw if passed a parsingContext", { skipIfBrowser: true }, () => {
+    it("should throw if passed a parsingContext", () => {
       const dom = new JSDOM(``, { runScripts: "outside-only" });
       const c = "return input * 2;";
 
@@ -228,6 +228,20 @@ describe("API: JSDOM class's methods", () => {
         () => dom.compileVMFunction(c, [], { parsingContext: vm.createContext() }),
         "You cannot pass a parsing context to compileVMFunction"
       );
+    });
+
+    it("should not attempt to mutate the options object", () => {
+      const dom = new JSDOM(``, { runScripts: "outside-only" });
+      const options = Object.freeze({});
+
+      // This would throw if we tried to mutate options.
+      const compiledFunction = dom.compileVMFunction("this.ran = true;", undefined, options);
+
+      assert.strictEqual(dom.window.ran, undefined);
+
+      compiledFunction();
+
+      assert.strictEqual(dom.window.ran, true);
     });
   });
 


### PR DESCRIPTION
Id like to move Jest away from the module wrapper, similar to what Node core did here: https://github.com/nodejs/node/pull/21573. Jest currently uses its own module wrapper, puts it in a `Script`, then executes it using `runVMScript`. However, if we use `compileFunction` instead, we don't need to create the wrapper.

Note that this function was added in `node@10.10`, so I've added a guard that'll throw on node 8 (or some minor of node that don't have the function). I'd prefer this to land in the current version of JSDOM without bumping the major, as otherwise we'd be unable to use this in Jest until sometime next year. I probably need to add a guard in the tests for this case, but I'd like to get some feedback on this first approach first.