### PR TITLE
Update w3c-xmlserializer dependency

### DIFF
--- a/lib/jsdom/living/domparsing/XMLSerializer-impl.js
+++ b/lib/jsdom/living/domparsing/XMLSerializer-impl.js
@@ -1,0 +1,18 @@
+"use strict";
+const serialize = require("w3c-xmlserializer");
+const DOMException = require("domexception/webidl2js-wrapper");
+const utils = require("../generated/utils");
+
+exports.implementation = class XMLSerializerImpl {
+  constructor(globalObject) {
+    this._globalObject = globalObject;
+  }
+
+  serializeToString(root) {
+    try {
+      return serialize(utils.wrapperForImpl(root), { requireWellFormed: false });
+    } catch (e) {
+      throw DOMException.create(this._globalObject, [e.message, "InvalidStateError"]);
+    }
+  }
+};

--- a/lib/jsdom/living/domparsing/XMLSerializer.webidl
+++ b/lib/jsdom/living/domparsing/XMLSerializer.webidl
@@ -1,0 +1,6 @@
+// https://w3c.github.io/DOM-Parsing/#the-xmlserializer-interface
+[Constructor,
+ Exposed=Window]
+interface XMLSerializer {
+  DOMString serializeToString(Node root);
+};

--- a/lib/jsdom/living/domparsing/serialization.js
+++ b/lib/jsdom/living/domparsing/serialization.js
@@ -1,7 +1,8 @@
 "use strict";
 
-const { produceXMLSerialization } = require("w3c-xmlserializer");
+const produceXMLSerialization = require("w3c-xmlserializer");
 const parse5 = require("parse5");
+const DOMException = require("domexception/webidl2js-wrapper");
 
 const utils = require("../generated/utils");
 const treeAdapter = require("./parse5-adapter-serialization");
@@ -20,7 +21,7 @@ function htmlSerialization(node) {
   return parse5.serialize(node, { treeAdapter });
 }
 
-module.exports.fragmentSerialization = (node, { requireWellFormed }) => {
+module.exports.fragmentSerialization = (node, { requireWellFormed, globalObject }) => {
   const contextDocument =
     node.nodeType === NODE_TYPE.DOCUMENT_NODE ? node : node._ownerDocument;
   if (contextDocument._parsingMode === "html") {
@@ -28,12 +29,17 @@ module.exports.fragmentSerialization = (node, { requireWellFormed }) => {
   }
 
   const childNodes = node.childNodesForSerializing || node.childNodes;
-  let serialized = "";
-  for (let i = 0; i < childNodes.length; ++i) {
-    serialized += produceXMLSerialization(
-      utils.wrapperForImpl(childNodes[i] || childNodes.item(i)),
-      requireWellFormed
-    );
+
+  try {
+    let serialized = "";
+    for (let i = 0; i < childNodes.length; ++i) {
+      serialized += produceXMLSerialization(
+        utils.wrapperForImpl(childNodes[i] || childNodes.item(i)),
+        { requireWellFormed }
+      );
+    }
+    return serialized;
+  } catch (e) {
+    throw DOMException.create(globalObject, [e.message, "InvalidStateError"]);
   }
-  return serialized;
 };

--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const { URL, URLSearchParams } = require("whatwg-url");
-const XMLSerializer = require("w3c-xmlserializer/lib/XMLSerializer").interface;
 
 const registerElements = require("./register-elements");
 const style = require("../level2/style");
@@ -154,6 +153,7 @@ const generatedInterfaces = [
   require("./generated/ValidityState"),
 
   require("./generated/DOMParser"),
+  require("./generated/XMLSerializer"),
 
   require("./generated/FormData"),
   require("./generated/XMLHttpRequestEventTarget"),
@@ -193,7 +193,6 @@ exports.installInterfaces = function (window) {
   // TODO: update those packages webidl2js version to consume the install method.
   install(window, "URL", URL);
   install(window, "URLSearchParams", URLSearchParams);
-  install(window, "XMLSerializer", XMLSerializer);
 
   // Install generated interface.
   for (const generatedInterface of generatedInterfaces) {

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -149,7 +149,8 @@ class ElementImpl extends NodeImpl {
     // It's currently prevented by the fact that a node can't be duplicated in the same tree.
     // Then we could get rid of all the code for childNodesForSerializing.
     return fragmentSerialization({ childNodesForSerializing: [this], _ownerDocument: this._ownerDocument }, {
-      requireWellFormed: true
+      requireWellFormed: true,
+      globalObject: this._globalObject
     });
   }
   set outerHTML(markup) {
@@ -179,7 +180,10 @@ class ElementImpl extends NodeImpl {
 
   // https://w3c.github.io/DOM-Parsing/#dfn-innerhtml
   get innerHTML() {
-    return fragmentSerialization(this, { requireWellFormed: true });
+    return fragmentSerialization(this, {
+      requireWellFormed: true,
+      globalObject: this._globalObject
+    });
   }
   set innerHTML(markup) {
     const fragment = parseFragment(markup, this);

--- a/lib/jsdom/living/nodes/ShadowRoot-impl.js
+++ b/lib/jsdom/living/nodes/ShadowRoot-impl.js
@@ -34,7 +34,10 @@ class ShadowRootImpl extends DocumentFragment {
 
   // https://w3c.github.io/DOM-Parsing/#dfn-innerhtml
   get innerHTML() {
-    return fragmentSerialization(this, { requireWellFormed: true });
+    return fragmentSerialization(this, {
+      requireWellFormed: true,
+      globalObject: this._globalObject
+    });
   }
   set innerHTML(markup) {
     const fragment = parseFragment(markup, this._host);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "symbol-tree": "^3.2.2",
     "tough-cookie": "^3.0.1",
     "w3c-hr-time": "^1.0.1",
-    "w3c-xmlserializer": "^1.1.2",
+    "w3c-xmlserializer": "^2.0.0",
     "webidl-conversions": "^5.0.0",
     "whatwg-encoding": "^1.0.5",
     "whatwg-mimetype": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,13 +1305,6 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
   integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
-domexception@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
-  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
-  dependencies:
-    webidl-conversions "^4.0.2"
-
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -4804,13 +4797,11 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-w3c-xmlserializer@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz#30485ca7d70a6fd052420a3d12fd90e6339ce794"
-  integrity sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==
+w3c-xmlserializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
+  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
-    domexception "^1.0.1"
-    webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
 
 watchify@^3.11.1:


### PR DESCRIPTION
This updates to the latest version of w3c-xmlserializer, which no longer contains a generated XMLSerializer class, but just a serialize function. Instead, we now wrap that package's serialize function as appropriate. This allows us to properly generate an XMLSerializer constructor per jsdom Window, in line with other recent constructor and prototype reform.

---

Note to self: do not merge until we merge and publish https://github.com/jsdom/w3c-xmlserializer/pull/21 and update the package.json and yarn.lock in this PR.