### PR TITLE
Add console.timeLog()

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -698,6 +698,7 @@ function Window(options) {
     log: wrapConsoleMethod("log"),
     table: wrapConsoleMethod("table"),
     time: wrapConsoleMethod("time"),
+    timeLog: wrapConsoleMethod("timeLog"),
     timeEnd: wrapConsoleMethod("timeEnd"),
     trace: wrapConsoleMethod("trace"),
     warn: wrapConsoleMethod("warn")

--- a/test/api/virtual-console.js
+++ b/test/api/virtual-console.js
@@ -20,6 +20,7 @@ const consoleMethods = [
   "log",
   "table",
   "time",
+  "timeLog",
   "timeEnd",
   "trace",
   "warn"

--- a/test/web-platform-tests/to-upstream/console/methods.html
+++ b/test/web-platform-tests/to-upstream/console/methods.html
@@ -27,9 +27,10 @@ test(() => {
     "trace",
     "warn",
     "group",
-    "groupCollapsed", // https://github.com/whatwg/console/issues/64
+    "groupCollapsed",
     "groupEnd",
     "time",
+    "timeLog",
     "timeEnd"
   ];
 


### PR DESCRIPTION
Support for `console.timeLog()` was added in Node.js v10.7.0, and this wraps it like our other `console` methods. With this we expose every method from the current Console Standard.