### PR TITLE
Fix Node v10 and Node v11 support

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -37,6 +37,8 @@ const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-imp
 module.exports = Window;
 const { installInterfaces } = require("../living/interfaces");
 
+const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in global);
+
 // https://html.spec.whatwg.org/#the-window-object
 function setupWindow(windowInstance, { runScripts }) {
   if (runScripts === "outside-only" || runScripts === "dangerously") {
@@ -44,14 +46,14 @@ function setupWindow(windowInstance, { runScripts }) {
 
     // Without this, these globals will only appear to scripts running inside the context using vm.runScript; they will
     // not appear to scripts running from the outside, including to JSDOM implementation code.
-    for (const [globalName, globalPropDesc] of Object.entries(jsGlobals)) {
+    for (const [globalName, globalPropDesc] of jsGlobalEntriesToInstall) {
       const propDesc = { ...globalPropDesc, value: vm.runInContext(globalName, windowInstance) };
       Object.defineProperty(windowInstance, globalName, propDesc);
     }
   } else {
     // Without contextifying the window, none of the globals will exist. So, let's at least alias them from the Node.js
     // context. See https://github.com/jsdom/jsdom/issues/2727 for more background and discussion.
-    for (const [globalName, globalPropDesc] of Object.entries(jsGlobals)) {
+    for (const [globalName, globalPropDesc] of jsGlobalEntriesToInstall) {
       const propDesc = { ...globalPropDesc, value: global[globalName] };
       Object.defineProperty(windowInstance, globalName, propDesc);
     }


### PR DESCRIPTION
Closes #2795.

I manually tested this (using nvm). I'm not sure it's worth testing on CI, but if we wanted to I think something like this (not tested) could work:

```yaml
    - node_js: stable
      ENV: TEST_SUITE=downlevel
      script:
        - nvm use 10
        - yarn test-api
```