### PR TITLE
Add test for issue 2639 - setting rgba color style

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "acorn": "^7.1.0",
     "acorn-globals": "^4.3.2",
     "cssom": "^0.4.4",
-    "cssstyle": "^2.0.0",
+    "cssstyle": "^2.1.0",
     "data-urls": "^2.0.0",
     "decimal.js": "^10.2.0",
     "domexception": "^2.0.1",

--- a/test/web-platform-tests/to-upstream/cssom/element-style-color.html
+++ b/test/web-platform-tests/to-upstream/cssom/element-style-color.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Computed visibility is inherited</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- Test for https://github.com/jsdom/jsdom/issues/2639 -->
+<!-- Test for https://github.com/jsdom/jsdom/issues/825 -->
+
+<body>
+  <p id="paragraph">Hello CSS Style</p>
+</body>
+
+<script>
+"use strict";
+
+test(() => {
+  const element = document.querySelector("#paragraph");
+  element.style.color = "";
+  element.style.color = "rgba(255, 255, 255, 0.5)";
+
+  assert_equals(element.style.color, "rgba(255, 255, 255, 0.5)");
+}, "Setting a color with a decimal transparency should update the style");
+
+test(() => {
+  const element = document.querySelector("#paragraph");
+  element.style.color = "";
+  element.style.color = "rgb(0%, 100%, 100%)";
+
+  assert_equals(element.style.color, "rgb(0, 255, 255)");
+}, "Setting a color with a nil value and percentages should update the style");
+
+test(() => {
+  const element = document.querySelector("#paragraph");
+  element.style.color = "";
+  element.style.color = "rgb(0, 100%, 100%)";
+
+  assert_equals(element.style.color, "");
+}, "Setting a mixed percent and value color should NOT update the style");
+
+test(() => {
+  const element = document.querySelector("#paragraph");
+  element.style.color = "";
+  element.style.color = "hsl(0, 100%, 50%)";
+
+  assert_equals(element.style.color, "rgb(255, 0, 0)");
+}, "Setting an hsl color should update the style");
+
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,10 +1067,10 @@ cssom@~0.3.6:
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
 
-cssstyle@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.0.0.tgz#911f0fe25532db4f5d44afc83f89cc4b82c97fe3"
-  integrity sha512-QXSAu2WBsSRXCPjvI43Y40m6fMevvyRm8JVAuF9ksQz5jha4pWP1wpaK7Yu5oLFc6+XAY+hj8YhefyXcBB53gg==
+cssstyle@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.1.0.tgz#99f50a3aa21d4af16e758ae3e454dcf5940b9122"
+  integrity sha512-1iwCdymVYhMdQWiZ+9mB7x+urdNLPGTWsIZt6euFk8Yi+dOERK2ccoAUA3Bl8I5vmK5qfz/eLkBRyLbs42ov4A==
   dependencies:
     cssom "~0.3.6"
 


### PR DESCRIPTION
I pinpointed the issue #2639 to a problem with cssstyle.
I submitted a PR on cssstyle (see https://github.com/jsdom/cssstyle/pull/109) and added a test here.
I can rename/move the test if you feel it is not in the right place.

In order for this test to pass, we need to merge/release a new version of cssstyle, bump the version used by jsdom and rerun the test.

Concerning issue #825, I could not reproduce the issue. It may have been fixed by a cssstyle update since 2014?

