### PR TITLE
Add live collection tests

### DIFF
--- a/test/web-platform-tests/to-upstream/dom/nodes/HTMLCollection-live-mutations.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/HTMLCollection-live-mutations.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTMLCollection live mutations</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#ref-for-concept-collection-live">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+function testHTMLCollection(name, hooks) {
+  test(() => {
+    const nodes = {
+      root: document.createElement("div"),
+      div1: document.createElement("div"),
+      div2: document.createElement("div"),
+      p: document.createElement("p")
+    };
+
+    nodes.div1.id = "div1";
+    nodes.div2.id = "div2";
+
+    const list = nodes.root.getElementsByTagName("div");
+
+    hooks.initial(list, nodes);
+
+    nodes.root.appendChild(nodes.div1);
+    nodes.root.appendChild(nodes.p);
+    nodes.root.appendChild(nodes.div2);
+
+    hooks.afterInsertion(list, nodes);
+
+    nodes.root.removeChild(nodes.div1);
+
+    hooks.afterRemoval(list, nodes);
+  }, `HTMLCollection live mutations: ${name}`);
+}
+
+testHTMLCollection("HTMLCollection.length", {
+  initial(list) {
+    assert_equals(list.length, 0);
+  },
+  afterInsertion(list) {
+    assert_equals(list.length, 2);
+  },
+  afterRemoval(list) {
+    assert_equals(list.length, 1);
+  }
+});
+
+testHTMLCollection("HTMLCollection.item(index)", {
+  initial(list) {
+    assert_equals(list.item(0), null);
+  },
+  afterInsertion(list, nodes) {
+    assert_equals(list.item(0), nodes.div1);
+    assert_equals(list.item(1), nodes.div2);
+  },
+  afterRemoval(list, nodes) {
+    assert_equals(list.item(0), nodes.div2);
+  }
+});
+
+testHTMLCollection("HTMLCollection[index]", {
+  initial(list) {
+    assert_equals(list[0], undefined);
+  },
+  afterInsertion(list, nodes) {
+    assert_equals(list[0], nodes.div1);
+    assert_equals(list[1], nodes.div2);
+  },
+  afterRemoval(list, nodes) {
+    assert_equals(list[0], nodes.div2);
+  }
+});
+
+testHTMLCollection("HTMLCollection.namedItem(index)", {
+  initial(list) {
+    assert_equals(list.namedItem("div1"), null);
+    assert_equals(list.namedItem("div2"), null);
+  },
+  afterInsertion(list, nodes) {
+    assert_equals(list.namedItem("div1"), nodes.div1);
+    assert_equals(list.namedItem("div2"), nodes.div2);
+  },
+  afterRemoval(list, nodes) {
+    assert_equals(list.namedItem("div1"), null);
+    assert_equals(list.namedItem("div2"), nodes.div2);
+  }
+});
+
+testHTMLCollection("HTMLCollection ownPropertyNames", {
+  initial(list) {
+    assert_object_equals(Object.getOwnPropertyNames(list), []);
+  },
+  afterInsertion(list) {
+    assert_object_equals(Object.getOwnPropertyNames(list), ["0", "1", "div1", "div2"]);
+  },
+  afterRemoval(list) {
+    assert_object_equals(Object.getOwnPropertyNames(list), ["0", "div2"]);
+  }
+});
+</script>

--- a/test/web-platform-tests/to-upstream/dom/nodes/NodeList-live-mutations.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/NodeList-live-mutations.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>NodeList live mutations</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#ref-for-concept-collection-live">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+function testNodeList(name, hooks) {
+  test(() => {
+    const nodes = {
+      root: document.createElement("div"),
+      div1: document.createElement("div"),
+      div2: document.createElement("div"),
+      p: document.createElement("p")
+    };
+
+    const list = nodes.root.childNodes;
+
+    hooks.initial(list, nodes);
+
+    nodes.root.appendChild(nodes.div1);
+    nodes.root.appendChild(nodes.p);
+    nodes.root.appendChild(nodes.div2);
+
+    hooks.afterInsertion(list, nodes);
+
+    nodes.root.removeChild(nodes.div1);
+
+    hooks.afterRemoval(list, nodes);
+  }, `NodeList live mutations: ${name}`);
+}
+
+testNodeList("NodeList.length", {
+  initial(list) {
+    assert_equals(list.length, 0);
+  },
+  afterInsertion(list) {
+    assert_equals(list.length, 3);
+  },
+  afterRemoval(list) {
+    assert_equals(list.length, 2);
+  }
+});
+
+testNodeList("NodeList.item(index)", {
+  initial(list) {
+    assert_equals(list.item(0), null);
+  },
+  afterInsertion(list, nodes) {
+    assert_equals(list.item(0), nodes.div1);
+    assert_equals(list.item(1), nodes.p);
+    assert_equals(list.item(2), nodes.div2);
+  },
+  afterRemoval(list, nodes) {
+    assert_equals(list.item(0), nodes.p);
+    assert_equals(list.item(1), nodes.div2);
+  }
+});
+
+testNodeList("NodeList[index]", {
+  initial(list) {
+    assert_equals(list[0], undefined);
+  },
+  afterInsertion(list, nodes) {
+    assert_equals(list[0], nodes.div1);
+    assert_equals(list[1], nodes.p);
+    assert_equals(list[2], nodes.div2);
+  },
+  afterRemoval(list, nodes) {
+    assert_equals(list[0], nodes.p);
+    assert_equals(list[1], nodes.div2);
+  }
+});
+
+testNodeList("NodeList ownPropertyNames", {
+  initial(list) {
+    assert_object_equals(Object.getOwnPropertyNames(list), []);
+  },
+  afterInsertion(list) {
+    assert_object_equals(Object.getOwnPropertyNames(list), ["0", "1", "2"]);
+  },
+  afterRemoval(list) {
+    assert_object_equals(Object.getOwnPropertyNames(list), ["0", "1"]);
+  }
+});
+</script>


### PR DESCRIPTION
Add tests for live `NodeList` and `HTMLCollection` to ensure that the collections are always in sync when the DOM gets updated.
Fixes #77.