### PR TITLE
Implement uniform strategy for JS globals in the JSDOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ npm-debug.log*
 benchmark/browser-bundle.js
 
 lib/jsdom/living/generated/**/*.js
+lib/jsdom/browser/js-globals.json

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -27,6 +27,7 @@ const { fireAnEvent } = require("../living/helpers/events");
 const SessionHistory = require("../living/window/SessionHistory");
 const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented } =
   require("../living/helpers/style-rules");
+const jsGlobals = require("./js-globals.json");
 
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
@@ -128,6 +129,12 @@ function Window(options) {
   this._runScripts = options.runScripts;
   if (this._runScripts === "outside-only" || this._runScripts === "dangerously") {
     contextifyWindow(this);
+  } else {
+    // Without contextifying the window, none of the globals will exist. So, let's at least alias them from the Node.js
+    // context. See https://github.com/jsdom/jsdom/issues/2727 for more background and discussion.
+    for (const globalName of jsGlobals) {
+      this[globalName] = global[globalName];
+    }
   }
 
   // Set up the window as if it's a top level window.
@@ -438,18 +445,6 @@ function Window(options) {
   };
 
   this.XMLHttpRequest = createXMLHttpRequest(this);
-
-  // TODO: necessary for Blob and FileReader due to different-globals weirdness; investigate how to avoid this.
-  this.ArrayBuffer = ArrayBuffer;
-  this.Int8Array = Int8Array;
-  this.Uint8Array = Uint8Array;
-  this.Uint8ClampedArray = Uint8ClampedArray;
-  this.Int16Array = Int16Array;
-  this.Uint16Array = Uint16Array;
-  this.Int32Array = Int32Array;
-  this.Uint32Array = Uint32Array;
-  this.Float32Array = Float32Array;
-  this.Float64Array = Float64Array;
 
   this.stop = function () {
     const manager = idlUtils.implForWrapper(this._document)._requestManager;

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -129,6 +129,12 @@ function Window(options) {
   this._runScripts = options.runScripts;
   if (this._runScripts === "outside-only" || this._runScripts === "dangerously") {
     contextifyWindow(this);
+
+    // Without this, these globals will only appear to scripts running inside the context using vm.runScript; they will
+    // not appear to scripts running from the outside, including to JSDOM implementation code.
+    for (const globalName of jsGlobals) {
+      this[globalName] = vm.runInContext(globalName, this);
+    }
   } else {
     // Without contextifying the window, none of the globals will exist. So, let's at least alias them from the Node.js
     // context. See https://github.com/jsdom/jsdom/issues/2727 for more background and discussion.

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -38,7 +38,23 @@ module.exports = Window;
 const { installInterfaces } = require("../living/interfaces");
 
 // https://html.spec.whatwg.org/#the-window-object
-function setupWindow(windowInstance) {
+function setupWindow(windowInstance, { runScripts }) {
+  if (runScripts === "outside-only" || runScripts === "dangerously") {
+    contextifyWindow(windowInstance);
+
+    // Without this, these globals will only appear to scripts running inside the context using vm.runScript; they will
+    // not appear to scripts running from the outside, including to JSDOM implementation code.
+    for (const globalName of jsGlobals) {
+      windowInstance[globalName] = vm.runInContext(globalName, windowInstance);
+    }
+  } else {
+    // Without contextifying the window, none of the globals will exist. So, let's at least alias them from the Node.js
+    // context. See https://github.com/jsdom/jsdom/issues/2727 for more background and discussion.
+    for (const globalName of jsGlobals) {
+      windowInstance[globalName] = global[globalName];
+    }
+  }
+
   installInterfaces(windowInstance);
 
   const EventTargetConstructor = windowInstance.EventTarget;
@@ -83,7 +99,7 @@ function setupWindow(windowInstance) {
 // That is why we assign everything inside of the constructor, instead of using a shared prototype.
 // You can verify this in e.g. Firefox or Internet Explorer, which do a good job with Web IDL compliance.
 function Window(options) {
-  setupWindow(this);
+  setupWindow(this, { runScripts: options.runScripts });
 
   const rawPerformance = new RawPerformance();
   const windowInitialized = rawPerformance.now();
@@ -117,6 +133,12 @@ function Window(options) {
       global: this
     }
   });
+
+  if (window._runScripts === "outside-only" || window._runScripts === "dangerously") {
+    const documentImpl = idlUtils.implForWrapper(window._document);
+    documentImpl._defaultView = window._globalProxy = vm.runInContext("this", window);
+  }
+
   // https://html.spec.whatwg.org/#session-history
   this._sessionHistory = new SessionHistory({
     document: idlUtils.implForWrapper(this._document),
@@ -127,21 +149,6 @@ function Window(options) {
   this._virtualConsole = options.virtualConsole;
 
   this._runScripts = options.runScripts;
-  if (this._runScripts === "outside-only" || this._runScripts === "dangerously") {
-    contextifyWindow(this);
-
-    // Without this, these globals will only appear to scripts running inside the context using vm.runScript; they will
-    // not appear to scripts running from the outside, including to JSDOM implementation code.
-    for (const globalName of jsGlobals) {
-      this[globalName] = vm.runInContext(globalName, this);
-    }
-  } else {
-    // Without contextifying the window, none of the globals will exist. So, let's at least alias them from the Node.js
-    // context. See https://github.com/jsdom/jsdom/issues/2727 for more background and discussion.
-    for (const globalName of jsGlobals) {
-      this[globalName] = global[globalName];
-    }
-  }
 
   // Set up the window as if it's a top level window.
   // If it's not, then references will be corrected by frame/iframe code.
@@ -670,6 +677,4 @@ function contextifyWindow(window) {
   }
 
   vm.createContext(window);
-  const documentImpl = idlUtils.implForWrapper(window._document);
-  documentImpl._defaultView = window._globalProxy = vm.runInContext("this", window);
 }

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -134,7 +134,7 @@ function Window(options) {
     }
   });
 
-  if (window._runScripts === "outside-only" || window._runScripts === "dangerously") {
+  if (vm.isContext(window)) {
     const documentImpl = idlUtils.implForWrapper(window._document);
     documentImpl._defaultView = window._globalProxy = vm.runInContext("this", window);
   }

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -44,14 +44,16 @@ function setupWindow(windowInstance, { runScripts }) {
 
     // Without this, these globals will only appear to scripts running inside the context using vm.runScript; they will
     // not appear to scripts running from the outside, including to JSDOM implementation code.
-    for (const globalName of jsGlobals) {
-      windowInstance[globalName] = vm.runInContext(globalName, windowInstance);
+    for (const [globalName, globalPropDesc] of Object.entries(jsGlobals)) {
+      const propDesc = { ...globalPropDesc, value: vm.runInContext(globalName, windowInstance) };
+      Object.defineProperty(windowInstance, globalName, propDesc);
     }
   } else {
     // Without contextifying the window, none of the globals will exist. So, let's at least alias them from the Node.js
     // context. See https://github.com/jsdom/jsdom/issues/2727 for more background and discussion.
-    for (const globalName of jsGlobals) {
-      windowInstance[globalName] = global[globalName];
+    for (const [globalName, globalPropDesc] of Object.entries(jsGlobals)) {
+      const propDesc = { ...globalPropDesc, value: global[globalName] };
+      Object.defineProperty(windowInstance, globalName, propDesc);
     }
   }
 

--- a/lib/jsdom/living/file-api/Blob-impl.js
+++ b/lib/jsdom/living/file-api/Blob-impl.js
@@ -1,5 +1,6 @@
 "use strict";
 const Blob = require("../generated/Blob");
+const { isArrayBuffer } = require("../generated/utils");
 
 function convertLineEndingsToNative(s) {
   // jsdom always pretends to be *nix, for consistency.
@@ -17,7 +18,7 @@ exports.implementation = class BlobImpl {
     if (parts !== undefined) {
       for (const part of parts) {
         let buffer;
-        if (part instanceof ArrayBuffer) {
+        if (isArrayBuffer(part)) {
           buffer = Buffer.from(part);
         } else if (ArrayBuffer.isView(part)) {
           buffer = Buffer.from(part.buffer, part.byteOffset, part.byteLength);

--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -24,6 +24,7 @@ class FileReaderImpl extends EventTargetImpl {
     this.readyState = READY_STATES.EMPTY;
     this.result = null;
 
+    this._globalObject = globalObject;
     this._ownerDocument = globalObject.document;
     this._terminated = false;
   }
@@ -95,7 +96,7 @@ class FileReaderImpl extends EventTargetImpl {
         switch (format) {
           default:
           case "buffer": {
-            this.result = (new Uint8Array(data)).buffer;
+            this.result = (new this._globalObject.Uint8Array(data)).buffer;
             break;
           }
           case "binaryString": {

--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -7,6 +7,7 @@ const EventTargetImpl = require("../events/EventTarget-impl").implementation;
 const ProgressEvent = require("../generated/ProgressEvent");
 const { setupForSimpleEventAccessors } = require("../helpers/create-event-accessor");
 const { fireAnEvent } = require("../helpers/events");
+const { copyToArrayBufferInNewRealm } = require("../helpers/binary-data");
 
 const READY_STATES = Object.freeze({
   EMPTY: 0,
@@ -96,7 +97,7 @@ class FileReaderImpl extends EventTargetImpl {
         switch (format) {
           default:
           case "buffer": {
-            this.result = (new this._globalObject.Uint8Array(data)).buffer;
+            this.result = copyToArrayBufferInNewRealm(data, this._globalObject);
             break;
           }
           case "binaryString": {

--- a/lib/jsdom/living/helpers/binary-data.js
+++ b/lib/jsdom/living/helpers/binary-data.js
@@ -1,0 +1,9 @@
+"use strict";
+
+// See https://github.com/jsdom/jsdom/pull/2743#issuecomment-562991955 for background.
+exports.copyToArrayBufferInNewRealm = (nodejsBuffer, newRealm) => {
+  const newAB = new newRealm.ArrayBuffer(nodejsBuffer.byteLength);
+  const view = new Uint8Array(newAB);
+  view.set(nodejsBuffer);
+  return newAB;
+};

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -63,7 +63,7 @@ function fetchFrame(serializedURL, frame, document, contentDoc) {
       parseIntoDocument(html, contentDoc);
     } catch (error) {
       if (
-        error instanceof DOMException &&
+        error.constructor.name === "DOMException" &&
         error.code === DOMException.SYNTAX_ERR &&
         contentDoc._parsingMode === "xml"
       ) {

--- a/lib/jsdom/living/websockets/WebSocket-impl.js
+++ b/lib/jsdom/living/websockets/WebSocket-impl.js
@@ -8,6 +8,7 @@ const WebSocket = require("ws");
 
 const { setupForSimpleEventAccessors } = require("../helpers/create-event-accessor");
 const { fireAnEvent } = require("../helpers/events");
+const { isArrayBuffer } = require("../generated/utils");
 
 const EventTargetImpl = require("../events/EventTarget-impl").implementation;
 
@@ -192,7 +193,7 @@ class WebSocketImpl extends EventTargetImpl {
     if (typeof data === "string") {
       dataForEvent = data;
     } else if (this.binaryType === "arraybuffer") {
-      if (data instanceof ArrayBuffer) {
+      if (isArrayBuffer(data)) {
         dataForEvent = data;
       } else if (Array.isArray(data)) {
         dataForEvent = new Uint8Array(Buffer.concat(data)).buffer;

--- a/lib/jsdom/living/websockets/WebSocket-impl.js
+++ b/lib/jsdom/living/websockets/WebSocket-impl.js
@@ -9,6 +9,7 @@ const WebSocket = require("ws");
 const { setupForSimpleEventAccessors } = require("../helpers/create-event-accessor");
 const { fireAnEvent } = require("../helpers/events");
 const { isArrayBuffer } = require("../generated/utils");
+const { copyToArrayBufferInNewRealm } = require("../helpers/binary-data");
 
 const EventTargetImpl = require("../events/EventTarget-impl").implementation;
 
@@ -196,9 +197,9 @@ class WebSocketImpl extends EventTargetImpl {
       if (isArrayBuffer(data)) {
         dataForEvent = data;
       } else if (Array.isArray(data)) {
-        dataForEvent = new Uint8Array(Buffer.concat(data)).buffer;
+        dataForEvent = copyToArrayBufferInNewRealm(Buffer.concat(data), this._globalObject);
       } else {
-        dataForEvent = new Uint8Array(data).buffer;
+        dataForEvent = copyToArrayBufferInNewRealm(data, this._globalObject);
       }
     } else { // this.binaryType === "blob"
       if (!Array.isArray(data)) {

--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -21,6 +21,7 @@ const FormData = require("./generated/FormData");
 const XMLHttpRequestEventTarget = require("./generated/XMLHttpRequestEventTarget");
 const XMLHttpRequestUpload = require("./generated/XMLHttpRequestUpload");
 const ProgressEvent = require("./generated/ProgressEvent");
+const { isArrayBuffer } = require("./generated/utils");
 const { parseIntoDocument } = require("../browser/parser");
 const { fragmentSerialization } = require("./domparsing/serialization");
 const { setupForSimpleEventAccessors } = require("./helpers/create-event-accessor");
@@ -1030,7 +1031,7 @@ function coerceBodyArg(body) {
     return null;
   }
 
-  if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+  if (isArrayBuffer(body) || ArrayBuffer.isView(body)) {
     return body;
   }
 
@@ -1056,7 +1057,7 @@ function extractBody(bodyInit) {
       buffer: bodyInit._buffer,
       contentType: bodyInit.type === "" ? null : bodyInit.type
     };
-  } else if (bodyInit instanceof ArrayBuffer) {
+  } else if (isArrayBuffer(bodyInit)) {
     return {
       buffer: Buffer.from(bodyInit),
       contentType: null

--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -27,6 +27,7 @@ const { fragmentSerialization } = require("./domparsing/serialization");
 const { setupForSimpleEventAccessors } = require("./helpers/create-event-accessor");
 const { parseJSONFromBytes } = require("./helpers/json");
 const { fireAnEvent } = require("./helpers/events");
+const { copyToArrayBufferInNewRealm } = require("./helpers/binary-data");
 
 const syncWorkerFile = require.resolve ? require.resolve("./xhr-sync-worker.js") : null;
 
@@ -208,7 +209,7 @@ module.exports = function createXMLHttpRequest(window) {
           if (!responseBuffer) {
             return null;
           }
-          res = (new Uint8Array(responseBuffer)).buffer;
+          res = copyToArrayBufferInNewRealm(responseBuffer, this._globalObject);
           break;
         }
         case "blob": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tough-cookie": "^3.0.1",
     "w3c-hr-time": "^1.0.1",
     "w3c-xmlserializer": "^1.1.2",
-    "webidl-conversions": "^4.0.2",
+    "webidl-conversions": "^5.0.0",
     "whatwg-encoding": "^1.0.5",
     "whatwg-mimetype": "^2.3.0",
     "whatwg-url": "^7.1.0",
@@ -82,7 +82,7 @@
     "st": "^2.0.0",
     "watchify": "^3.11.1",
     "wd": "^1.11.2",
-    "webidl2js": "^11.0.0"
+    "webidl2js": "jsdom/webidl2js#master"
   },
   "browser": {
     "canvas": false,

--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
     "./lib/jsdom/living/websockets/WebSocket-impl.js": "./lib/jsdom/living/websockets/WebSocket-impl-browser.js"
   },
   "scripts": {
-    "prepare": "yarn convert-idl",
-    "pretest": "yarn convert-idl && yarn init-wpt",
+    "prepare": "yarn convert-idl && yarn generate-js-globals",
+    "pretest": "yarn prepare && yarn init-wpt",
     "test-wpt": "mocha test/web-platform-tests/run-wpts.js",
     "test-tuwpt": "mocha test/web-platform-tests/run-tuwpts.js",
     "test-mocha": "mocha",
@@ -108,7 +108,8 @@
     "update-authors": "git log --format=\"%aN <%aE>\" | sort -f | uniq > AUTHORS.txt",
     "benchmark": "node ./benchmark/runner",
     "benchmark-browser": "node ./benchmark/runner --bundle",
-    "convert-idl": "node ./scripts/webidl/convert"
+    "convert-idl": "node ./scripts/webidl/convert.js",
+    "generate-js-globals": "node ./scripts/generate-js-globals.js"
   },
   "main": "./lib/api.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "st": "^2.0.0",
     "watchify": "^3.11.1",
     "wd": "^1.11.2",
-    "webidl2js": "jsdom/webidl2js#master"
+    "webidl2js": "^12.0.0"
   },
   "browser": {
     "canvas": false,

--- a/scripts/generate-js-globals.js
+++ b/scripts/generate-js-globals.js
@@ -2,6 +2,7 @@
 const vm = require("vm");
 const fs = require("fs");
 const path = require("path");
+const assert = require("assert");
 
 // Creates a list of globals from the JS environment (not the web), so that Window.js can alias them when necessary.
 // The generated list should match https://tc39.es/ecma262/#sec-global-object, to the extent V8 implements the spec.
@@ -11,13 +12,20 @@ const path = require("path");
 const dest = path.resolve(__dirname, "../lib/jsdom/browser/js-globals.json");
 
 const context = vm.createContext();
-const globals = vm.runInContext("Object.getOwnPropertyNames(this)", context);
+
+const globals = vm.runInContext("Object.getOwnPropertyDescriptors(this)", context);
 
 // I guess VM contexts have a console, from V8? That isn't a JS global and JSDOM will install its own, so don't include
 // that.
-const consoleIndex = globals.indexOf("console");
-if (consoleIndex !== -1) {
-  globals.splice(consoleIndex, 1);
+delete globals.console;
+
+// All JS globals are data properties as of the time of this writing. If that becomes false then we need to adapt the
+// code in Window.js.
+for (const [key, global] of Object.entries(globals)) {
+  assert("value" in global && !("get" in global) && !("set" in global), `${key} was unexpectedly a non-data property`);
+
+  // We don't want to serialize value; Window.js will get it afresh, and having it in the JSON is confusing.
+  delete global.value;
 }
 
 fs.writeFileSync(dest, JSON.stringify(globals, undefined, 2) + "\n");

--- a/scripts/generate-js-globals.js
+++ b/scripts/generate-js-globals.js
@@ -1,0 +1,20 @@
+"use strict";
+const vm = require("vm");
+const fs = require("fs");
+const path = require("path");
+
+// Creates a list of globals from the JS environment (not the web), so that Window.js can alias them when necessary.
+// The generated list should match https://tc39.es/ecma262/#sec-global-object, to the extent V8 implements the spec.
+// We generate this at build time instead of runtime because we want to avoid the performance and memory overhead of
+// creating a new context when scripting is disabled in the JSDOM.
+
+const dest = path.resolve(__dirname, "../lib/jsdom/browser/js-globals.json");
+
+const context = vm.createContext();
+const globals = vm.runInContext("Object.getOwnPropertyNames(this)", context);
+
+// I guess VM contexts have a console, from V8? That isn't a JS global and JSDOM will install its own, so don't include
+// that.
+globals.splice(globals.indexOf("console"), 1);
+
+fs.writeFileSync(dest, JSON.stringify(globals, undefined, 2));

--- a/scripts/generate-js-globals.js
+++ b/scripts/generate-js-globals.js
@@ -15,6 +15,9 @@ const globals = vm.runInContext("Object.getOwnPropertyNames(this)", context);
 
 // I guess VM contexts have a console, from V8? That isn't a JS global and JSDOM will install its own, so don't include
 // that.
-globals.splice(globals.indexOf("console"), 1);
+const consoleIndex = globals.indexOf("console");
+if (consoleIndex !== -1) {
+  globals.splice(consoleIndex, 1);
+}
 
-fs.writeFileSync(dest, JSON.stringify(globals, undefined, 2));
+fs.writeFileSync(dest, JSON.stringify(globals, undefined, 2) + "\n");

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -6,6 +6,10 @@ const { delay } = require("../util.js");
 const { JSDOM, VirtualConsole } = require("../..");
 const jsGlobals = Object.keys(require("../../lib/jsdom/browser/js-globals.json"));
 
+// Node 10 has a bug with the vm module that causes some global-related tests to fail.
+const hasNode10 = Number(process.versions.node.split(".")[0]) >= 10;
+
+
 describe("API: runScripts constructor option", () => {
   describe("<script>s and eval()", () => {
     it("should not execute any scripts by default", () => {
@@ -91,7 +95,8 @@ describe("API: runScripts constructor option", () => {
     });
   });
 
-  describe("JS spec globals", () => {
+  const jsSpecGlobalsDescribe = hasNode10 ? describe.skip : describe;
+  jsSpecGlobalsDescribe("JS spec globals", () => {
     it("should include aliased globals by default", () => {
       // Sanity check that our global-generation process hasn't broken.
       assert.include(jsGlobals, "TypeError");

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -7,7 +7,7 @@ const { JSDOM, VirtualConsole } = require("../..");
 const jsGlobals = Object.keys(require("../../lib/jsdom/browser/js-globals.json"));
 
 // Node 10 has a bug with the vm module that causes some global-related tests to fail.
-const hasNode10 = Number(process.versions.node.split(".")[0]) >= 10;
+const hasNode10 = process.versions.node && Number(process.versions.node.split(".")[0]) >= 10;
 
 
 describe("API: runScripts constructor option", () => {

--- a/test/api/options.js
+++ b/test/api/options.js
@@ -193,50 +193,6 @@ describe("API: constructor options", () => {
 
       assert.strictEqual(windowPassed, dom.window);
     });
-
-    it("should not have built-ins on the window by default", () => {
-      let windowPassed;
-
-      const dom = new JSDOM(``, {
-        beforeParse(window) {
-          assert.strictEqual(window.Array, undefined);
-
-          windowPassed = window;
-        }
-      });
-
-      assert.strictEqual(windowPassed, dom.window);
-    });
-
-    it("should have built-ins on the window when running scripts outside-only", () => {
-      let windowPassed;
-
-      const dom = new JSDOM(``, {
-        runScripts: "outside-only",
-        beforeParse(window) {
-          assert.typeOf(window.Array, "function");
-
-          windowPassed = window;
-        }
-      });
-
-      assert.strictEqual(windowPassed, dom.window);
-    });
-
-    it("should have built-ins on the window when running scripts dangerously", () => {
-      let windowPassed;
-
-      const dom = new JSDOM(``, {
-        runScripts: "dangerously",
-        beforeParse(window) {
-          assert.typeOf(window.Array, "function");
-
-          windowPassed = window;
-        }
-      });
-
-      assert.strictEqual(windowPassed, dom.window);
-    });
   });
 
   describe("pretendToBeVisual", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4832,24 +4832,28 @@ wd@^1.11.2:
     request "2.88.0"
     vargs "^0.1.0"
 
-webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
+webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
 
 webidl2@^23.10.1:
   version "23.10.1"
   resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.10.1.tgz#2d2786fdff7b72c6b4a9a43e70f1611ded8ec8e6"
   integrity sha512-SK/KzMGgkPLN73HNqyU9tWPduireSzV6p/WAsmYYweI/ED19FC8+ymsi2InMX80+VjSvsfc3vA7UbMjXYWNPhA==
 
-webidl2js@^11.0.0:
+webidl2js@jsdom/webidl2js#master:
   version "11.0.0"
-  resolved "https://registry.yarnpkg.com/webidl2js/-/webidl2js-11.0.0.tgz#102fc91f4b4a73d4b40648f46fb85e7e9ea7e490"
-  integrity sha512-Kv+WVa6i/eXtcvO+SJGULu91CjQE3befNq+kBcaYvIHCTttczK2RxxzZqc+fA9r76tVr0HCe0kYlpfvIlSCbsg==
+  resolved "https://codeload.github.com/jsdom/webidl2js/tar.gz/33b4f5201b3e1a01afd09a29ba4c08712bd7982a"
   dependencies:
     pn "^1.1.0"
     prettier "^1.19.1"
-    webidl-conversions "^4.0.0"
+    webidl-conversions "^5.0.0"
     webidl2 "^23.10.1"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4847,9 +4847,10 @@ webidl2@^23.10.1:
   resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.10.1.tgz#2d2786fdff7b72c6b4a9a43e70f1611ded8ec8e6"
   integrity sha512-SK/KzMGgkPLN73HNqyU9tWPduireSzV6p/WAsmYYweI/ED19FC8+ymsi2InMX80+VjSvsfc3vA7UbMjXYWNPhA==
 
-webidl2js@jsdom/webidl2js#master:
-  version "11.0.0"
-  resolved "https://codeload.github.com/jsdom/webidl2js/tar.gz/33b4f5201b3e1a01afd09a29ba4c08712bd7982a"
+webidl2js@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/webidl2js/-/webidl2js-12.0.0.tgz#974b48f1fda5b24669a0ed4bdc4c9849ca2e81b9"
+  integrity sha512-81Dpw+91iCOIi81ygTUKrH5mHyueglfR0Z3DSiTtW9xDq8ZFrAnqb3ifXaiBBqE02YUlhpJBnblmE3njvTf2Og==
   dependencies:
     pn "^1.1.0"
     prettier "^1.19.1"


### PR DESCRIPTION
This implements one of the strategies discussed in https://github.com/jsdom/jsdom/issues/2727 for JS globals. Namely, it aliases to the Node.js globals for when runScripts is disabled, and ensures fresh copies from the VM are used when runScripts is set.

---

Some tests currently fail with this approach. So far I am debugging the FileAPI tests. Help would be appreciated though.