### PR TITLE
Remove no-longer-necessary workaround for DOMException

### DIFF
--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -189,13 +189,6 @@ function install(window, name, interfaceConstructor) {
 }
 
 exports.installInterfaces = function (window) {
-  // TODO: Fix me
-  Object.defineProperty(window, "Error", {
-    configurable: true,
-    writable: true,
-    value: Error
-  });
-
   // Install interface originated from packages.
   // TODO: update those packages webidl2js version to consume the install method.
   install(window, "URL", URL);


### PR DESCRIPTION
2b0dbc98bcffa738c676dc99d49d5716e5578422 was merged slightly prematurely as it contained a no-longer necessary workaround of installing Error manually before DOMException. In particular, 3a4fd6258e6b13e9cf8341ddba60a06b9b5c7b5b made it unnecessary.

---

I'll merge this if CI is happy; no serious review should be needed.