### PR TITLE
Remove mutates-globals test failure reason

### DIFF
--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -14,7 +14,6 @@ const validReasons = new Set([
   "fail-with-canvas",
   "timeout",
   "flaky",
-  "mutates-globals",
   "needs-node10",
   "needs-node11",
   "needs-node12",
@@ -59,7 +58,7 @@ describe("web-platform-tests", () => {
 
           const testFile = testFilePath.slice((toRunDoc.DIR + "/").length);
           const reason = matchingPattern && toRunDoc[matchingPattern][0];
-          const shouldSkip = ["fail-slow", "timeout", "flaky", "mutates-globals"].includes(reason) ||
+          const shouldSkip = ["fail-slow", "timeout", "flaky"].includes(reason) ||
                              (["fail-with-canvas", "needs-canvas"].includes(reason) && !hasCanvas);
           const expectFail = (reason === "fail") ||
                              (reason === "fail-with-canvas" && hasCanvas) ||

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -985,7 +985,6 @@ Create-Secure-extensions-empty.any.html: [timeout, Buggy test as the test does n
 Create-on-worker-shutdown.any.html: [fail, Needs Worker implementation]
 cookies/006.html?wss: [fail, Unknown]
 cookies/third-party-cookie-accepted.https.html: [fail, 'https://github.com/salesforce/tough-cookie/issues/80']
-interfaces/WebSocket/close/close-basic.html*: [mutates-globals]
 interfaces/WebSocket/close/close-connecting.html*: [fail, Potentially buggy test as Chrome fails it too]
 remove-own-iframe-during-onerror.window.html: [timeout, iframe.srcdoc not implemented]
 stream-tentative/*: [timeout, Not implemented]


### PR DESCRIPTION
The `mutates-global` failure reason is not needed anymore after the release of the constructor and prototype reform.