### PR TITLE
Fix issue leaking memory in parser of html

### DIFF
--- a/lib/jsdom/browser/parser/html.js
+++ b/lib/jsdom/browser/parser/html.js
@@ -16,6 +16,35 @@ const OpenElementStack = require("parse5/lib/parser/open-element-stack");
 const OpenElementStackOriginalPop = OpenElementStack.prototype.pop;
 const OpenElementStackOriginalPush = OpenElementStack.prototype.push;
 
+function setOpenElementStack(updater) {
+  const updaterIsFunction = typeof updater === "function";
+
+  OpenElementStack.prototype.push = function (...args) {
+    OpenElementStackOriginalPush.apply(this, args);
+    if (updaterIsFunction) {
+      updater(this.current);
+    }
+
+    const after = this.items[this.stackTop];
+    if (after._pushedOnStackOfOpenElements) {
+      after._pushedOnStackOfOpenElements();
+    }
+  };
+
+  OpenElementStack.prototype.pop = function (...args) {
+    const before = this.items[this.stackTop];
+
+    OpenElementStackOriginalPop.apply(this, args);
+    if (updaterIsFunction) {
+      updater(this.current);
+    }
+
+    if (before._poppedOffStackOfOpenElements) {
+      before._poppedOffStackOfOpenElements();
+    }
+  };
+}
+
 class JSDOMParse5Adapter {
   constructor(documentImpl) {
     this._documentImpl = documentImpl;
@@ -27,25 +56,14 @@ class JSDOMParse5Adapter {
 
     // Horrible monkey-patch to implement https://github.com/inikulin/parse5/issues/237
     const adapter = this;
-    OpenElementStack.prototype.push = function (...args) {
-      OpenElementStackOriginalPush.apply(this, args);
-      adapter._currentElement = this.current;
+    setOpenElementStack(currentElement => {
+      adapter._currentElement = currentElement;
+    });
+  }
 
-      const after = this.items[this.stackTop];
-      if (after._pushedOnStackOfOpenElements) {
-        after._pushedOnStackOfOpenElements();
-      }
-    };
-    OpenElementStack.prototype.pop = function (...args) {
-      const before = this.items[this.stackTop];
-
-      OpenElementStackOriginalPop.apply(this, args);
-      adapter._currentElement = this.current;
-
-      if (before._poppedOffStackOfOpenElements) {
-        before._poppedOffStackOfOpenElements();
-      }
-    };
+  clear() {
+    this._currentElement = undefined;
+    setOpenElementStack();
   }
 
   _ownerDocument() {
@@ -161,19 +179,25 @@ Object.assign(JSDOMParse5Adapter.prototype, serializationAdapter);
 function parseFragment(markup, contextElement) {
   const ownerDocument = contextElement._ownerDocument;
 
+  const treeAdapter = new JSDOMParse5Adapter(ownerDocument);
   const config = Object.assign({}, ownerDocument._parseOptions, {
-    treeAdapter: new JSDOMParse5Adapter(ownerDocument)
+    treeAdapter
   });
 
-  return parse5.parseFragment(contextElement, markup, config);
+  const result = parse5.parseFragment(contextElement, markup, config);
+  treeAdapter.clear();
+  return result;
 }
 
 function parseIntoDocument(markup, ownerDocument) {
+  const treeAdapter = new JSDOMParse5Adapter(ownerDocument);
   const config = Object.assign({}, ownerDocument._parseOptions, {
-    treeAdapter: new JSDOMParse5Adapter(ownerDocument)
+    treeAdapter
   });
 
-  return parse5.parse(markup, config);
+  const result = parse5.parse(markup, config);
+  treeAdapter.clear();
+  return result;
 }
 
 module.exports = {


### PR DESCRIPTION
Resolved #2757 

Add a step to clean up the reference object after use.
Please review it, thanks.