### PR TITLE
update web-platform-tests to the latest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/web-platform-tests/tests"]
 	path = test/web-platform-tests/tests
-	url = https://github.com/w3c/web-platform-tests.git
+	url = https://github.com/web-platform-tests/wpt.git

--- a/Changelog.md
+++ b/Changelog.md
@@ -257,7 +257,7 @@ Other changes:
 * Fixed one regression (since v11.6.0) in `<style>` elements, where their `sheet` property would sometimes be `null` when it should not be.
 * Fixed a case where a `<style>` element's `sheet` property would be left as a `CSSStyleSheet` despite it not being in the document.
 
-Another regression remains where we are emitting spurious CSS-parsing `jsdomError` events; see [#2123](https://github.com/tmpvar/jsdom/issues/2123). We also discovered a large amount of preexisting brokenness around `<style>`, `<link>`, and `@import`; see [#2124](https://github.com/tmpvar/jsdom/issues/2124) for more details.
+Another regression remains where we are emitting spurious CSS-parsing `jsdomError` events; see [#2123](https://github.com/jsdom/jsdom/issues/2123). We also discovered a large amount of preexisting brokenness around `<style>`, `<link>`, and `@import`; see [#2124](https://github.com/jsdom/jsdom/issues/2124) for more details.
 
 We'll try to fix these soon, especially the regression.
 
@@ -276,7 +276,7 @@ We'll try to fix these soon, especially the regression.
 * Fixed the firing of `popstate` and `hashchange` events during fragment navigation to make them trusted events.
 * Fixed `data:` URL parsing to not include the fragment portions.
 * Fixed all URL-accepting properties to properly perform [scalar value string conversion](https://infra.spec.whatwg.org/#javascript-string-convert) and URL resolution.
-* Fixed many other small edge-case conformance issues in the API surface of various web APIs; see [#2053](https://github.com/tmpvar/jsdom/pull/2053) and [#2081](https://github.com/tmpvar/jsdom/pull/2081) for more information.
+* Fixed many other small edge-case conformance issues in the API surface of various web APIs; see [#2053](https://github.com/jsdom/jsdom/pull/2053) and [#2081](https://github.com/jsdom/jsdom/pull/2081) for more information.
 * Fixed various APIs to use ASCII lowercasing, instead of Unicode lowercasing, for element and attribute names.
 * Fixed the encoding of a document created via `new Document()` to be UTF-8.
 * Fixed event handler properties behavior when given non-callable objects.
@@ -293,10 +293,10 @@ We'll try to fix these soon, especially the regression.
 
 ## 11.4.0
 
-For this release we'd like to welcome [@Zirro](https://github.com/tmpvar/jsdom/commits?author=Zirro) to the core team; his contributions over the course of this year have enhanced jsdom immensely.
+For this release we'd like to welcome [@Zirro](https://github.com/jsdom/jsdom/commits?author=Zirro) to the core team; his contributions over the course of this year have enhanced jsdom immensely.
 
 * Added a rudimentary set of SVG element classes, namely `SVGElement`, `SVGGraphicsElement`, `SVGSVGElement`, `SVGTests`, `SVGAnimatedString`, `SVGNumber`, and `SVGStringList`. The main impact here is that SVG elements are now instances of `SVGElement`, instead of being simply `Element` (as they were in v11.3.0) or `HTMLUnknownElement` (as they were in v11.2.0 and previously). The only concrete subclass that is implemented is `SVGSVGElement`, for `<svg>` itself; other tags will not map to their correct classes, because those classes are not yet implemented.
-* Added the new `pretendToBeVisual` option, which controls the presence of the new `requestAnimationFrame()` and `cancelAnimationFrame()` methods, and the new values of `document.hidden`/`document.visibilityState`. [See the README](https://github.com/tmpvar/jsdom#pretending-to-be-a-visual-browser) for more information. (SimenB)
+* Added the new `pretendToBeVisual` option, which controls the presence of the new `requestAnimationFrame()` and `cancelAnimationFrame()` methods, and the new values of `document.hidden`/`document.visibilityState`. [See the README](https://github.com/jsdom/jsdom#pretending-to-be-a-visual-browser) for more information. (SimenB)
 * Added the `append()` and `prepend()` methods to `Document`, `DocumentFragment`, and `Element`. (caub)
 * Added the `before()`, `after()`, and `replaceWith()` methods to `DocumentType`, `Element`, and `CharacterData`. (caub)
 * Added `node.isConnected`.
@@ -315,7 +315,7 @@ For this release we'd like to welcome [@Zirro](https://github.com/tmpvar/jsdom/c
 
 ## 11.3.0
 
-For this release we'd like to formally welcome [@TimothyGu](https://github.com/tmpvar/jsdom/commits?author=TimothyGu) to the core team, as a prolific contributor. He will join the illustrious ranks of those who do so much work on jsdom that we no longer note their names in the changelog.
+For this release we'd like to formally welcome [@TimothyGu](https://github.com/jsdom/jsdom/commits?author=TimothyGu) to the core team, as a prolific contributor. He will join the illustrious ranks of those who do so much work on jsdom that we no longer note their names in the changelog.
 
 * Added `table.tHead`, `table.tFoot`, and `table.caption` setters, and the `table.createTBody()` method.
 * Added `CompositionEvent` and `WheelEvent` classes.
@@ -346,7 +346,7 @@ This release brings with it a much-awaited infrastructure change, as part of [we
 * Added suport for `FileList` indexed properties, i.e. `fileList[i]`.
 * Made `select.options` an instance of the newly-implemented `HTMLOptionsCollection`, instead of just a `HTMLCollection`.
 
-This infrastructure will allow us to improve and implement many other similar behaviors; that work is being tracked in [#1129](https://github.com/tmpvar/jsdom/issues/1129).
+This infrastructure will allow us to improve and implement many other similar behaviors; that work is being tracked in [#1129](https://github.com/jsdom/jsdom/issues/1129).
 
 In addition to these improvements to the object model, we have more work to share:
 
@@ -607,7 +607,7 @@ This major release removes jsdom's support for mutation events. Mutation events 
 
 However, recent performance investigations revealed that mutation events were the major bottleneck in most jsdom operations; tools like [ecmarkup](https://github.com/bterlson/ecmarkup) which make heavy use of jsdom had their running time halved by removing mutation events, which add serious overhead to every DOM mutation. As such, we are doing a major release with them removed, so that jsdom users can benefit from this massive performance gain.
 
-Mutation observer support is [in progress](https://github.com/tmpvar/jsdom/issues/639); please use the GitHub reactions feature to vote on that issue if you are impacted by this removal and are hoping for mutation observer support to replace it.
+Mutation observer support is [in progress](https://github.com/jsdom/jsdom/issues/639); please use the GitHub reactions feature to vote on that issue if you are impacted by this removal and are hoping for mutation observer support to replace it.
 
 Your normal change log follows:
 
@@ -738,7 +738,7 @@ Although normally jsdom does not mark a new major release for changes that simpl
 ## 7.2.0
 
 * Added support for text selection APIs on `<input>` and `<textarea>`! (sjelin and yaycmyk)
-* Replaced our default XML parser with [sax](https://www.npmjs.com/package/sax), thus fixing many (but not all) issues with XML and XHTML parsing. To get a flavor of the issues fixed, check out these now-closed bugs: [#393](https://github.com/tmpvar/jsdom/issues/393), [#651](https://github.com/tmpvar/jsdom/issues/651), [#415](https://github.com/tmpvar/jsdom/issues/415), [#1276](https://github.com/tmpvar/jsdom/issues/1276).
+* Replaced our default XML parser with [sax](https://www.npmjs.com/package/sax), thus fixing many (but not all) issues with XML and XHTML parsing. To get a flavor of the issues fixed, check out these now-closed bugs: [#393](https://github.com/jsdom/jsdom/issues/393), [#651](https://github.com/jsdom/jsdom/issues/651), [#415](https://github.com/jsdom/jsdom/issues/415), [#1276](https://github.com/jsdom/jsdom/issues/1276).
 * Fixed the `<canvas>` tag to reset its contents when its width or height changed, including the change from the default 300 × 150 canvas. (Applies only when using the `canvas` npm package.)
 * Fixed an issue where `HTMLCollection`s would get confused when they contained elements with numeric `id`s or `name`s.
 * Fixed an issue with doctype parsing confusing the system ID and public ID.
@@ -856,7 +856,7 @@ This major release has as its headlining feature a completely re-written `XMLHtt
 
 This major release is focused on massive improvements in speed, URL parsing, and error handling. The potential breaking changes are highlighted in bold below; the largest ones are around the `jsdom.env` error-handling paradigm.
 
-This release also welcomes [long-time contributer](https://github.com/tmpvar/jsdom/commits/master?author=Joris-van-der-Wel) [@Joris-van-der-Wel](https://github.com/Joris-van-der-Wel/) to the core team. You may recognize him from earlier changelogs. We're very happy to have his help in making jsdom awesome!
+This release also welcomes [long-time contributer](https://github.com/jsdom/jsdom/commits/master?author=Joris-van-der-Wel) [@Joris-van-der-Wel](https://github.com/Joris-van-der-Wel/) to the core team. You may recognize him from earlier changelogs. We're very happy to have his help in making jsdom awesome!
 
 * **io.js 2.0 onward is now required**, as we have begun using ES2015 features only present there.
 * Improved performance dramatically, by ~10000x in some cases, due to the following changes:
@@ -865,7 +865,7 @@ This release also welcomes [long-time contributer](https://github.com/tmpvar/jsd
   - Sped up `node.compareDocumentPosition` and anything that used it (like `node.contains`) by doing more intelligent tree traversal instead of directly implementing the specced algorithm.
 * Overhauled how error handling works in jsdom:
   - `window.onerror` (or `window.addEventListener("error", ...)`) now work, and will catch all script errors, similar to in browsers. This also introduces the `ErrorEvent` class, incidentally.
-  - The virtual console is now the destination for several types of errors from jsdom, using [the new event `"jsdomError"`](https://github.com/tmpvar/jsdom#virtual-console-jsdomerror-error-reporting). This includes: errors loading external resources; script execution errors unhandled by `window.onerror`; and not-implemented warnings resulting from calling methods like `window.alert` which jsdom explicitly does not support.
+  - The virtual console is now the destination for several types of errors from jsdom, using [the new event `"jsdomError"`](https://github.com/jsdom/jsdom#virtual-console-jsdomerror-error-reporting). This includes: errors loading external resources; script execution errors unhandled by `window.onerror`; and not-implemented warnings resulting from calling methods like `window.alert` which jsdom explicitly does not support.
   - Since script errors are now handled by `window.onerror` and the virtual console, they are no longer included in the initialization process. This results in two changes to `jsdom.env` and the initialization lifecycle:
     + **The `load(errors, window)` callback was changed to `onload(window)`**, to reflect that it is now just sugar for setting a `window.onload` handler.
     + **The `done(errors, window)` callback (i.e., the default callback for `jsdom.env`) has become `done(error, window)`**, and like every other io.js callback now simply gives you a single error object, instead of an array of them.
@@ -881,7 +881,7 @@ This release also welcomes [long-time contributer](https://github.com/tmpvar/jsd
 * Fixed the `hashchange` event to correctly fire `HashChangeEvent` instances, with correct properties `newURL` and `oldURL` (instead of the incorrect `newUrl` and `oldUrl` used previously).
 * Removed usage of the setimmediate library, as it required `eval` and thus did not work in CSP scenarios.
 
-Finally, if you're a loyal jsdom fan whose made it this far into the changelog, I'd urge you to come join us in [#1139](https://github.com/tmpvar/jsdom/issues/1139), where we are brainstorming a modernized jsdom API that could get rid of many of the warts in the current one.
+Finally, if you're a loyal jsdom fan whose made it this far into the changelog, I'd urge you to come join us in [#1139](https://github.com/jsdom/jsdom/issues/1139), where we are brainstorming a modernized jsdom API that could get rid of many of the warts in the current one.
 
 ## 5.6.1
 
@@ -892,13 +892,13 @@ Finally, if you're a loyal jsdom fan whose made it this far into the changelog, 
 
 ## 5.6.0
 
-* `virtualConsole.sendTo` now returns `this`, allowing for [a nice shorthand](https://github.com/tmpvar/jsdom/tree/60ccb9b318d0bae8fe37e19af5af444b9c98ddac#forward-a-windows-console-output-to-the-iojs-console). (jeffcarp)
+* `virtualConsole.sendTo` now returns `this`, allowing for [a nice shorthand](https://github.com/jsdom/jsdom/tree/60ccb9b318d0bae8fe37e19af5af444b9c98ddac#forward-a-windows-console-output-to-the-iojs-console). (jeffcarp)
 
 ## 5.5.0
 
 * Added `postMessage` support, for communicating between parent windows, iframes, and combinations thereof. It's missing a few semantics, especially around origins, as well as MessageEvent source. Objects are not yet structured cloned, but instead passed by reference. But it's working, and awesome! (jeffcarp)
 * Rewrote cloning code (underlying `cloneNode` and `importNode`), fixing a number of issues:
-  - Elements with weird tag names, of the type that only the parser can normally create, can now be cloned ([#1142](https://github.com/tmpvar/jsdom/issues/1142))
+  - Elements with weird tag names, of the type that only the parser can normally create, can now be cloned ([#1142](https://github.com/jsdom/jsdom/issues/1142))
   - Doctypes can now be cloned, per the latest spec.
   - Attrs cannot be cloned, per the latest spec (although they still have a `cloneNode` method for now due to legacy).
   - Document clones now correctly copy over the URL and content-type.
@@ -907,7 +907,7 @@ Finally, if you're a loyal jsdom fan whose made it this far into the changelog, 
 * Fixed clicking on submit `<button>`s to submit their containing form; previously only `<input type="submit">` worked. (rxgx)
 * Fixed `document.open()` to return `this`, per spec. (ryanseddon)
 
-Additionally, Joris-van-der-Wel added [a benchmarking framework](https://github.com/tmpvar/jsdom/blob/master/Contributing.md#running-the-benchmarks), and a number of benchmarks, which should help us avoid performance regressions going forward, and also make targeted performance fixes. We're already investigating [some real-world issues](https://github.com/tmpvar/jsdom/issues/1156) using this framework. Very exciting!
+Additionally, Joris-van-der-Wel added [a benchmarking framework](https://github.com/jsdom/jsdom/blob/master/Contributing.md#running-the-benchmarks), and a number of benchmarks, which should help us avoid performance regressions going forward, and also make targeted performance fixes. We're already investigating [some real-world issues](https://github.com/jsdom/jsdom/issues/1156) using this framework. Very exciting!
 
 ## 5.4.3
 
@@ -926,7 +926,7 @@ Additionally, Joris-van-der-Wel added [a benchmarking framework](https://github.
 This is a pretty exciting release! It includes a couple features I never really anticipated jsdom being awesome enough to have, but our wonderful contributors powered through and made them happen anyway:
 
 * Added support for the default HTML stylesheet when using `window.getComputedStyle`! (akhaku)
-  - Notably, this makes jQuery's `show()` and `hide()` methods now work correctly; see [#994](https://github.com/tmpvar/jsdom/issues/994).
+  - Notably, this makes jQuery's `show()` and `hide()` methods now work correctly; see [#994](https://github.com/jsdom/jsdom/issues/994).
 * Added support for named properties on `window`: any elements with an `id` attribute, or certain elements with a `name` attribute, will cause properties to show up on the `window`, and thus as global variables within the jsdom. (Joris-van-der-Wel)
   - Although this is fairly unfortunate browser behavior, it's standardized and supported everywhere, so the fact that jsdom now supports this too means we can run a lot of scripts that would previously fail.
   - Previously, we only supported this for `<iframe>`s, and our implementation was quite buggy: e.g., `<iframe name="addEventListener">` would override `window.addEventListener`.
@@ -938,7 +938,7 @@ We also have a bunch more fixes and additions:
 * Updated `StyleSheetList` to inherit from `Array`, as per the latest CSSOM spec.
 * Overhauled the handling of attributes throughout the DOM, to follow the spec more exactly.
   - Our `NamedNodeMap` implementation is up to date, as are the various `Element` methods; other places in the code that deal with attributes now all go through a spec-compliant set of helpers.
-  - Some weirdnesses around the `style` attribute were fixed along the way; see e.g. [#1109](https://github.com/tmpvar/jsdom/issues/1109).
+  - Some weirdnesses around the `style` attribute were fixed along the way; see e.g. [#1109](https://github.com/jsdom/jsdom/issues/1109).
   - However, `Attr` objects themselves are not yet spec-compliant (e.g., they still inherit from `Node`). That's coming soon.
 * Fixed an unfortunate bug where `getElementById` would fail to work correctly on `<img>` elements whose `id` attributes were modified. (Joris-van-der-Wel)
 * Fixed the `virtualConsole` option to work with `jsdom.env`, not just `jsdom.jsdom`. (jeffcarp)
@@ -946,7 +946,7 @@ We also have a bunch more fixes and additions:
 
 ## 5.3.0
 
-* Added a `virtualConsole` option to the document creation methods, along with the `jsdom.createVirtualConsole` factory. (See [examples in the readme](https://github.com/tmpvar/jsdom/blob/dbf88666d1152576237ed1c741263f5516bb4005/README.md#capturing-console-output).) With this option you can install a virtual console before the document is even created, thus allowing you to catch any virtual console events that occur during initialization. (jeffcarp)
+* Added a `virtualConsole` option to the document creation methods, along with the `jsdom.createVirtualConsole` factory. (See [examples in the readme](https://github.com/jsdom/jsdom/blob/dbf88666d1152576237ed1c741263f5516bb4005/README.md#capturing-console-output).) With this option you can install a virtual console before the document is even created, thus allowing you to catch any virtual console events that occur during initialization. (jeffcarp)
 
 ## 5.2.0
 
@@ -990,7 +990,7 @@ In addition to these changes to the public API, the following new cookie-related
 * Implemented automatic cookie-jar sharing with descendant `<iframe>`s. (So, if the iframe is same-domain, it can automatically access the appropriate cookies.)
 * Let `options.document.cookie` accept arrays, instead of just strings, for if you want to set multiple cookies at once.
 
-Finally, it's worth noting that we now delegate our cookie handling in general to the [tough-cookie](https://www.npmjs.com/package/tough-cookie) package, which should hopefully mean that it now captures many of the behaviors that were previously missing (for example [#1027](https://github.com/tmpvar/jsdom/issues/1027)). @inikulin is working on [a large pull request to fix tough-cookie to be more spec compliant](https://github.com/goinstant/tough-cookie/pull/30), which should automatically be picked up by jsdom installs once it is merged.
+Finally, it's worth noting that we now delegate our cookie handling in general to the [tough-cookie](https://www.npmjs.com/package/tough-cookie) package, which should hopefully mean that it now captures many of the behaviors that were previously missing (for example [#1027](https://github.com/jsdom/jsdom/issues/1027)). @inikulin is working on [a large pull request to fix tough-cookie to be more spec compliant](https://github.com/goinstant/tough-cookie/pull/30), which should automatically be picked up by jsdom installs once it is merged.
 
 ## 4.5.1
 
@@ -1058,7 +1058,7 @@ _Note:_ this probably should have been a minor version number increment (i.e. 4.
 
 This release relies on the newly-overhauled `vm` module of io.js to eliminate the Contextify native module dependency. jsdom should now be much easier to use and install, without requiring a C++ compiler toolchain!
 
-Note that as of this release, jsdom no longer works with Node.js™, and instead requires io.js. You are still welcome to install a release in [the 3.x series](https://github.com/tmpvar/jsdom/tree/3.x) if you are stuck on legacy technology like Node.js™.
+Note that as of this release, jsdom no longer works with Node.js™, and instead requires io.js. You are still welcome to install a release in [the 3.x series](https://github.com/jsdom/jsdom/tree/3.x) if you are stuck on legacy technology like Node.js™.
 
 In the process of rewriting parts of jsdom to use `vm`, a number of related fixes were made regarding the `Window` object:
 
@@ -1077,11 +1077,11 @@ In the process of rewriting parts of jsdom to use `vm`, a number of related fixe
 
 * Updated `Node.prototype.isEqualNode` to the algorithm of the DOM Standard, fixing a bug where it would throw an error along the way.
 * Removed `Node.prototype.isSameNode`, which is not present in the DOM Standard (and was just a verbose `===` check anyway).
-* Fixed a couple small issues while browserifying, mainly around `jsdom.env`. However, while doing so discovered that `<script>`s in general don't work too well in a browserified jsdom; see [#1023](https://github.com/tmpvar/jsdom/issues/1023).
+* Fixed a couple small issues while browserifying, mainly around `jsdom.env`. However, while doing so discovered that `<script>`s in general don't work too well in a browserified jsdom; see [#1023](https://github.com/jsdom/jsdom/issues/1023).
 
 ## 3.1.0
 
-* Added support for [custom external resource loading](https://github.com/tmpvar/jsdom#custom-external-resource-loader). (tobie)
+* Added support for [custom external resource loading](https://github.com/jsdom/jsdom#custom-external-resource-loader). (tobie)
 
 ## 3.0.3
 
@@ -1104,7 +1104,7 @@ This release updates large swathes of the DOM APIs to conform to the standard, m
 3.0.x will be the last release of jsdom to support Node.js. All future releases (starting with 4.0.0) will require [io.js](https://iojs.org/), whose [new `vm` module](https://github.com/iojs/io.js/blob/v1.x/CHANGELOG.md#vm) will allow us to remove our contextify native-module dependency. (Given that I submitted the relevant patch to joyent/node [1.5 years ago](https://github.com/joyent/node/commit/7afdba6e0bc3b69c2bf5fdbd59f938ac8f7a64c5), I'm very excited that we can finally use it!)
 
 * By default documents now use `about:blank` as their URL, instead of trying to infer some type of file URL from the call site (in Node.js) or using `location.href` (in browsers).
-* Introduced a new "virtual console" abstraction for capturing console output from inside the page. [See the readme for more information.](https://github.com/tmpvar/jsdom#capturing-console-output) Note that `console.error` will no longer contribute to the (non-standard, and likely dying in the future) `window.errors` array. (jeffcarp)
+* Introduced a new "virtual console" abstraction for capturing console output from inside the page. [See the readme for more information.](https://github.com/jsdom/jsdom#capturing-console-output) Note that `console.error` will no longer contribute to the (non-standard, and likely dying in the future) `window.errors` array. (jeffcarp)
 * Added the named `new Image(width, height)` constructor. (vinothkr)
 * Fixed an exception when using `querySelector` with selectors like `div:last-child > span[title]`.
 * Removed all traces of entities, entity types, notations, default attributes, and CDATA sections.
@@ -1122,7 +1122,7 @@ This release updates large swathes of the DOM APIs to conform to the standard, m
 
 ## 2.0.0
 
-This release is largely a refactoring release to remove the defunct concept of "levels" from jsdom, in favor of the [living standard model](https://wiki.whatwg.org/wiki/FAQ#What_does_.22Living_Standard.22_mean.3F) that browsers follow. Although the code is still organized that way, that's now [noted as a historical artifact](https://github.com/tmpvar/jsdom/blob/2ff5747488ad4b518fcef97a026c82eab42a0a14/lib/README.md). The public API changes while doing so were fairly minimal, but this sets the stage for a cleaner jsdom code structure going forward.
+This release is largely a refactoring release to remove the defunct concept of "levels" from jsdom, in favor of the [living standard model](https://wiki.whatwg.org/wiki/FAQ#What_does_.22Living_Standard.22_mean.3F) that browsers follow. Although the code is still organized that way, that's now [noted as a historical artifact](https://github.com/jsdom/jsdom/blob/2ff5747488ad4b518fcef97a026c82eab42a0a14/lib/README.md). The public API changes while doing so were fairly minimal, but this sets the stage for a cleaner jsdom code structure going forward.
 
 * Removed: `jsdom.level`, and the `level` option from `jsdom.jsdom`.
 * Change: the nonstandard `Element.prototype.matchesSelector` method was replaced with the standard `Element.prototype.matches`. (KenPowers)
@@ -1130,7 +1130,7 @@ This release is largely a refactoring release to remove the defunct concept of "
 
 ## 1.5.0
 
-* Add: missing `window.console` methods, viz. `assert`, `clear`, `count`, `debug`, `group`, `groupCollapse`, `groupEnd`, `table`, `time`, `timeEnd`, and `trace`. All except `assert` do nothing for now, but see [#979](https://github.com/tmpvar/jsdom/issues/979) for future plans. (jeffcarp)
+* Add: missing `window.console` methods, viz. `assert`, `clear`, `count`, `debug`, `group`, `groupCollapse`, `groupEnd`, `table`, `time`, `timeEnd`, and `trace`. All except `assert` do nothing for now, but see [#979](https://github.com/jsdom/jsdom/issues/979) for future plans. (jeffcarp)
 * Tweak: make `childNodes`, and the many places in jsdom that use it, much faster. (Joris-van-der-Wel)
 
 ## 1.4.1
@@ -1203,7 +1203,7 @@ This release is largely a refactoring release to remove the defunct concept of "
 
 ## 1.0.0
 
-For a consolidated list of changes from 0.11.1 to 1.0.0, see [this wiki page](https://github.com/tmpvar/jsdom/wiki/Changes-from-0.11.1-to-1.0.0).
+For a consolidated list of changes from 0.11.1 to 1.0.0, see [this wiki page](https://github.com/jsdom/jsdom/wiki/Changes-from-0.11.1-to-1.0.0).
 
 * Remove: nonstandard `EventTarget.getListeners`; `EventTarget.forwardIterator`; `EventTarget.backwardIterator`; `EventTarget.singleIterator`.
 * Remove: nonstandard `document.innerHTML`. (jorendorff)
@@ -1239,16 +1239,16 @@ For a consolidated list of changes from 0.11.1 to 1.0.0, see [this wiki page](ht
 
 ## 1.0.0-pre.1
 
-This is a prerelease of jsdom's first major version. It incorporates several great additions, as well as a general cleanup of the API surface, which make it more backward-incompatible than usual. Starting with the 1.0.0 release, we will be following semantic versioning, so that you can depend on stability within major version ranges. But we still have [a few more issues](https://github.com/tmpvar/jsdom/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0) before we can get there, so I don't want to do 1.0.0 quite yet.
+This is a prerelease of jsdom's first major version. It incorporates several great additions, as well as a general cleanup of the API surface, which make it more backward-incompatible than usual. Starting with the 1.0.0 release, we will be following semantic versioning, so that you can depend on stability within major version ranges. But we still have [a few more issues](https://github.com/jsdom/jsdom/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0) before we can get there, so I don't want to do 1.0.0 quite yet.
 
 This release owes a special thanks to [@Sebmaster](https://github.com/Sebmaster), for his amazing work taking on some of the hardest problems in jsdom and solving them with gusto.
 
 ### Major changes
 
 * jsdom now can be browserified into a bundle that works in web workers! This is highly experimental, but also highly exciting! (lawnsea)
-* An overhaul of the [initialization lifecycle](https://github.com/tmpvar/jsdom#initialization-lifecycle), to bring more control and address common use cases. (Sebmaster)
+* An overhaul of the [initialization lifecycle](https://github.com/jsdom/jsdom#initialization-lifecycle), to bring more control and address common use cases. (Sebmaster)
 * The excellent [parse5](https://npmjs.org/package/parse5) HTML parser is now the default parser, fixing many parsing bugs and giving us full, official-test-suite-passing HTML parsing support. This especially impacts documents that didn't include optional tags like `<html>`, `<head>`, or `<body>` in their source. We also use parse5 for serialization, fixing many bugs there. (Sebmaster)
-* As part of the new parser story, we are not supporting XML for now. It might work if you switch to a different parser (e.g. htmlparser2), but in the end, HTML and XML are very different, and we are not attempting to be an XML DOM. That said, we eventually want to support XML to the same extent browsers do (i.e., support XHTML and SVG, with an appropriate MIME type switch); this is being planned in [#820](https://github.com/tmpvar/jsdom/issues/820).
+* As part of the new parser story, we are not supporting XML for now. It might work if you switch to a different parser (e.g. htmlparser2), but in the end, HTML and XML are very different, and we are not attempting to be an XML DOM. That said, we eventually want to support XML to the same extent browsers do (i.e., support XHTML and SVG, with an appropriate MIME type switch); this is being planned in [#820](https://github.com/jsdom/jsdom/issues/820).
 
 ### Removed jsdom APIs
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -40,7 +40,7 @@ Other specs might pop up from time to time, especially in regard to CSS stuff. I
 
 ### Running the tests
 
-First you'll want to run `yarn` to install all dependencies. Then, configure your system to run the web platform tests as described in [their README](https://github.com/web-platform-tests/wpt/blob/master/README.md). If you can't get that set up correctly, the test runner will make a best-faith effort to run the tests hosted on http://w3c-test.org/, but this is pretty slow and fragile.
+First you'll want to run `yarn` to install all dependencies. Then, configure your system to run the web platform tests as described in [their README](https://github.com/web-platform-tests/wpt/blob/master/README.md).
 
 **To run all the tests:** `yarn test`
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -16,9 +16,9 @@ In general, a web platform class (like `Window`, or `Node`, or `Location`, or `C
 
 As such, most web platform classes present in jsdom are implemented in two parts:
 
-- An IDL file, such as [`Attr.webidl`](https://github.com/tmpvar/jsdom/blob/master/lib/jsdom/living/attributes/Attr.webidl), drawn more or less straight from the spec
+- An IDL file, such as [`Attr.webidl`](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/living/attributes/Attr.webidl), drawn more or less straight from the spec
 
-- An implementation file, such as [`Attr-impl.js`](https://github.com/tmpvar/jsdom/blob/master/lib/jsdom/living/attributes/Attr-impl.js), containing the relevant implementation logic
+- An implementation file, such as [`Attr-impl.js`](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/living/attributes/Attr-impl.js), containing the relevant implementation logic
 
 Our build step (`yarn prepare`) then generates a public API file (e.g. `Attr.js`) which takes care of all the Web IDL-derived boilerplate, delegating to the implementation file for the important stuff. We then wire it together with a line in `lib/jsdom/living/index.js` that exposes the generated class on all jsdom windows.
 
@@ -40,7 +40,7 @@ Other specs might pop up from time to time, especially in regard to CSS stuff. I
 
 ### Running the tests
 
-First you'll want to run `yarn` to install all dependencies. Then, configure your system to run the web platform tests as described in [their README](https://github.com/w3c/web-platform-tests/blob/master/README.md). If you can't get that set up correctly, the test runner will make a best-faith effort to run the tests hosted on http://w3c-test.org/, but this is pretty slow and fragile.
+First you'll want to run `yarn` to install all dependencies. Then, configure your system to run the web platform tests as described in [their README](https://github.com/web-platform-tests/wpt/blob/master/README.md). If you can't get that set up correctly, the test runner will make a best-faith effort to run the tests hosted on http://w3c-test.org/, but this is pretty slow and fragile.
 
 **To run all the tests:** `yarn test`
 
@@ -50,9 +50,9 @@ In the following sections, we'll give commands for running a subset of the tests
 
 ### Web platform feature tests
 
-All tests for web platform features (as opposed to features of jsdom itself, such as the `JSDOM()` constructor) should be in [web-platform-tests](https://github.com/w3c/web-platform-tests) format. We have some infrastructure for running these directly against jsdom documents. So ideally, when contributing a bugfix or new feature, you can browse the web-platform-tests repository and find the test covering your work, and then just enable it in [the `to-run.yaml` file](https://github.com/tmpvar/jsdom/blob/master/test/web-platform-tests/to-run.yaml). These tests are HTML files which use a special library called [testharness.js](http://testthewebforward.org/docs/testharness-library.html) to report their results.
+All tests for web platform features (as opposed to features of jsdom itself, such as the `JSDOM()` constructor) should be in [web-platform-tests](https://github.com/web-platform-tests/wpt) format. We have some infrastructure for running these directly against jsdom documents. So ideally, when contributing a bugfix or new feature, you can browse the web-platform-tests repository and find the test covering your work, and then just enable it in [the `to-run.yaml` file](https://github.com/jsdom/jsdom/blob/master/test/web-platform-tests/to-run.yaml). These tests are HTML files which use a special library called [testharness.js](https://web-platform-tests.org/writing-tests/testharness-api.html) to report their results.
 
-However, the web-platform-tests project is not fully comprehensive. If you need to write your own test for a web platform feature, place it in our [to-upstream](https://github.com/tmpvar/jsdom/tree/master/test/web-platform-tests/to-upstream) directory. (It's so named because, over time, we hope to upstream these tests back to the web-platform-tests repository, so all browsers can benefit from them.) Note that you may need to create new directory structure, paralleling that of the main [web-platform-tests](https://github.com/w3c/web-platform-tests) repository.
+However, the web-platform-tests project is not fully comprehensive. If you need to write your own test for a web platform feature, place it in our [to-upstream](https://github.com/jsdom/jsdom/tree/master/test/web-platform-tests/to-upstream) directory. (It's so named because, over time, we hope to upstream these tests back to the web-platform-tests repository, so all browsers can benefit from them.) Note that you may need to create new directory structure, paralleling that of the main [web-platform-tests](https://github.com/web-platform-tests/wpt) repository.
 
 **To run all web-platform-tests:** `yarn test-wpt`
 
@@ -102,4 +102,4 @@ You can also run the benchmarks using the native DOM implementation of Chrome. A
 
 ## Issues
 
-If you've read this far, you should know everything there is to know about contributing to jsdom. We have [an active and full issue tracker](https://github.com/tmpvar/jsdom/issues) that we'd love you to help with. Go find something broken or missing, and fix it!
+If you've read this far, you should know everything there is to know about contributing to jsdom. We have [an active and full issue tracker](https://github.com/jsdom/jsdom/issues) that we'd love you to help with. Go find something broken or missing, and fix it!

--- a/benchmark/dom/inner-html.js
+++ b/benchmark/dom/inner-html.js
@@ -2,7 +2,7 @@
 const suite = require("../document-suite");
 
 // Based on the hard part of
-// https://github.com/w3c/web-platform-tests/blob/3b19057653a313f4ee7d6ff90c01456962d87d12/html/semantics/tabular-data/processing-model-1/span-limits.html
+// https://github.com/web-platform-tests/wpt/blob/3b19057653a313f4ee7d6ff90c01456962d87d12/html/semantics/tabular-data/processing-model-1/span-limits.html
 // which was noticed to be slow.
 
 exports.tables = suite(document => {

--- a/lib/jsdom/living/constraint-validation/ValidityState-impl.js
+++ b/lib/jsdom/living/constraint-validation/ValidityState-impl.js
@@ -52,7 +52,7 @@ exports.implementation = class ValidityStateImpl {
   _failsConstraint(method) {
     const validationMethod = this._state[method];
     if (validationMethod) {
-      return this._element.willValidate && validationMethod();
+      return validationMethod();
     }
 
     return false;

--- a/lib/jsdom/living/helpers/stylesheets.js
+++ b/lib/jsdom/living/helpers/stylesheets.js
@@ -81,7 +81,7 @@ function fetchStylesheetInternal(elementImpl, urlString, parsedURL) {
 }
 
 // TODO this is actually really messed up and overwrites the sheet on elementImpl
-// Tracking in https://github.com/tmpvar/jsdom/issues/2124
+// Tracking in https://github.com/jsdom/jsdom/issues/2124
 function scanForImportRules(elementImpl, cssRules, baseURL) {
   if (!cssRules) {
     return;

--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -22,7 +22,7 @@ module.exports = function (globalObject) {
     }
 
     // TODO: targetOrigin === '/' - requires reference to source window
-    // See https://github.com/tmpvar/jsdom/pull/1140#issuecomment-111587499
+    // See https://github.com/jsdom/jsdom/pull/1140#issuecomment-111587499
     if (targetOrigin !== "*" && targetOrigin !== this.location.origin) {
       return;
     }

--- a/lib/jsdom/living/websockets/WebSocket-impl.js
+++ b/lib/jsdom/living/websockets/WebSocket-impl.js
@@ -155,7 +155,7 @@ class WebSocketImpl extends EventTargetImpl {
           );
         }
       });
-      this._ws.on("error", () => {
+      this._ws.once("error", () => {
         // The exact error is passed into this callback, but it is ignored as we don't really care about it.
         resolve();
         this._requiredToFail = true;

--- a/test/LICENSE.md
+++ b/test/LICENSE.md
@@ -2,6 +2,6 @@
 
 All tests in the `to-port-to-wpts/{level1,level2,level3}` directories were written by the W3C. See: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html.
 
-All tests in the submodule in `web-platform-tests/tests` are from https://github.com/w3c/web-platform-tests. See that repository for its licensing details.
+All tests in the submodule in `web-platform-tests/tests` are from https://github.com/web-platform-tests/wpt. See that repository for its licensing details.
 
 All other folders in this directory follow the same license as `../LICENSE.txt`.

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -41,7 +41,7 @@ describe("API: runScripts constructor option", () => {
     });
 
     // In the browser, vm-shim uses Function() on the code to be evaluated, which inserts an extra first line. So we are
-    // always off by one there. See https://github.com/tmpvar/jsdom/issues/2004.
+    // always off by one there. See https://github.com/jsdom/jsdom/issues/2004.
     it("should execute <script>s with correct location when set to \"dangerously\" and " +
        "includeNodeLocations", { skipIfBrowser: true }, () => {
       const virtualConsole = new VirtualConsole();

--- a/test/to-port-to-wpts/level2/html.js
+++ b/test/to-port-to-wpts/level2/html.js
@@ -409,7 +409,7 @@ describe("level2/html", { skipIfBrowser: true }, () => {
     var doc = load("anchor3");
     var nodeList = doc.getElementsByTagName("a");
     assert.equal(nodeList.length, 1, 'Asize');
-    assert.equal(nodeList.item(0).pathname, '/tmpvar/jsdom', 'a.pathname absolute');
+    assert.equal(nodeList.item(0).pathname, '/jsdom/jsdom', 'a.pathname absolute');
   });
 
   /**

--- a/test/to-port-to-wpts/level2/html/files/anchor3.html
+++ b/test/to-port-to-wpts/level2/html/files/anchor3.html
@@ -7,7 +7,7 @@
 </HEAD>
 <BODY onload="parent.loadComplete()">
 <P>
-<A HREF="https://www.github.com/tmpvar/jsdom" TARGET="dynamic">View Submit Button</A>
+<A HREF="https://www.github.com/jsdom/jsdom" TARGET="dynamic">View Submit Button</A>
 </P>
 </BODY>
 </HTML>

--- a/test/to-port-to-wpts/level2/html/files/anchor4.html
+++ b/test/to-port-to-wpts/level2/html/files/anchor4.html
@@ -7,7 +7,7 @@
 </HEAD>
 <BODY onload="parent.loadComplete()">
 <P>
-<A HREF="http://www.github.com:3020/tmpvar/jsdom" TARGET="dynamic">View Submit Button</A>
+<A HREF="http://www.github.com:3020/jsdom/jsdom" TARGET="dynamic">View Submit Button</A>
 </P>
 </BODY>
 </HTML>

--- a/test/to-port-to-wpts/level2/html/files/anchor5.html
+++ b/test/to-port-to-wpts/level2/html/files/anchor5.html
@@ -7,7 +7,7 @@
 </HEAD>
 <BODY onload="parent.loadComplete()">
 <P>
-    <A HREF="http://www.github.com:3020/tmpvar/jsdom#fragment-identifier" TARGET="dynamic">View Submit Button</A>
+    <A HREF="http://www.github.com:3020/jsdom/jsdom#fragment-identifier" TARGET="dynamic">View Submit Button</A>
 </P>
 </BODY>
 </HTML>

--- a/test/to-port-to-wpts/level2/html/files/anchor6.html
+++ b/test/to-port-to-wpts/level2/html/files/anchor6.html
@@ -6,7 +6,7 @@
 </head>
 <body onload="parent.loadComplete()">
 <p>
-<a href="special://www.github.com/tmpvar/jsdom" target="dynamic">View Submit Button</a>
+<a href="special://www.github.com/jsdom/jsdom" target="dynamic">View Submit Button</a>
 </p>
 </body>
 </html>

--- a/test/to-port-to-wpts/level2/html/files/anchor7.html
+++ b/test/to-port-to-wpts/level2/html/files/anchor7.html
@@ -6,7 +6,7 @@
 </head>
 <body onload="parent.loadComplete()">
 <p>
-<a href="http://user:pa:ss@www.github.com:500/tmpvar/jsdom?testing=tested#hashed" target="dynamic">View Submit Button</a>
+<a href="http://user:pa:ss@www.github.com:500/jsdom/jsdom?testing=tested#hashed" target="dynamic">View Submit Button</a>
 </p>
 </body>
 </html>

--- a/test/to-port-to-wpts/level2/style.js
+++ b/test/to-port-to-wpts/level2/style.js
@@ -117,7 +117,7 @@ describe("level2/style", { skipIfBrowser: true }, () => {
   });
 
   specify("getComputedStyleFromDefaultStylesheet1", () => {
-    // browsers have default stylesheets, see https://github.com/tmpvar/jsdom/issues/994
+    // browsers have default stylesheets, see https://github.com/jsdom/jsdom/issues/994
     var { window } = new JSDOM("<html><head></head><body><div></div></body></html>");
     var div = window.document.getElementsByTagName("div")[0];
     var cs = window.getComputedStyle(div);
@@ -125,7 +125,7 @@ describe("level2/style", { skipIfBrowser: true }, () => {
   });
 
   specify("getComputedStyleFromDefaultStylesheet2", () => {
-    // browsers have default stylesheets, see https://github.com/tmpvar/jsdom/issues/994
+    // browsers have default stylesheets, see https://github.com/jsdom/jsdom/issues/994
     var { window } = new JSDOM("<html><head></head><body><ul></ul></body></html>");
     var ul = window.document.getElementsByTagName("ul")[0];
     var cs = window.getComputedStyle(ul);
@@ -172,7 +172,7 @@ describe("level2/style", { skipIfBrowser: true }, () => {
   });
 
   specify("getComputedStyleFromEmbeddedSheet3", () => {
-    // use grouping with embedded quotes and commas, see https://github.com/tmpvar/jsdom/pull/541#issuecomment-18114747
+    // use grouping with embedded quotes and commas, see https://github.com/jsdom/jsdom/pull/541#issuecomment-18114747
     const { window } = new JSDOM(`
         <html><head><style>#id1 .clazz, button[onclick="ga(this, event)"],
         #id2 .clazz { margin-left: 100px; }</style></head><body>
@@ -325,7 +325,7 @@ describe("level2/style", { skipIfBrowser: true }, () => {
   });
 
   specify("parseStyleWithBogusComment", () => {
-    // https://github.com/tmpvar/jsdom/issues/1214
+    // https://github.com/jsdom/jsdom/issues/1214
     const { window } = new JSDOM(`<style>.block-title .block-title-inner a:visited { color: #48484d; } // MAIN MENU - (used to keep mobile menu options hidden and keep weather/search and menu on one line) // #tncms-region-nav-main-nav-right-nav { float:left; }</style>`);
 
     // Should not hang forever

--- a/test/to-port-to-wpts/misc2.js
+++ b/test/to-port-to-wpts/misc2.js
@@ -383,7 +383,7 @@ describe("jsdom/miscellaneous", () => {
     assert.ok(dom.serialize().match(/0: *color/) === null);
   });
 
-  // see: https://github.com/tmpvar/jsdom/issues/262
+  // see: https://github.com/jsdom/jsdom/issues/262
   specify("issue_262", () => {
     const { document } = (new JSDOM()).window;
     const a = document.createElement("a");
@@ -392,7 +392,7 @@ describe("jsdom/miscellaneous", () => {
     assert.equal(a.outerHTML.match(/style="/g).length, 1, "style attribute must not be serialized twice");
   });
 
-  // see: https://github.com/tmpvar/jsdom/issues/267
+  // see: https://github.com/jsdom/jsdom/issues/267
   specify("issue_267", () => {
     const { document } = (new JSDOM()).window;
     const a = document.createElement("a");
@@ -404,7 +404,7 @@ describe("jsdom/miscellaneous", () => {
   // TODO this currently fails!?
   specify.skip("test_body_event_handler_inline", { skipIfBrowser: true, async: true }, t => {
     // currently skipped in browsers because of an issue:
-    // TODO: https://github.com/tmpvar/jsdom/issues/1379
+    // TODO: https://github.com/jsdom/jsdom/issues/1379
     const html = `
       <html>
         <head>

--- a/test/to-port-to-wpts/node-clone-node.js
+++ b/test/to-port-to-wpts/node-clone-node.js
@@ -12,7 +12,7 @@ describe("node-clone-node", () => {
   specify(
     "Should be able to clone elements with strange names containing colons",
     () => {
-      // https://github.com/tmpvar/jsdom/issues/1142#issuecomment-108122608
+      // https://github.com/jsdom/jsdom/issues/1142#issuecomment-108122608
       const doc = (new JSDOM("KSL.com <http://KSL.com> has not verified the accuracy of the information provided with")).window.document;
 
       // Parses as <http: ksl.com=""> has not verified ...</http:>
@@ -29,7 +29,7 @@ describe("node-clone-node", () => {
   specify(
     "Should be able to clone elements with strange names containing angle brackets",
     () => {
-      // https://github.com/tmpvar/jsdom/issues/1142#issuecomment-108122608
+      // https://github.com/jsdom/jsdom/issues/1142#issuecomment-108122608
       const html = "<p>Blah blah blah<p><Home-Schooling</b><p><p>In talking with parents who home-school";
       const doc = (new JSDOM(html)).window.document;
 

--- a/test/to-port-to-wpts/node-parent-element.js
+++ b/test/to-port-to-wpts/node-parent-element.js
@@ -5,7 +5,7 @@ const { describe, specify } = require("mocha-sugar-free");
 
 const load = require("../util.js").load(__dirname);
 
-// Tests adapted from https://github.com/w3c/web-platform-tests/blob/master/dom/nodes/Node-parentElement.html
+// Tests adapted from https://github.com/web-platform-tests/wpt/blob/master/dom/nodes/Node-parentElement.html
 // Spec: http://dom.spec.whatwg.org/#dom-node-parentelement
 
 describe("node-parent-element", { skipIfBrowser: true }, () => {

--- a/test/to-port-to-wpts/post-message.js
+++ b/test/to-port-to-wpts/post-message.js
@@ -127,7 +127,7 @@ describe("post-message", () => {
   specify("postMessage respects '/' targetOrigin option", () => {
     todo(assert, tt => {
       // This would require knowledge of the source window
-      // See: https://github.com/tmpvar/jsdom/pull/1140#issuecomment-111587499
+      // See: https://github.com/jsdom/jsdom/pull/1140#issuecomment-111587499
 
       const { window } = new JSDOM();
       const { document } = window;

--- a/test/to-port-to-wpts/xhr-file-urls.js
+++ b/test/to-port-to-wpts/xhr-file-urls.js
@@ -10,7 +10,7 @@ const toFileUrl = require("../util.js").toFileUrl(__dirname);
 
 describe("xhr-file-urls", { skipIfBrowser: true }, () => {
   specify("Getting a file URL should work (from the same file URL)", t => {
-    // From https://github.com/tmpvar/jsdom/pull/1180
+    // From https://github.com/jsdom/jsdom/pull/1180
     const { window } = new JSDOM(``, { url: toFileUrl(__filename) });
 
     const xhr = new window.XMLHttpRequest();
@@ -28,7 +28,7 @@ describe("xhr-file-urls", { skipIfBrowser: true }, () => {
   specify(
     "Getting a file URL should have valid default response without setting responseType",
     t => {
-      // From https://github.com/tmpvar/jsdom/pull/1183
+      // From https://github.com/jsdom/jsdom/pull/1183
       const { window } = new JSDOM(``, { url: toFileUrl(__filename) });
 
       const xhr = new window.XMLHttpRequest();
@@ -46,7 +46,7 @@ describe("xhr-file-urls", { skipIfBrowser: true }, () => {
   );
 
   specify("Getting a file URL should not throw for getResponseHeader", t => {
-    // From https://github.com/tmpvar/jsdom/pull/1180
+    // From https://github.com/jsdom/jsdom/pull/1180
     const { window } = new JSDOM(``, { url: toFileUrl(__filename) });
 
     const xhr = new window.XMLHttpRequest();
@@ -64,7 +64,7 @@ describe("xhr-file-urls", { skipIfBrowser: true }, () => {
   });
 
   specify("Getting a file URL should not throw for getAllResponseHeaders", t => {
-    // From https://github.com/tmpvar/jsdom/pull/1183
+    // From https://github.com/jsdom/jsdom/pull/1183
     const { window } = new JSDOM(``, { url: toFileUrl(__filename) });
 
     const xhr = new window.XMLHttpRequest();

--- a/test/to-port-to-wpts/xhr-requires-server.js
+++ b/test/to-port-to-wpts/xhr-requires-server.js
@@ -31,7 +31,7 @@ describe("xhr-requires-server", { skipIfBrowser: true }, () => {
   });
 
   specify("Getting a non-file URL should not fail for getAllResponseHeaders", t => {
-    // From https://github.com/tmpvar/jsdom/pull/1183
+    // From https://github.com/jsdom/jsdom/pull/1183
     const { window } = new JSDOM(``, { url: testHost + "/TestPath/get-headers" });
 
     const xhr = new window.XMLHttpRequest();

--- a/test/web-platform-tests/run-single-wpt.js
+++ b/test/web-platform-tests/run-single-wpt.js
@@ -113,7 +113,9 @@ function createJSDOM(urlPrefix, testPath, expectFail) {
               window.close();
             });
 
-            if (harnessStatus.status === 2) {
+            if (harnessStatus.status === harnessStatus.ERROR) {
+              errors.push(new Error(`test harness should not error: ${testPath}\n${harnessStatus.message}`));
+            } else if (harnessStatus.status === harnessStatus.TIMEOUT) {
               errors.push(new Error(`test harness should not timeout: ${testPath}`));
             }
 

--- a/test/web-platform-tests/run-single-wpt.js
+++ b/test/web-platform-tests/run-single-wpt.js
@@ -44,7 +44,7 @@ class CustomResourceLoader extends ResourceLoader {
       // When running to-upstream tests, the server doesn't have a /resources/ directory.
       // So, always go to the one in ./tests.
       // The path replacement accounts for a rewrite performed by the WPT server:
-      // https://github.com/w3c/web-platform-tests/blob/master/tools/serve/serve.py#L271
+      // https://github.com/web-platform-tests/wpt/blob/master/tools/serve/serve.py#L271
       const filePath = path.resolve(__dirname, "tests" + url.pathname)
         .replace("/resources/WebIDLParser.js", "/resources/webidl2/lib/webidl2.js");
 

--- a/test/web-platform-tests/start-wpt-server.js
+++ b/test/web-platform-tests/start-wpt-server.js
@@ -59,7 +59,7 @@ module.exports = ({ toUpstream = false } = {}) => {
     },
     () => {
       throw new Error("Host entries not present for web platform tests. See " +
-                      "https://github.com/w3c/web-platform-tests#running-the-tests");
+                      "https://github.com/web-platform-tests/wpt#running-the-tests");
     }
   ).then(([firstURL]) => firstURL);
 };

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -48,8 +48,11 @@ CaretPosition-001.html: [fail, Unknown]
 DOMRectList.html: [fail, Unknown]
 GetBoundingRect.html: [fail, Not implemented]
 HTMLBody-ScrollArea_quirksmode.html: [fail, Unknown]
-MediaQueryList-001.html: [fail, Unknown]
-MediaQueryList-with-empty-string.html: [fail, Unknown]
+MediaQueryList-addListener-handleEvent.html: [fail, Unknown]
+MediaQueryList-addListener-removeListener.html: [fail, Unknown]
+MediaQueryList-extends-EventTarget-interop.html: [fail, Unknown]
+MediaQueryList-extends-EventTarget.html: [fail, Unknown]
+MediaQueryListEvent.html: [fail, Unknown]
 cssom-getBoundingClientRect-002.html: [fail, Unknown]
 cssom-getBoxQuads-001.html: [fail, Not implemented]
 cssom-getClientRects-002.html: [fail, Unknown]
@@ -71,18 +74,19 @@ getClientRects**: [fail, Not implemented]
 idlharness.html: [fail, Depends on Fetch]
 inheritance.html: [fail, inherit not implemented (or not properly implemented)]
 matchMedia-display-none-iframe.html: [fail, Not implemented]
-matchMedia.xht: [timeout, Not implemented]
-matchMediaAddListener.html: [fail, Not implemented]
+matchMedia.html: [fail, Unknown]
 mouseEvent.html: [fail, Unknown]
 negativeMargins.html: [fail, Unknown]
 offsetParent_element_test.html: [fail, Unknown]
 offsetTopLeft-border-box.html: [fail, Unknown]
 offsetTopLeftInScrollableParent.html: [fail, Unknown]
 outer-svg.html: [fail, clientTop not implemented]
+parsing/scroll-behavior-computed.html: [fail, scroll-behavior not implemented]
 parsing/scroll-behavior-invalid.html: [fail, scroll-behavior not implemented]
 position-sticky-root-scroller-with-scroll-behavior.html: [fail, Unknown]
 scroll-**: [timeout, Scroll methods not implemented]
 scrollIntoView**: [fail, Scroll methods not implemented]
+scrollLeft-of-scroller-with-wider-scrollbar.html: [fail, Unknown]
 scrollWidthHeight.xht: [fail, Unknown]
 scrollWidthHeightWhenNotScrollable.xht: [fail, Unknown]
 scrolling-no-browsing-context.html: [fail, Unknown]
@@ -109,6 +113,7 @@ DIR: dom/collections
 DIR: dom/events
 
 Event-dispatch-on-disabled-elements.html: [timeout, Uses testdriver.js]
+Event-dispatch-redispatch.html: [fail, Unknown]
 Event-isTrusted.any.html: [fail, Unknown]
 Event-timestamp-high-resolution.html: [fail, Not implemented]
 EventListener-handleEvent.html: [fail, Unknown]
@@ -155,8 +160,10 @@ ParentNode-querySelector-All-xht.xht: [fail, ::slotted() pseudo-class is not sup
 ParentNode-querySelector-All.html: [fail, ::slotted() pseudo-class is not supported]
 ProcessingInstruction-escapes-1.xhtml: [fail, Unknown]
 Text-constructor.html: [fail, Unknown]
+adoption.window.html: [fail, "We do not implement https://github.com/whatwg/dom/pull/754 due to https://github.com/whatwg/dom/issues/813"]
+aria-attribute-reflection.tentative.html: [fail, Unknown]
 aria-element-reflection.tentative.html: [fail, WAI-ARIA not implemented]
-remove-and-adopt-crash.html: [fail, Unknown]
+remove-and-adopt-thcrash.html: [fail, window.open not implemented]
 
 ---
 
@@ -345,6 +352,7 @@ auxiliary-browsing-contexts/opener.html: [timeout, Unknown]
 browsing-context-names/**: [timeout, Not implemented]
 browsing-context.html: [fail, Unknown]
 document-access/**: [fail, Not implemented]
+document-domain-nested-navigate.window.html: [fail, Unknown]
 embedded-opener-a-form.html: [timeout, Opener not implemented]
 embedded-opener-remove-frame.html: [timeout, Opener not implemented]
 embedded-opener.html: [timeout, Opener not implemented]
@@ -362,8 +370,8 @@ targeting-with-embedded-null-in-target.html: [timeout, Unknown]
 DIR: html/dom/documents/dom-tree-accessors
 
 Document.currentScript.html: [timeout, Unknown]
-document.getElementsByName/document.getElementsByName-namespace-xhtml.xhtml: [fail, Needs MathML and SVG support]
-document.getElementsByName/document.getElementsByName-namespace.html: [fail, Needs MathML and SVG support]
+document.getElementsByName/document.getElementsByName-namespace-xhtml.xhtml: [fail, Needs MathML support]
+document.getElementsByName/document.getElementsByName-namespace.html: [fail, Needs MathML support]
 nameditem-01.html: [fail, Unknown]
 nameditem-02.html: [fail, Unknown]
 nameditem-04.html: [fail, Unknown]
@@ -434,6 +442,20 @@ sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html
 sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive.html: [fail, scrollIntoView() not implemented]
 sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero.html: [fail, scrollIntoView() not implemented]
 tabindex-focus-flag.html: [fail, contentEditable is not implemented; has dont-upstream version]
+the-autofocus-attribute/autofocus-on-stable-document.html: [fail, Not implemented]
+the-autofocus-attribute/first-reconnected.html: [fail, Not implemented]
+the-autofocus-attribute/first-when-later-but-before.html: [fail, Not implemented]
+the-autofocus-attribute/first-when-later.html: [fail, Not implemented]
+the-autofocus-attribute/first.html: [fail, Not implemented]
+the-autofocus-attribute/focusable-area-in-top-document.html: [fail, Not implemented]
+the-autofocus-attribute/queue-non-focusable.html: [fail, Not implemented]
+the-autofocus-attribute/same-origin-autofocus.html: [fail, Not implemented]
+the-autofocus-attribute/skip-another-top-level-browsing-context.html: [fail, Not implemented]
+the-autofocus-attribute/skip-document-with-fragment.html: [fail, Not implemented]
+the-autofocus-attribute/skip-non-focusable.html: [fail, Not implemented]
+the-autofocus-attribute/spin-by-blocking-style-sheet.html: [fail, Not implemented]
+the-autofocus-attribute/supported-elements.html: [fail, Not implemented]
+the-autofocus-attribute/update-the-rendering.html: [fail, Not implemented]
 
 ---
 
@@ -476,6 +498,7 @@ stylesheet-not-removed-until-next-stylesheet-loads.html: [fail, Unknown]
 
 DIR: html/semantics/document-metadata/the-style-element
 
+mutations.window.html: [fail, Unknown]
 style-error-01.html: [timeout, Unknown]
 style_disabled.html: [fail, Not implemented]
 style_events.html: [timeout, Unknown]
@@ -535,6 +558,9 @@ formaction.html: [fail, Unknown]
 
 DIR: html/semantics/forms/constraints
 
+form-validation-validity-stepMismatch.html: [fail, High precision modulo operation needed]
+infinite_backtracking.html: [timeout, We cannot restrict duration of regex matching from JavaScript]
+
 ---
 
 DIR: html/semantics/forms/form-control-infrastructure
@@ -551,7 +577,8 @@ DIR: html/semantics/forms/resetting-a-form
 
 DIR: html/semantics/forms/the-button-element
 
-button-activate.html: [fail, Unknown]
+button-activate.html: [fail, iframe onload needs to run after synchronous script]
+button-submit-children.html: [fail, We do not support form target yet]
 
 ---
 
@@ -659,6 +686,8 @@ toggleEvent.html: [fail, The ninth test requires a streaming HTML parser to pass
 
 DIR: html/semantics/interactive-elements/the-summary-element
 
+anchor-with-inline-element.html: [fail, SVGAElement needed for last two tests]
+
 ---
 
 DIR: html/semantics/links
@@ -681,6 +710,9 @@ async_002.htm: [timeout, Unknown]
 async_006.htm: [timeout, Unknown]
 async_009.htm: [timeout, Unknown]
 async_011.htm: [timeout, Unknown]
+css-module/css-module-worker-test.html: [fail, CSS modules and Worker not implemented]
+css-module/import-css-module-basic.html: [fail, not implemented]
+css-module/utf8.tentative.html: [timeout, not implemented]
 data-url.html: [timeout, Unknown]
 emptyish-script-elements.html: [fail, Unknown]
 execution-timing/005.html: [fail, Unknown]
@@ -789,6 +821,8 @@ script-type-and-language-js.html: [fail, Our script execution timing is off; see
 
 DIR: html/semantics/scripting-1/the-template-element
 
+template-element/template-content-hierarcy.html: [fail, "We do not implement https://github.com/whatwg/dom/pull/754 due to https://github.com/whatwg/dom/issues/813"]
+
 ---
 
 DIR: html/semantics/selectors
@@ -827,6 +861,7 @@ parsing-html-fragments/*: [timeout, Unknown]
 parsing/DOMContentLoaded-defer.html: [fail, Script execution timing]
 parsing/html-integration-point.html: [fail, Incorrect handling of encoded entity references inside <noframes> element]
 parsing/html5lib*: [timeout, Unknown]
+parsing/html_content_in_foreign_context.html: [fail, Parser issues with foreign elements]
 parsing/unclosed-svg-script.html: [fail, Unknown]
 serializing-html-fragments/serializing.html: [fail, https://github.com/inikulin/parse5/issues/289]
 
@@ -898,9 +933,13 @@ DocumentOrShadowRoot-prototype-elementFromPoint.html: [fail, offsetTop not imple
 Element-interface-attachShadow-custom-element.html: [fail, CustomElement.define is not implemented]
 MouseEvent-prototype-offsetX-offsetY.html: [fail, offsetTop not implemented]
 ShadowRoot-interface.html: [fail, shadowRoot.styleSheet is not yet implemented]
+focus/click-focus-delegatesFocus-tabindex-varies.html: [fail, element.scrollIntoView is not implemented]
+focus/click-focus-delegatesFocus-tabindex-zero.html: [fail, element.scrollIntoView is not implemented]
+focus/focus-method-delegatesFocus.html: [fail, delegatesFocus is not implemented]
 focus/focus-selector-delegatesFocus.html: [fail, 'https://github.com/dperini/nwsapi/issues/31']
 focus/focus-tabindex-order-*: [fail, Uses testdriver.js]
 form-control-form-attribute.html: [fail, Form association doesn't respect the spec]
+innerHTML-setter.xhtml: [fail, customElements is not implemented]
 leaktests/html-collection.html: [fail, Document.all is not implemented]
 leaktests/window-frames.html: [fail, Window.name is not implemeneted]
 offsetParent-across-shadow-boundaries.html: [fail, offsetParent not implemented]

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -32,13 +32,13 @@ client-hint-request-headers.htm: [fail-slow, Client Hints not implemented]
 cors-safelisted-request-header.any.html: [fail, Depends on fetch]
 credentials-flag.htm: [needs-node12, Unknown]
 image-tainting-in-cross-origin-iframe.sub.html: [timeout, Unknown]
-origin.htm: [timeout, https://github.com/tmpvar/jsdom/issues/1833]
+origin.htm: [timeout, https://github.com/jsdom/jsdom/issues/1833]
 preflight-cache.htm: [timeout, Cache should probably be implemented for simple requests before]
 redirect-preflight-2.htm: [fail, Preflight should also be done before redirected requests but request module redirects cannot be paused while doing preflight]
 remote-origin.htm: [timeout, postMessage event does not contain source]
-response-headers.htm: [timeout, I don't find a spec about combining same value response headers; also https://github.com/tmpvar/jsdom/issues/1833]
+response-headers.htm: [timeout, I don't find a spec about combining same value response headers; also https://github.com/jsdom/jsdom/issues/1833]
 simple-requests-ch.tentative.htm: [fail, Client Hints not implemented]
-simple-requests.htm: [timeout, Maybe https://github.com/tmpvar/jsdom/issues/1833 but it fails locally too]
+simple-requests.htm: [timeout, Maybe https://github.com/jsdom/jsdom/issues/1833 but it fails locally too]
 
 ---
 
@@ -815,7 +815,7 @@ script-onerror-insertion-point-1.html: [timeout, Unknown]
 script-onerror-insertion-point-2.html: [flaky]
 script-onload-insertion-point.html: [fail, Unknown]
 script-text-modifications.html: [fail, Unknown]
-script-type-and-language-js.html: [fail, Our script execution timing is off; see discussion in https://github.com/tmpvar/jsdom/pull/1406]
+script-type-and-language-js.html: [fail, Our script execution timing is off; see discussion in https://github.com/jsdom/jsdom/pull/1406]
 
 ---
 
@@ -869,7 +869,7 @@ serializing-html-fragments/serializing.html: [fail, https://github.com/inikulin/
 
 DIR: html/webappapis/animation-frames
 
-same-dispatch-time.html: [fail, Probably https://github.com/tmpvar/jsdom/pull/1994#discussion_r147567274]
+same-dispatch-time.html: [fail, Probably https://github.com/jsdom/jsdom/pull/1994#discussion_r147567274]
 
 ---
 
@@ -1018,7 +1018,7 @@ symbol-props.window.html: [fail, Unknown]
 
 DIR: xhr
 
-abort-after-stop.window.html: [fail, https://github.com/w3c/web-platform-tests/issues/6942]
+abort-after-stop.window.html: [fail, https://github.com/web-platform-tests/wpt/issues/6942]
 abort-during-loading.window.html: [fail, Unknown]
 access-control-basic-allow-preflight-cache.any.html: [fail, Unknown]
 access-control-basic-non-cors-safelisted-content-type.htm: [fail, Unknown]
@@ -1049,7 +1049,7 @@ open-during-abort-processing.htm: [fail, Unknown]
 open-method-case-sensitive.htm: [fail-slow, request module forces upper case]
 open-send-during-abort.htm: [fail, Unknown]
 open-url-encoding.htm: [fail, URL parser should use the encoding of the document - https://bugzilla.mozilla.org/show_bug.cgi?id=1405696]
-open-url-multi-window-4.htm: [timeout, https://github.com/w3c/web-platform-tests/issues/6941]
+open-url-multi-window-4.htm: [timeout, https://github.com/web-platform-tests/wpt/issues/6941]
 open-url-multi-window-5.htm: [timeout, location.reload is not implemented]
 open-url-multi-window-6.htm: [timeout, Unknown]
 open-url-redirected-sharedworker-origin.htm: [fail, Needs Shared Worker implementation]
@@ -1064,8 +1064,8 @@ responseXML-unavailable-in-worker.html: [fail, Needs Worker implementation]
 responsedocument-decoding.htm: [fail, Unknown]
 responsetext-decoding.htm: [fail, Unknown]
 responsetype.any.html: [timeout, Unknown]
-responsexml-document-properties.htm: [fail, https://github.com/w3c/web-platform-tests/issues/2668]
-responsexml-media-type.htm: [timeout, https://github.com/tmpvar/jsdom/issues/1833]
+responsexml-document-properties.htm: [fail, https://github.com/web-platform-tests/wpt/issues/2668]
+responsexml-media-type.htm: [timeout, https://github.com/jsdom/jsdom/issues/1833]
 send-after-setting-document-domain.htm: [timeout, document.domain not implemented]
 send-authentication-competing-names-passwords.htm: [fail-slow, Unknown]
 send-authentication-cors-setrequestheader-no-cred.htm: [fail, Unknown]
@@ -1073,7 +1073,7 @@ send-blob-with-no-mime-type.html: [fail, Unknown]
 send-conditional-cors.htm: [timeout, Unknown]
 send-content-type-charset.htm: [fail-slow, bad test because not-yet-updated spec https://github.com/whatwg/xhr/issues/188]
 send-data-readablestream.any.html: [fail, ReadableStream not implemented]
-send-entity-body-document.htm: [timeout, https://github.com/tmpvar/jsdom/issues/1833]
+send-entity-body-document.htm: [timeout, https://github.com/jsdom/jsdom/issues/1833]
 send-entity-body-empty.htm: [fail, hard to get Node to not send Content-Length]
 send-entity-body-get-head-async.htm: [fail, hard to get Node to not send Content-Length]
 send-entity-body-get-head.htm: [fail, hard to get Node to not send Content-Length]
@@ -1084,7 +1084,7 @@ send-redirect.htm: [fail, request module remove content-type header on redirect]
 send-response-event-order.htm: [fail, why no readystatechange for headers received? Test seems wrong maybe?]
 send-sync-response-event-order.htm: [fail-slow, not sure; sync is special]
 setrequestheader-content-type.htm: [fail-slow, we don't implement ReadableStream; also unsure we can get request() to send no content-type for ArrayBuffer]
-status-basic.htm: [timeout, https://github.com/tmpvar/jsdom/issues/1833]
+status-basic.htm: [timeout, https://github.com/jsdom/jsdom/issues/1833]
 sync-no-progress.any.html: [fail, Unknown]
 sync-xhr-supported-by-feature-policy.html: [fail, We don't support Feature Policy]
 xmlhttprequest-sync-default-feature-policy.sub.html: [timeout, We don't support Feature Policy]

--- a/test/web-platform-tests/to-upstream/XMLHttpRequest/abort-during-readystatechange.html
+++ b/test/web-platform-tests/to-upstream/XMLHttpRequest/abort-during-readystatechange.html
@@ -9,6 +9,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const xhr = new XMLHttpRequest();
 
 // In jsdom's implementation, this would cause a crash, as after firing readystatechange for HEADERS_RECEIVED, it would

--- a/test/web-platform-tests/to-upstream/dom/events/Event-stopImmediatePropagation.html
+++ b/test/web-platform-tests/to-upstream/dom/events/Event-stopImmediatePropagation.html
@@ -12,6 +12,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const target = document.querySelector("#target");
 
 let timesCalled = 0;

--- a/test/web-platform-tests/to-upstream/dom/nodes/Document-createCDATASection.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Document-createCDATASection.html
@@ -8,6 +8,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 assert_throws("NotSupportedError", () => document.createCDATASection("foo"));
 
 done();

--- a/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-querySelectorAll-after-modification.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-querySelectorAll-after-modification.html
@@ -8,6 +8,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const frag = document.createDocumentFragment();
 frag.appendChild(document.createElement("div"));
 

--- a/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-external-stylesheet-no-bc.sub.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-external-stylesheet-no-bc.sub.html
@@ -7,6 +7,9 @@
 
 <script>
 "use strict";
+
+setup({ single_test: true });
+
 const doc = document.implementation.createHTMLDocument();
 
 // Bug was only triggered by absolute URLs, for some reason...

--- a/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-svg.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-svg.html
@@ -3,7 +3,7 @@
 <title>Cloning of SVG elements and attributes</title>
 <link rel="help" href="https://dom.spec.whatwg.org/#dom-node-clonenode">
 <link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone">
-<!-- regression test for https://github.com/tmpvar/jsdom/issues/1601 -->
+<!-- regression test for https://github.com/jsdom/jsdom/issues/1601 -->
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelector-escapes.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelector-escapes.html
@@ -65,7 +65,6 @@ testMatched("outOfRange\u{fffd}", "#outOfRange\\555555");
 testMatched("outOfRange\u{fffd}", "#outOfRange\\ffffff");
 
 // - escape EOF
-testMatched("eof\u{fffd}", "#eof\\");
 testNeverMatched("eof\\", "#eof\\");
 
 // - escape anythong else

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-removed-elements.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-removed-elements.html
@@ -10,6 +10,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const container = document.querySelector("#container");
 function getIDs() {
   return [...container.querySelectorAll("a.test")].map(el => el.id);

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectors-exclusive.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectors-exclusive.html
@@ -8,6 +8,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const button = document.createElement("button");
 
 assert_equals(button.querySelector("*"), null, "querySelector, '*', before modification");

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectors-namespaces.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectors-namespaces.html
@@ -9,6 +9,9 @@
 
 <script>
 "use strict";
+
+setup({ single_test: true });
+
 const el = document.getElementById("thesvg");
 
 assert_equals(document.querySelector("[*|href]"), el);

--- a/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/non-parser-style.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/non-parser-style.html
@@ -13,6 +13,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const el = document.createElement("style");
 el.textContent = "p { color: rgb(1, 2, 3); }";
 document.head.appendChild(el);

--- a/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/sheet-with-empty-style.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/sheet-with-empty-style.html
@@ -13,6 +13,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 assert_not_equals(document.querySelector("style").sheet, null);
 assert_true(document.querySelector("style").sheet instanceof CSSStyleSheet);
 

--- a/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/with-spaces.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/with-spaces.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>Spaces inside style sheet properties should work fine</title>
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
-<!-- Regression test for https://github.com/tmpvar/jsdom/issues/2123 -->
+<!-- Regression test for https://github.com/jsdom/jsdom/issues/2123 -->
 
 <style>
 .cool-class {

--- a/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/with-spaces.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/with-spaces.html
@@ -20,6 +20,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const el = document.querySelector(".cool-class");
 assert_equals(window.getComputedStyle(el).fontFamily, `"Helvetica Neue", Helvetica, Arial, sans-serif`);
 

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-option-element/option-ask-for-a-reset.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-option-element/option-ask-for-a-reset.html
@@ -9,6 +9,8 @@
 <script>
 "use strict";
 
+setup({ single_test: true });
+
 const select = document.createElement("select");
 select.multiple = false;
 select.size = 1;

--- a/test/web-platform-tests/to-upstream/html/semantics/scripting-1/the-script-element/script-languages-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/scripting-1/the-script-element/script-languages-dont-upstream.html
@@ -7,7 +7,7 @@
 <div id="log"></div>
 
 <!-- this duplicates html/semantics/scripting-1/the-script-element/script-languages-02.html -->
-<!-- don't upstream this; see https://github.com/tmpvar/jsdom/pull/1406 -->
+<!-- don't upstream this; see https://github.com/jsdom/jsdom/pull/1406 -->
 
 <script>
 var interpretedScripts = {

--- a/test/web-platform-tests/to-upstream/html/semantics/tabular-data/the-td-element/class-hierarchy.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/tabular-data/the-td-element/class-hierarchy.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/tables.html#the-td-element">
 <link rel="author" title="Timothy Gu" href="mailto:timothygu99@gmail.com">
 <!-- This test is redundant with the changes in
-  https://github.com/w3c/web-platform-tests/commit/5b6aa3d108eeb306a326465e87447b53dee68a13
+  https://github.com/web-platform-tests/wpt/commit/5b6aa3d108eeb306a326465e87447b53dee68a13
   but since we can't run partial tests (yet), it's good to have here. -->
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/test/web-platform-tests/to-upstream/html/semantics/tabular-data/the-th-element/class-hierarchy.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/tabular-data/the-th-element/class-hierarchy.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/tables.html#the-th-element">
 <link rel="author" title="Timothy Gu" href="mailto:timothygu99@gmail.com">
 <!-- This test is redundant with the changes in
-  https://github.com/w3c/web-platform-tests/commit/5b6aa3d108eeb306a326465e87447b53dee68a13
+  https://github.com/web-platform-tests/wpt/commit/5b6aa3d108eeb306a326465e87447b53dee68a13
   but since we can't run partial tests (yet), it's good to have here. -->
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/test/web-platform-tests/wpt-manifest-utils.js
+++ b/test/web-platform-tests/wpt-manifest-utils.js
@@ -1,7 +1,7 @@
 "use strict";
 const fs = require("fs");
 
-const EXPECTED_MANIFEST_VERSION = 6;
+const EXPECTED_MANIFEST_VERSION = 7;
 
 exports.getPossibleTestFilePaths = manifest => {
   const testharnessTests = manifest.items.testharness;


### PR DESCRIPTION
Implementation of whatwg/dom#754 is delayed due to lingering issues with
the PR; see whatwg/dom#813.

Single-page to-upstream tests are updated to declare themselves as such;
per WPT RFC 28
(https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md).

Co-authored-by: @TimothyGu 