### PR TITLE
Revert `HTMLDocument` removal

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -249,7 +249,7 @@ function Window(options) {
     defaultView: this._globalProxy,
     global: this,
     parentOrigin: options.parentOrigin
-  }, { alwaysUseDocumentClass: true });
+  }, { alwaysUseDocumentClass: options.parsingMode === "xml" });
 
   if (vm.isContext(window)) {
     const documentImpl = idlUtils.implForWrapper(window._document);

--- a/lib/jsdom/living/documents.js
+++ b/lib/jsdom/living/documents.js
@@ -1,11 +1,15 @@
 "use strict";
+const HTMLDocument = require("../living/generated/HTMLDocument.js");
 const XMLDocument = require("../living/generated/XMLDocument.js");
 const Document = require("../living/generated/Document.js");
 const { wrapperForImpl } = require("./generated/utils.js");
 
 exports.createImpl = (globalObject, options, { alwaysUseDocumentClass = false } = {}) => {
-  if (options.parsingMode === "xml" && !alwaysUseDocumentClass) {
-    return XMLDocument.createImpl(globalObject, [], { options });
+  if (!alwaysUseDocumentClass) {
+    if (options.parsingMode === "xml") {
+      return XMLDocument.createImpl(globalObject, [], { options });
+    }
+    return HTMLDocument.createImpl(globalObject, [], { options });
   }
   return Document.createImpl(globalObject, [], { options });
 };

--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -23,6 +23,7 @@ const generatedInterfaces = {
   DocumentFragment: require("./generated/DocumentFragment"),
   DOMImplementation: require("./generated/DOMImplementation"),
   Document: require("./generated/Document"),
+  HTMLDocument: require("./generated/HTMLDocument"),
   XMLDocument: require("./generated/XMLDocument"),
   CharacterData: require("./generated/CharacterData"),
   Text: require("./generated/Text"),
@@ -188,23 +189,11 @@ const generatedInterfaces = {
   AbortSignal: require("./generated/AbortSignal")
 };
 
-function install(window, name, interfaceConstructor) {
-  Object.defineProperty(window, name, {
-    configurable: true,
-    writable: true,
-    value: interfaceConstructor
-  });
-}
-
 exports.installInterfaces = (window, globalNames) => {
   // Install generated interface.
   for (const generatedInterface of Object.values(generatedInterfaces)) {
     generatedInterface.install(window, globalNames);
   }
-
-  // Install legacy HTMLDocument interface
-  // https://html.spec.whatwg.org/#htmldocument
-  install(window, "HTMLDocument", window.Document);
 
   // These need to be cleaned up...
   style.addToCore(window);

--- a/lib/jsdom/living/nodes/DOMImplementation.webidl
+++ b/lib/jsdom/living/nodes/DOMImplementation.webidl
@@ -3,7 +3,7 @@
 interface DOMImplementation {
   [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
   [NewObject] XMLDocument createDocument(DOMString? namespace, [LegacyNullToEmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
-  [NewObject] Document createHTMLDocument(optional DOMString title);
+  [NewObject] HTMLDocument createHTMLDocument(optional DOMString title);
 
   boolean hasFeature(); // useless; always returns true
 };

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -916,6 +916,9 @@ class DocumentImpl extends NodeImpl {
         contentType: this.contentType,
         encoding: this._encoding,
         parsingMode: this._parsingMode
+      },
+      {
+        alwaysUseDocumentClass: Object.getPrototypeOf(this) === DocumentImpl.prototype
       }
     );
 

--- a/lib/jsdom/living/nodes/Document.webidl
+++ b/lib/jsdom/living/nodes/Document.webidl
@@ -50,7 +50,6 @@ enum DocumentReadyState { "loading", "interactive", "complete" };
 // We don't support SVGScriptElement yet
 // typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
 
-[LegacyOverrideBuiltins]
 partial interface Document {
   // resource metadata management
   [PutForwards=href, LegacyUnforgeable] readonly attribute Location? location;
@@ -61,7 +60,6 @@ partial interface Document {
   readonly attribute DocumentReadyState readyState;
 
   // DOM tree accessors
-//  getter object (DOMString name);
   [CEReactions] attribute DOMString title;
   [CEReactions] attribute DOMString dir;
   [CEReactions] attribute HTMLElement? body;

--- a/lib/jsdom/living/nodes/HTMLDocument-impl.js
+++ b/lib/jsdom/living/nodes/HTMLDocument-impl.js
@@ -1,0 +1,6 @@
+"use strict";
+const DocumentImpl = require("./Document-impl").implementation;
+
+exports.implementation = class HTMLDocumentImpl extends DocumentImpl {
+  // TODO: Implement named item getter
+};

--- a/lib/jsdom/living/nodes/HTMLDocument.webidl
+++ b/lib/jsdom/living/nodes/HTMLDocument.webidl
@@ -1,0 +1,7 @@
+// https://html.spec.whatwg.org/multipage/dom.html#htmldocument
+[Exposed=Window,
+ LegacyOverrideBuiltins]
+interface HTMLDocument : Document {
+  // DOM tree accessors
+//  getter object (DOMString name);
+};


### PR DESCRIPTION
Turns out, trying to make `HTMLDocument` an alias of `Document` [wasn’t](https://github.com/whatwg/html/issues/4792) [exactly](https://github.com/whatwg/dom/issues/221) [web‑compatible](https://github.com/whatwg/dom/issues/278).

The main reasons were the legacy `[LegacyOverrideBuiltins]` extended attribute and `document instanceof HTMLDocument` checks expecting to fail for `XMLDocument`.

## Depends on:
- [x] <https://github.com/jsdom/jsdom/pull/2753> (merged)
- [x] <https://github.com/jsdom/jsdom/pull/2841> (merged)

---

This PR implements <https://github.com/whatwg/html/pull/5104> and <https://github.com/whatwg/dom/pull/799>.

See also: <https://github.com/web-platform-tests/wpt/pull/20676>
