### PR TITLE
Fix incorrect DocumentFragment constructor

### DIFF
--- a/lib/jsdom/living/nodes/DocumentFragment-impl.js
+++ b/lib/jsdom/living/nodes/DocumentFragment-impl.js
@@ -5,10 +5,14 @@ const NODE_TYPE = require("../node-type");
 const NodeImpl = require("./Node-impl").implementation;
 const NonElementParentNodeImpl = require("./NonElementParentNode-impl").implementation;
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
+const idUtils = require("../generated/utils");
 
 class DocumentFragmentImpl extends NodeImpl {
   constructor(globalObject, args, privateData) {
-    super(globalObject, args, privateData);
+    super(globalObject, args, {
+      ownerDocument: idUtils.implForWrapper(globalObject._document),
+      ...privateData
+    });
 
     const { host } = privateData;
     this._host = host;

--- a/lib/jsdom/living/nodes/DocumentFragment-impl.js
+++ b/lib/jsdom/living/nodes/DocumentFragment-impl.js
@@ -5,12 +5,12 @@ const NODE_TYPE = require("../node-type");
 const NodeImpl = require("./Node-impl").implementation;
 const NonElementParentNodeImpl = require("./NonElementParentNode-impl").implementation;
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
-const idUtils = require("../generated/utils");
+const idlUtils = require("../generated/utils");
 
 class DocumentFragmentImpl extends NodeImpl {
   constructor(globalObject, args, privateData) {
     super(globalObject, args, {
-      ownerDocument: idUtils.implForWrapper(globalObject._document),
+      ownerDocument: idlUtils.implForWrapper(globalObject._document),
       ...privateData
     });
 

--- a/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-constructor.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/DocumentFragment-constructor.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DocumentFragment constructor</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-documentfragment-documentfragment">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const fragment = new DocumentFragment();
+  assert_equals(fragment.ownerDocument, document);
+}, "Sets the owner document to the current global object associated document");
+
+test(() => {
+  const fragment = new DocumentFragment();
+  const text = document.createTextNode("");
+  fragment.appendChild(text);
+  assert_equals(fragment.firstChild, text);
+}, "Create a valid document DocumentFragment");
+</script>


### PR DESCRIPTION
Fix DocumentFragment constructor by setting the ownerDocument associated with the current global object.
Fixes #2274.