### PR TITLE
Replace alias with my actual name as contributor/maintainer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,3 +21,4 @@ Martin Naumann <mr.avgp@gmail.com> <martin@geekonaut.de>
 Christoph Pojer <christoph.pojer@gmail.com>
 Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
 Jesus David Garcia Gomez <jdgarcia@outlook.com> <dgarcia@plainconcepts.com>
+Magne Andersson <code@zirro.se>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -168,6 +168,7 @@ Lucian Buzzo <LucianBuzzo@users.noreply.github.com>
 Ludovico Fischer <livrerie@gmail.com>
 Luis Silva <fetzpt@gmail.com>
 Lukas Bünger <lukas.buenger@fixxpunkt.ch>
+Magne Andersson <code@zirro.se>
 makana <mamas-albtraum@web.de>
 Manuel Lopez <jmlopez.rod@gmail.com>
 Marak Squires <marak.squires@gmail.com>
@@ -283,4 +284,3 @@ Yun Cui <ycui@microstrategy.com>
 Yunlei Liu <yunlei.liu@appfolio.com>
 Zach Bjornson <zbbjornson@gmail.com>
 Zach Smith <zach@amicushq.com>
-Zirro <code@zirro.se>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "Sebastian Mayr <sebmaster16@gmail.com> (https://blog.smayr.name/)",
     "Joris van der Wel <joris@jorisvanderwel.com>",
     "Timothy Gu <timothygu99@gmail.com> (https://timothygu.me/)",
-    "Zirro <code@zirro.se>",
+    "Magne Andersson <code@zirro.se> (https://zirro.se/)",
     "Pierre-Marie Dartus <dartus.pierremarie@gmail.com>"
   ],
   "license": "MIT",


### PR DESCRIPTION
I'm no longer as concerned about sharing personal details in connection to my online accounts as I once was, so it's about time I made this change 🙂