### PR TITLE
refactor: Use `constructor(…)` operation instead of extended attribute

### DIFF
--- a/lib/jsdom/living/aborting/AbortController.webidl
+++ b/lib/jsdom/living/aborting/AbortController.webidl
@@ -1,6 +1,8 @@
-[Constructor,
- Exposed=(Window,Worker)]
+// https://dom.spec.whatwg.org/#interface-abortcontroller
+[Exposed=(Window,Worker)]
 interface AbortController {
+  constructor();
+
   [SameObject] readonly attribute AbortSignal signal;
 
   void abort();

--- a/lib/jsdom/living/domparsing/DOMParser.webidl
+++ b/lib/jsdom/living/domparsing/DOMParser.webidl
@@ -1,13 +1,14 @@
-[Constructor,
-  Exposed=Window]
+// https://w3c.github.io/DOM-Parsing/#the-domparser-interface
+[Exposed=Window]
 interface DOMParser {
+  constructor();
   [NewObject] Document parseFromString(DOMString str, SupportedType type);
 };
 
 enum SupportedType {
-    "text/html",
-    "text/xml",
-    "application/xml",
-    "application/xhtml+xml",
-    "image/svg+xml"
+  "text/html",
+  "text/xml",
+  "application/xml",
+  "application/xhtml+xml",
+  "image/svg+xml"
 };

--- a/lib/jsdom/living/events/CloseEvent.webidl
+++ b/lib/jsdom/living/events/CloseEvent.webidl
@@ -1,5 +1,8 @@
-[Constructor(DOMString type, optional CloseEventInit eventInitDict), Exposed=(Window,Worker)]
+// https://html.spec.whatwg.org/multipage/web-sockets.html#the-closeevent-interface
+[Exposed=(Window,Worker)]
 interface CloseEvent : Event {
+  constructor(DOMString type, optional CloseEventInit eventInitDict);
+
   readonly attribute boolean wasClean;
   readonly attribute unsigned short code;
   readonly attribute USVString reason;

--- a/lib/jsdom/living/events/CompositionEvent.webidl
+++ b/lib/jsdom/living/events/CompositionEvent.webidl
@@ -1,6 +1,8 @@
 // https://w3c.github.io/uievents/#interface-compositionevent
-[Constructor(DOMString type, optional CompositionEventInit eventInitDict), Exposed=Window]
+[Exposed=Window]
 interface CompositionEvent : UIEvent {
+  constructor(DOMString type, optional CompositionEventInit eventInitDict = {});
+
   readonly attribute DOMString data;
 };
 

--- a/lib/jsdom/living/events/CustomEvent.webidl
+++ b/lib/jsdom/living/events/CustomEvent.webidl
@@ -1,6 +1,8 @@
-[Constructor(DOMString type, optional CustomEventInit eventInitDict),
- Exposed=(Window,Worker)]
+// https://dom.spec.whatwg.org/#interface-customevent
+[Exposed=(Window,Worker)]
 interface CustomEvent : Event {
+  constructor(DOMString type, optional CustomEventInit eventInitDict = {});
+
   readonly attribute any detail;
 
   void initCustomEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null);

--- a/lib/jsdom/living/events/ErrorEvent.webidl
+++ b/lib/jsdom/living/events/ErrorEvent.webidl
@@ -1,5 +1,8 @@
-[Constructor(DOMString type, optional ErrorEventInit eventInitDict), Exposed=(Window,Worker)]
+// https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface
+[Exposed=(Window,Worker)]
 interface ErrorEvent : Event {
+  constructor(DOMString type, optional ErrorEventInit eventInitDict = {});
+
   readonly attribute DOMString message;
   readonly attribute USVString filename;
   readonly attribute unsigned long lineno;

--- a/lib/jsdom/living/events/Event.webidl
+++ b/lib/jsdom/living/events/Event.webidl
@@ -1,6 +1,8 @@
-[Constructor(DOMString type, optional EventInit eventInitDict),
- Exposed=(Window,Worker,AudioWorklet)]
+// https://dom.spec.whatwg.org/#interface-event
+[Exposed=(Window,Worker,AudioWorklet)]
 interface Event {
+  constructor(DOMString type, optional EventInit eventInitDict = {});
+
   readonly attribute DOMString type;
   readonly attribute EventTarget? target;
   readonly attribute EventTarget? srcElement; // historical

--- a/lib/jsdom/living/events/EventTarget.webidl
+++ b/lib/jsdom/living/events/EventTarget.webidl
@@ -1,6 +1,8 @@
-[Constructor,
- Exposed=(Window,Worker,AudioWorklet)]
+// https://dom.spec.whatwg.org/#interface-eventtarget
+[Exposed=(Window,Worker,AudioWorklet)]
 interface EventTarget {
+  constructor();
+
   void addEventListener(DOMString type, EventListener? callback, optional (AddEventListenerOptions or boolean) options);
   void removeEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options);
   boolean dispatchEvent(Event event);

--- a/lib/jsdom/living/events/FocusEvent.webidl
+++ b/lib/jsdom/living/events/FocusEvent.webidl
@@ -1,8 +1,12 @@
-[Constructor(DOMString type, optional FocusEventInit eventInitDict), Exposed=Window]
+// https://w3c.github.io/uievents/#idl-focusevent
+[Exposed=Window]
 interface FocusEvent : UIEvent {
+  constructor(DOMString type, optional FocusEventInit eventInitDict = {});
+
   readonly attribute EventTarget? relatedTarget;
 };
 
+// https://w3c.github.io/uievents/#idl-focuseventinit
 dictionary FocusEventInit : UIEventInit {
   EventTarget? relatedTarget = null;
 };

--- a/lib/jsdom/living/events/HashChangeEvent.webidl
+++ b/lib/jsdom/living/events/HashChangeEvent.webidl
@@ -1,6 +1,7 @@
-[Exposed=Window,
- Constructor(DOMString type, optional HashChangeEventInit eventInitDict)]
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-hashchangeevent-interface
+[Exposed=Window]
 interface HashChangeEvent : Event {
+  constructor(DOMString type, optional HashChangeEventInit eventInitDict = {});
   readonly attribute USVString oldURL;
   readonly attribute USVString newURL;
 };

--- a/lib/jsdom/living/events/InputEvent.webidl
+++ b/lib/jsdom/living/events/InputEvent.webidl
@@ -1,9 +1,13 @@
-[Constructor(DOMString type, optional InputEventInit eventInitDict), Exposed=Window]
+// https://w3c.github.io/uievents/#idl-inputevent
+[Exposed=Window]
 interface InputEvent : UIEvent {
+  constructor(DOMString type, optional InputEventInit eventInitDict = {});
+
   readonly attribute DOMString? data;
   readonly attribute boolean isComposing;
 };
 
+// https://w3c.github.io/uievents/#idl-inputeventinit
 dictionary InputEventInit : UIEventInit {
   // The spec seems incorrect about data's default value - https://github.com/w3c/uievents/issues/139
   // DOMString? data = "";

--- a/lib/jsdom/living/events/KeyboardEvent.webidl
+++ b/lib/jsdom/living/events/KeyboardEvent.webidl
@@ -1,5 +1,8 @@
-[Constructor(DOMString type, optional KeyboardEventInit eventInitDict), Exposed=Window]
+// https://w3c.github.io/uievents/#idl-keyboardevent
+[Exposed=Window]
 interface KeyboardEvent : UIEvent {
+  constructor(DOMString type, optional KeyboardEventInit eventInitDict = {});
+
   // KeyLocationCode
   const unsigned long DOM_KEY_LOCATION_STANDARD = 0x00;
   const unsigned long DOM_KEY_LOCATION_LEFT = 0x01;
@@ -21,6 +24,7 @@ interface KeyboardEvent : UIEvent {
   boolean getModifierState(DOMString keyArg);
 };
 
+// https://w3c.github.io/uievents/#idl-keyboardeventinit
 dictionary KeyboardEventInit : EventModifierInit {
   DOMString key = "";
   DOMString code = "";
@@ -43,12 +47,14 @@ partial interface KeyboardEvent {
                          optional boolean metaKey = false);
 };
 
+// https://w3c.github.io/uievents/#legacy-interface-KeyboardEvent
 partial interface KeyboardEvent {
   // The following support legacy user agents
   readonly attribute unsigned long charCode;
   readonly attribute unsigned long keyCode;
 };
 
+// https://w3c.github.io/uievents/#legacy-dictionary-KeyboardEventInit
 partial dictionary KeyboardEventInit {
   // The following support legacy user agents
   unsigned long charCode = 0;

--- a/lib/jsdom/living/events/MessageEvent.webidl
+++ b/lib/jsdom/living/events/MessageEvent.webidl
@@ -1,5 +1,8 @@
-[Constructor(DOMString type, optional MessageEventInit eventInitDict), Exposed=(Window,Worker,AudioWorklet)]
+// https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interface
+[Exposed=(Window,Worker,AudioWorklet)]
 interface MessageEvent : Event {
+  constructor(DOMString type, optional MessageEventInit eventInitDict = {});
+
   readonly attribute any data;
   readonly attribute USVString origin;
   readonly attribute DOMString lastEventId;

--- a/lib/jsdom/living/events/MouseEvent.webidl
+++ b/lib/jsdom/living/events/MouseEvent.webidl
@@ -1,5 +1,8 @@
-[Constructor(DOMString type, optional MouseEventInit eventInitDict), Exposed=Window]
+// https://w3c.github.io/uievents/#idl-mouseevent
+[Exposed=Window]
 interface MouseEvent : UIEvent {
+  constructor(DOMString type, optional MouseEventInit eventInitDict = {});
+
   readonly attribute long screenX;
   readonly attribute long screenY;
   readonly attribute long clientX;
@@ -18,6 +21,7 @@ interface MouseEvent : UIEvent {
   boolean getModifierState(DOMString keyArg);
 };
 
+// https://w3c.github.io/uievents/#idl-mouseeventinit
 dictionary MouseEventInit : EventModifierInit {
   long screenX = 0;
   long screenY = 0;

--- a/lib/jsdom/living/events/PageTransitionEvent.webidl
+++ b/lib/jsdom/living/events/PageTransitionEvent.webidl
@@ -1,6 +1,7 @@
-[Exposed=Window,
- Constructor(DOMString type, optional PageTransitionEventInit eventInitDict)]
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-pagetransitionevent-interface
+[Exposed=Window]
 interface PageTransitionEvent : Event {
+  constructor(DOMString type, optional PageTransitionEventInit eventInitDict = {});
   readonly attribute boolean persisted;
 };
 

--- a/lib/jsdom/living/events/PopStateEvent.webidl
+++ b/lib/jsdom/living/events/PopStateEvent.webidl
@@ -1,6 +1,7 @@
-[Exposed=Window,
- Constructor(DOMString type, optional PopStateEventInit eventInitDict)]
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-popstateevent-interface
+[Exposed=Window]
 interface PopStateEvent : Event {
+  constructor(DOMString type, optional PopStateEventInit eventInitDict = {});
   readonly attribute any state;
 };
 

--- a/lib/jsdom/living/events/ProgressEvent.webidl
+++ b/lib/jsdom/living/events/ProgressEvent.webidl
@@ -1,6 +1,8 @@
-[Constructor(DOMString type, optional ProgressEventInit eventInitDict),
- Exposed=(Window,DedicatedWorker,SharedWorker)]
+// https://xhr.spec.whatwg.org/#interface-progressevent
+[Exposed=(Window,DedicatedWorker,SharedWorker)]
 interface ProgressEvent : Event {
+  constructor(DOMString type, optional ProgressEventInit eventInitDict = {});
+
   readonly attribute boolean lengthComputable;
   readonly attribute unsigned long long loaded;
   readonly attribute unsigned long long total;

--- a/lib/jsdom/living/events/StorageEvent.webidl
+++ b/lib/jsdom/living/events/StorageEvent.webidl
@@ -1,6 +1,7 @@
-[Exposed=Window,
- Constructor(DOMString type, optional StorageEventInit eventInitDict)]
+// https://html.spec.whatwg.org/multipage/webstorage.html#the-storageevent-interface
+[Exposed=Window]
 interface StorageEvent : Event {
+  constructor(DOMString type, optional StorageEventInit eventInitDict = {});
   readonly attribute DOMString? key;
   readonly attribute DOMString? oldValue;
   readonly attribute DOMString? newValue;

--- a/lib/jsdom/living/events/TouchEvent.webidl
+++ b/lib/jsdom/living/events/TouchEvent.webidl
@@ -1,12 +1,13 @@
+// https://w3c.github.io/touch-events/#touchevent-interface
 dictionary TouchEventInit : EventModifierInit {
     sequence<Touch> touches = [];
     sequence<Touch> targetTouches = [];
     sequence<Touch> changedTouches = [];
 };
 
-[Constructor(DOMString type, optional TouchEventInit eventInitDict),
- Exposed=Window]
+[Exposed=Window]
 interface TouchEvent : UIEvent {
+    constructor(DOMString type, optional TouchEventInit eventInitDict = {});
     readonly attribute TouchList touches;
     readonly attribute TouchList targetTouches;
     readonly attribute TouchList changedTouches;

--- a/lib/jsdom/living/events/UIEvent.webidl
+++ b/lib/jsdom/living/events/UIEvent.webidl
@@ -1,14 +1,18 @@
-[Constructor(DOMString type, optional UIEventInit eventInitDict), Exposed=Window]
+// https://w3c.github.io/uievents/#idl-uievent
+[Exposed=Window]
 interface UIEvent : Event {
+  constructor(DOMString type, optional UIEventInit eventInitDict = {});
   readonly attribute Window? view;
   readonly attribute long detail;
 };
 
+// https://w3c.github.io/uievents/#idl-uieventinit
 dictionary UIEventInit : EventInit {
   Window? view = null;
   long detail = 0;
 };
 
+// https://w3c.github.io/uievents/#event-modifier-initializers
 dictionary EventModifierInit : UIEventInit {
   boolean ctrlKey = false;
   boolean shiftKey = false;

--- a/lib/jsdom/living/events/WheelEvent.webidl
+++ b/lib/jsdom/living/events/WheelEvent.webidl
@@ -1,5 +1,8 @@
-[Constructor(DOMString type, optional WheelEventInit eventInitDict), Exposed=Window]
+// https://w3c.github.io/uievents/#idl-wheelevent
+[Exposed=Window]
 interface WheelEvent : MouseEvent {
+  constructor(DOMString type, optional WheelEventInit eventInitDict = {});
+
   // DeltaModeCode
   const unsigned long DOM_DELTA_PIXEL = 0x00;
   const unsigned long DOM_DELTA_LINE  = 0x01;
@@ -11,6 +14,7 @@ interface WheelEvent : MouseEvent {
   readonly attribute unsigned long deltaMode;
 };
 
+// https://w3c.github.io/uievents/#idl-wheeleventinit
 dictionary WheelEventInit : MouseEventInit {
   double deltaX = 0.0;
   double deltaY = 0.0;

--- a/lib/jsdom/living/fetch/Headers.webidl
+++ b/lib/jsdom/living/fetch/Headers.webidl
@@ -1,8 +1,10 @@
+// https://fetch.spec.whatwg.org/#headers-class
 typedef (sequence<sequence<ByteString>> or record<ByteString, ByteString>) HeadersInit;
 
-[Constructor(optional HeadersInit init),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface Headers {
+  constructor(optional HeadersInit init);
+
   void append(ByteString name, ByteString value);
   void delete(ByteString name);
   ByteString? get(ByteString name);

--- a/lib/jsdom/living/file-api/Blob.webidl
+++ b/lib/jsdom/living/file-api/Blob.webidl
@@ -1,7 +1,8 @@
-[Constructor(optional sequence<BlobPart> blobParts,
-             optional BlobPropertyBag options),
- Exposed=(Window,Worker), Serializable]
+[Exposed=(Window,Worker), Serializable]
 interface Blob {
+  constructor(optional sequence<BlobPart> blobParts,
+              optional BlobPropertyBag options = {});
+
 
   readonly attribute unsigned long long size;
   readonly attribute DOMString type;

--- a/lib/jsdom/living/file-api/File.webidl
+++ b/lib/jsdom/living/file-api/File.webidl
@@ -1,8 +1,9 @@
-[Constructor(sequence<BlobPart> fileBits,
-             USVString fileName,
-             optional FilePropertyBag options),
- Exposed=(Window,Worker), Serializable]
+// https://w3c.github.io/FileAPI/#file-section
+[Exposed=(Window,Worker), Serializable]
 interface File : Blob {
+  constructor(sequence<BlobPart> fileBits,
+              USVString fileName,
+              optional FilePropertyBag options = {});
   readonly attribute DOMString name;
   readonly attribute long long lastModified;
 };

--- a/lib/jsdom/living/file-api/FileReader.webidl
+++ b/lib/jsdom/living/file-api/FileReader.webidl
@@ -1,6 +1,7 @@
-[Constructor, Exposed=(Window,Worker)]
+// https://w3c.github.io/FileAPI/#APIASynch
+[Exposed=(Window,Worker)]
 interface FileReader: EventTarget {
-
+  constructor();
   // async read methods
   void readAsArrayBuffer(Blob blob);
   void readAsBinaryString(Blob blob);

--- a/lib/jsdom/living/mutation-observer/MutationObserver.webidl
+++ b/lib/jsdom/living/mutation-observer/MutationObserver.webidl
@@ -1,6 +1,8 @@
-[Constructor(MutationCallback callback),
- Exposed=Window]
+// https://dom.spec.whatwg.org/#interface-mutationobserver
+[Exposed=Window]
 interface MutationObserver {
+  constructor(MutationCallback callback);
+
   void observe(Node target, optional MutationObserverInit options);
   void disconnect();
   sequence<MutationRecord> takeRecords();

--- a/lib/jsdom/living/nodes/Comment.webidl
+++ b/lib/jsdom/living/nodes/Comment.webidl
@@ -1,4 +1,5 @@
-[Constructor(optional DOMString data = ""),
- Exposed=Window]
+// https://dom.spec.whatwg.org/#interface-comment
+[Exposed=Window]
 interface Comment : CharacterData {
+  constructor(optional DOMString data = "");
 };

--- a/lib/jsdom/living/nodes/Document.webidl
+++ b/lib/jsdom/living/nodes/Document.webidl
@@ -1,7 +1,8 @@
 // https://dom.spec.whatwg.org/#document
-[Constructor,
- Exposed=Window]
+[Exposed=Window]
 interface Document : Node {
+  constructor();
+
   [SameObject] readonly attribute DOMImplementation implementation;
   readonly attribute USVString URL;
   readonly attribute USVString documentURI;

--- a/lib/jsdom/living/nodes/DocumentFragment.webidl
+++ b/lib/jsdom/living/nodes/DocumentFragment.webidl
@@ -1,4 +1,5 @@
-[Constructor,
- Exposed=Window]
+// https://dom.spec.whatwg.org/#interface-documentfragment
+[Exposed=Window]
 interface DocumentFragment : Node {
+  constructor();
 };

--- a/lib/jsdom/living/nodes/Text.webidl
+++ b/lib/jsdom/living/nodes/Text.webidl
@@ -1,7 +1,8 @@
 // https://dom.spec.whatwg.org/#text
-[Constructor(optional DOMString data = ""),
- Exposed=Window]
+[Exposed=Window]
 interface Text : CharacterData {
+  constructor(optional DOMString data = "");
+
   [NewObject] Text splitText(unsigned long offset);
   readonly attribute DOMString wholeText;
 };

--- a/lib/jsdom/living/range/Range.webidl
+++ b/lib/jsdom/living/range/Range.webidl
@@ -1,7 +1,8 @@
 // https://dom.spec.whatwg.org/#range
-[Constructor,
- Exposed=Window]
+[Exposed=Window]
 interface Range : AbstractRange {
+  constructor();
+
   readonly attribute Node commonAncestorContainer;
 
   void setStart(Node node, unsigned long offset);

--- a/lib/jsdom/living/range/StaticRange.webidl
+++ b/lib/jsdom/living/range/StaticRange.webidl
@@ -1,3 +1,4 @@
+// https://dom.spec.whatwg.org/#interface-staticrange
 dictionary StaticRangeInit {
   required Node startContainer;
   required unsigned long startOffset;
@@ -5,5 +6,7 @@ dictionary StaticRangeInit {
   required unsigned long endOffset;
 };
 
-[Constructor(StaticRangeInit init), Exposed=Window]
-interface StaticRange : AbstractRange {};
+[Exposed=Window]
+interface StaticRange : AbstractRange {
+  constructor(StaticRangeInit init);
+};

--- a/lib/jsdom/living/websockets/WebSocket.webidl
+++ b/lib/jsdom/living/websockets/WebSocket.webidl
@@ -1,6 +1,8 @@
 enum BinaryType { "blob", "arraybuffer" };
-[Constructor(USVString url, optional (DOMString or sequence<DOMString>) protocols = []), Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface WebSocket : EventTarget {
+  constructor(USVString url, optional (DOMString or sequence<DOMString>) protocols = []);
+
   readonly attribute USVString url;
 
   // ready state

--- a/lib/jsdom/living/xhr/FormData.webidl
+++ b/lib/jsdom/living/xhr/FormData.webidl
@@ -1,8 +1,10 @@
+// https://xhr.spec.whatwg.org/#interface-formdata
 typedef (File or USVString) FormDataEntryValue;
 
-[Constructor(optional HTMLFormElement form),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface FormData {
+  constructor(optional HTMLFormElement form);
+
   void append(USVString name, USVString value);
   void append(USVString name, Blob value, optional USVString filename);
   void delete(USVString name);

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "st": "^2.0.0",
     "watchify": "^3.11.1",
     "wd": "^1.11.2",
-    "webidl2js": "^12.0.0"
+    "webidl2js": "https://github.com/jsdom/webidl2js.git#master"
   },
   "browser": {
     "canvas": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,10 +4854,9 @@ webidl2@^23.10.1:
   resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.10.1.tgz#2d2786fdff7b72c6b4a9a43e70f1611ded8ec8e6"
   integrity sha512-SK/KzMGgkPLN73HNqyU9tWPduireSzV6p/WAsmYYweI/ED19FC8+ymsi2InMX80+VjSvsfc3vA7UbMjXYWNPhA==
 
-webidl2js@^12.0.0:
+"webidl2js@https://github.com/jsdom/webidl2js.git#master":
   version "12.0.0"
-  resolved "https://registry.yarnpkg.com/webidl2js/-/webidl2js-12.0.0.tgz#974b48f1fda5b24669a0ed4bdc4c9849ca2e81b9"
-  integrity sha512-81Dpw+91iCOIi81ygTUKrH5mHyueglfR0Z3DSiTtW9xDq8ZFrAnqb3ifXaiBBqE02YUlhpJBnblmE3njvTf2Og==
+  resolved "https://github.com/jsdom/webidl2js.git#701f958b609c9571c95c47998fdaf4c2aee97a28"
   dependencies:
     pn "^1.1.0"
     prettier "^1.19.1"


### PR DESCRIPTION
As&nbsp;requested by&nbsp;@TimothyGu in&nbsp;[jsdom/webidl2js#153](https://github.com/jsdom/webidl2js/pull/153#issuecomment-569842489).