### PR TITLE
Fix catch syntax error in date-and-times.js

### DIFF
--- a/lib/jsdom/living/helpers/dates-and-times.js
+++ b/lib/jsdom/living/helpers/dates-and-times.js
@@ -232,7 +232,7 @@ function isDate(obj) {
   try {
     Date.prototype.valueOf.call(obj);
     return true;
-  } catch {
+  } catch(err) {
     return false;
   }
 }


### PR DESCRIPTION
In date-and-times.js there is a problem with a incorrect syntax of catch. 
This generates eslint errors, in particular with firebase a aws functions.