### PR TITLE
test(wpt): Improve “expected fail” message and “needs‑node*” code

### DIFF
--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -56,7 +56,7 @@ describe("web-platform-tests", () => {
           const reason = matchingPattern && toRunDoc[matchingPattern][0];
           const shouldSkip = ["fail-slow", "timeout", "flaky", "mutates-globals"].includes(reason) ||
                              (["fail-with-canvas", "needs-canvas"].includes(reason) && !hasCanvas);
-          const needsNodeVersion = reason.startsWith("needs-node") ?
+          const needsNodeVersion = typeof reason === "string" && reason.startsWith("needs-node") ?
             Number(reason.substring(10 /* "needs-node".length */)) :
             null;
           const expectFail = (reason === "fail") ||

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -18,7 +18,6 @@ const validReasons = new Set([
   "needs-node10",
   "needs-node11",
   "needs-node12",
-  "needs-node13",
   "needs-canvas"
 ]);
 
@@ -26,7 +25,6 @@ const nodeMajor = Number(process.versions.node.split(".")[0]);
 const hasNode10 = nodeMajor >= 10;
 const hasNode11 = nodeMajor >= 11;
 const hasNode12 = nodeMajor >= 12;
-const hasNode13 = nodeMajor >= 13;
 const hasCanvas = Boolean(Canvas);
 
 const manifestFilename = path.resolve(__dirname, "wpt-manifest.json");
@@ -67,17 +65,14 @@ describe("web-platform-tests", () => {
                              (reason === "fail-with-canvas" && hasCanvas) ||
                              (reason === "needs-node10" && !hasNode10) ||
                              (reason === "needs-node11" && !hasNode11) ||
-                             (reason === "needs-node12" && !hasNode12) ||
-                             (reason === "needs-node13" && !hasNode13);
+                             (reason === "needs-node12" && !hasNode12);
 
           if (matchingPattern && shouldSkip) {
             specify.skip(`[${reason}] ${testFile}`);
           } else if (expectFail) {
             let failReason = "";
-            if (reason.startsWith("needs-node")) {
+            if (reason !== "fail") {
               failReason = `: ${reason}`;
-            } else if (reason === "fail-with-canvas") {
-              failReason = ": canvas bug";
             }
             runSingleWPT(testFilePath, `[expected fail${failReason}] ${testFile}`, expectFail);
           } else {

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -58,16 +58,16 @@ describe("web-platform-tests", () => {
                              (["fail-with-canvas", "needs-canvas"].includes(reason) && !hasCanvas);
           const needsNodeVersion = reason.startsWith("needs-node") ?
             Number(reason.substring(10 /* "needs-node".length */)) :
-            false;
+            null;
           const expectFail = (reason === "fail") ||
                              (reason === "fail-with-canvas" && hasCanvas) ||
-                             (needsNodeVersion !== false && nodeMajor < needsNodeVersion);
+                             (needsNodeVersion !== null && nodeMajor < needsNodeVersion);
 
           if (matchingPattern && shouldSkip) {
             specify.skip(`[${reason}] ${testFile}`);
           } else if (expectFail) {
             let failReason = "";
-            if (needsNodeVersion !== false) {
+            if (needsNodeVersion !== null) {
               failReason = `: ${reason}`;
             } else if (reason === "fail-with-canvas") {
               failReason = ": canvas bug";

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -70,11 +70,13 @@ describe("web-platform-tests", () => {
           if (matchingPattern && shouldSkip) {
             specify.skip(`[${reason}] ${testFile}`);
           } else if (expectFail) {
-            let failReason = "";
-            if (reason !== "fail") {
-              failReason = `: ${reason}`;
-            }
-            runSingleWPT(testFilePath, `[expected fail${failReason}] ${testFile}`, expectFail);
+            runSingleWPT(
+              testFilePath,
+              `[expected fail${
+                reason !== "fail" ? `: ${reason}` : ""
+              }] ${testFile}`,
+              expectFail
+            );
           } else {
             runSingleWPT(testFilePath, testFile, expectFail);
           }

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -70,13 +70,8 @@ describe("web-platform-tests", () => {
           if (matchingPattern && shouldSkip) {
             specify.skip(`[${reason}] ${testFile}`);
           } else if (expectFail) {
-            runSingleWPT(
-              testFilePath,
-              `[expected fail${
-                reason !== "fail" ? `: ${reason}` : ""
-              }] ${testFile}`,
-              expectFail
-            );
+            const failReason = reason !== "fail" ? `: ${reason}` : "";
+            runSingleWPT(testFilePath, `[expected fail${failReason}] ${testFile}`, expectFail);
           } else {
             runSingleWPT(testFilePath, testFile, expectFail);
           }


### PR DESCRIPTION
Currently, each&nbsp;**Node.js**&nbsp;version needs&nbsp;to&nbsp;have its&nbsp;own&nbsp;`needs‑node*`&nbsp;reason added&nbsp;to&nbsp;`run‑wpts.js`.

This&nbsp;is&nbsp;problematic, as&nbsp;the&nbsp;code currently&nbsp;performs the&nbsp;`Number(process.versions.node.split(".")[0])`&nbsp;conversion for&nbsp;every&nbsp;supported&nbsp;`needs‑node*`&nbsp;entry, and&nbsp;each&nbsp;`needs‑node*`&nbsp;entry has&nbsp;to&nbsp;be&nbsp;manually&nbsp;added.

This&nbsp;simplifies&nbsp;that to&nbsp;only&nbsp;need to&nbsp;perform that&nbsp;conversion&nbsp;once.

I’ve&nbsp;also&nbsp;added a&nbsp;fail&nbsp;reason to&nbsp;<code>[expected&nbsp;fail]</code> when&nbsp;the&nbsp;reason is&nbsp;`needs‑node*` or&nbsp;`fail‑with‑canvas`.