### PR TITLE
Fix syntax error which halts execution

### DIFF
--- a/lib/jsdom/living/helpers/dates-and-times.js
+++ b/lib/jsdom/living/helpers/dates-and-times.js
@@ -232,7 +232,7 @@ function isDate(obj) {
   try {
     Date.prototype.valueOf.call(obj);
     return true;
-  } catch {
+  } catch(e) {
     return false;
   }
 }


### PR DESCRIPTION
fix the following syntax error:
```
.../jsdom/lib/jsdom/living/helpers/dates-and-times.js:235
  } catch {
          ^

SyntaxError: Unexpected token {
```