### PR TITLE
Ensure <input type="number"> doesn't overshoot step up/down values

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -545,13 +545,13 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
     if (!this._isStepAligned(value)) {
       value = this._stepAlign(value, /* roundUp = */ isUp);
+    } else {
+      let delta = n * allowedValueStep;
+      if (!isUp) {
+        delta *= -1;
+      }
+      value += delta;
     }
-
-    let delta = n * allowedValueStep;
-    if (!isUp) {
-      delta *= -1;
-    }
-    value += delta;
 
     if (min !== null && value < min) {
       value = this._stepAlign(min, /* roundUp = */ true);

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-input-element/input-step-realignment.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-input-element/input-step-realignment.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>input.stepUp/Down realignment</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<input type=number id=inputNumber>
+
+<script>
+  "use strict";
+
+  const inputNumber = document.getElementById("inputNumber");
+
+  test(() => {
+    inputNumber.min = 0;
+    inputNumber.step = 2;
+    inputNumber.value = 5;
+    assert_equals(inputNumber.value, "5");
+
+    inputNumber.stepUp();
+    assert_equals(inputNumber.value, "6");
+
+    inputNumber.stepUp();
+    assert_equals(inputNumber.value, "8");
+
+    inputNumber.step = 3;
+    inputNumber.stepDown();
+    assert_equals(inputNumber.value, "6");
+  }, "stepUp/Down work when starting from a value not aligned with value step");
+</script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-input-element/input-step-realignment.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-input-element/input-step-realignment.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>input.stepUp/Down realignment</title>
+<title>input.stepUp/Down work when starting from a value not aligned with value step</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <input type=number id=inputNumber>
 
 <script>
-  "use strict";
+"use strict";
 
-  const inputNumber = document.getElementById("inputNumber");
+const inputNumber = document.getElementById("inputNumber");
 
-  test(() => {
-    inputNumber.min = 0;
-    inputNumber.step = 2;
-    inputNumber.value = 5;
-    assert_equals(inputNumber.value, "5");
+test(() => {
+  inputNumber.min = 0;
+  inputNumber.step = 2;
+  inputNumber.value = 5;
+  assert_equals(inputNumber.value, "5");
 
-    inputNumber.stepUp();
-    assert_equals(inputNumber.value, "6");
+  inputNumber.stepUp();
+  assert_equals(inputNumber.value, "6");
 
-    inputNumber.stepUp();
-    assert_equals(inputNumber.value, "8");
+  inputNumber.stepUp();
+  assert_equals(inputNumber.value, "8");
 
-    inputNumber.step = 3;
-    inputNumber.stepDown();
-    assert_equals(inputNumber.value, "6");
-  }, "stepUp/Down work when starting from a value not aligned with value step");
+  inputNumber.step = 3;
+  inputNumber.stepDown();
+  assert_equals(inputNumber.value, "6");
+});
 </script>


### PR DESCRIPTION
When the value is not step aligned, align to nearest step multiple in appropriate direction. Only proceed to apply the step delta if the value WAS step aligned, and not otherwise.

Files changed:
lib/jsdom/living/nodes/HTMLInputElement-impl.js

Closes #2826 