### PR TITLE
fix(Window): Avoid re‑assigning `module.exports`

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -33,7 +33,7 @@ class JSDOM {
 
     options = transformOptions(options, encoding, mimeType);
 
-    this[window] = new Window(options.windowOptions);
+    this[window] = Window.createWindow(options.windowOptions);
 
     const documentImpl = idlUtils.implForWrapper(this[window]._document);
 

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -23,6 +23,7 @@ const Performance = require("../living/generated/Performance");
 const Screen = require("../living/generated/Screen");
 const Storage = require("../living/generated/Storage");
 const Selection = require("../living/generated/Selection");
+const { installInterfaces } = require("../living/interfaces");
 const reportException = require("../living/helpers/runtime-script-errors");
 const { fireAnEvent } = require("../living/helpers/events");
 const SessionHistory = require("../living/window/SessionHistory");
@@ -33,10 +34,15 @@ const jsGlobals = require("./js-globals.json");
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
 
-// NB: the require() must be after assigning `module.exports` because this require() is circular
-// TODO: this above note might not even be true anymore... figure out the cycle and document it, or clean up.
-module.exports = Window;
-const { installInterfaces } = require("../living/interfaces");
+// We can't re-assign `module.exports`, as there's the following cycle:
+// /lib/jsdom/browser/Window
+// -> /lib/jsdom/living/interfaces
+// -> /lib/jsdom/living/generated/HTMLFrameElement
+// -> /lib/jsdom/living/nodes/HTMLFrameElement-impl
+// -> /lib/jsdom/browser/Window
+exports.createWindow = function (options) {
+  return new Window(options);
+};
 
 // https://html.spec.whatwg.org/#the-window-object
 function setupWindow(windowInstance, { runScripts }) {

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -126,7 +126,7 @@ function loadFrame(frame, attaching) {
   }
   const serializedURL = serializeURL(url);
 
-  const wnd = new Window({
+  const wnd = Window.createWindow({
     parsingMode: "html",
     url: url.scheme === "javascript" || serializedURL === "about:blank" ? parentDoc.URL : serializedURL,
     resourceLoader: parentDoc._defaultView._resourceLoader,


### PR DESCRIPTION
This&nbsp;also&nbsp;allows us&nbsp;to&nbsp;move the&nbsp;`require("../living/interfaces")`&nbsp;call to&nbsp;the&nbsp;top.

Note&nbsp;that this&nbsp;will once&nbsp;again cause&nbsp;issues once&nbsp;**Window** is&nbsp;converted to&nbsp;**WebIDL** unless&nbsp;<https://github.com/jsdom/webidl2js/pull/154> is&nbsp;merged&nbsp;first.

---

Extracted&nbsp;from&nbsp;<https://github.com/jsdom/jsdom/pull/2548>.

---

review?(@pmdartus, @TimothyGu)