### PR TITLE
fix: Avoid reinstallation of already installed interfaces

### DIFF
--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -19,7 +19,6 @@ const generatedInterfaces = [
   require("./generated/Element"),
   require("./generated/DocumentFragment"),
   require("./generated/Document"),
-  require("./generated/Document"),
   require("./generated/XMLDocument"),
   require("./generated/CharacterData"),
   require("./generated/Text"),


### PR DESCRIPTION
Extracted&nbsp;from <https://github.com/jsdom/jsdom/pull/2744>.

This&nbsp;ensures that&nbsp;**JSDOM** won’t&nbsp;break from&nbsp;[jsdom/webidl2js#151](https://github.com/jsdom/webidl2js/pull/151).

---

review?(@domenic)