### PR TITLE
Bump minimum supported Node.js version and test v12 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 8
   - 10
+  - 12
   - stable
 
 before_install:
@@ -20,7 +20,7 @@ branches:
 
 matrix:
   include:
-    - node_js: 8
+    - node_js: 10
       env: TEST_SUITE=node-canvas
       addons:
         apt:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 jsdom is a pure-JavaScript implementation of many web standards, notably the WHATWG [DOM](https://dom.spec.whatwg.org/) and [HTML](https://html.spec.whatwg.org/multipage/) Standards, for use with Node.js. In general, the goal of the project is to emulate enough of a subset of a web browser to be useful for testing and scraping real-world web applications.
 
-The latest versions of jsdom require Node.js v8 or newer. (Versions of jsdom below v12 still work with Node.js v6, but are unsupported.)
+The latest versions of jsdom require Node.js v10 or newer. (Versions of jsdom below v16 still work with previous Node.js versions, but are unsupported.)
 
 ## Basic usage
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
   },
   "main": "./lib/api.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
Closes #2730.

---

It turns out that this is no longer forced if we merge #2768 instead of #2731. But, it still seems like a good idea, since we've got a lot of breaking changes coming anyway, and Node v8 is end of life.