### PR TITLE
Fix leaking memory during parsing

### DIFF
--- a/lib/jsdom/browser/parser/html.js
+++ b/lib/jsdom/browser/parser/html.js
@@ -12,9 +12,32 @@ const nodeTypes = require("../../living/node-type");
 
 const serializationAdapter = require("../../living/domparsing/parse5-adapter-serialization");
 
+// Horrible monkey-patch to implement https://github.com/inikulin/parse5/issues/237 and
+// https://github.com/inikulin/parse5/issues/285.
 const OpenElementStack = require("parse5/lib/parser/open-element-stack");
-const OpenElementStackOriginalPop = OpenElementStack.prototype.pop;
-const OpenElementStackOriginalPush = OpenElementStack.prototype.push;
+
+const openElementStackOriginalPush = OpenElementStack.prototype.push;
+OpenElementStack.prototype.push = function (...args) {
+  openElementStackOriginalPush.apply(this, args);
+  this.treeAdapter._currentElement = this.current;
+
+  const after = this.items[this.stackTop];
+  if (after._pushedOnStackOfOpenElements) {
+    after._pushedOnStackOfOpenElements();
+  }
+};
+
+const openElementStackOriginalPop = OpenElementStack.prototype.pop;
+OpenElementStack.prototype.pop = function (...args) {
+  const before = this.items[this.stackTop];
+
+  openElementStackOriginalPop.apply(this, args);
+  this.treeAdapter._currentElement = this.current;
+
+  if (before._poppedOffStackOfOpenElements) {
+    before._poppedOffStackOfOpenElements();
+  }
+};
 
 class JSDOMParse5Adapter {
   constructor(documentImpl) {
@@ -22,30 +45,8 @@ class JSDOMParse5Adapter {
     this._globalObject = documentImpl._globalObject;
 
     // Since the createElement hook doesn't provide the parent element, we keep track of this using _currentElement:
-    // https://github.com/inikulin/parse5/issues/285
+    // https://github.com/inikulin/parse5/issues/285. See above horrible monkey-patch for how this is maintained.
     this._currentElement = undefined;
-
-    // Horrible monkey-patch to implement https://github.com/inikulin/parse5/issues/237
-    const adapter = this;
-    OpenElementStack.prototype.push = function (...args) {
-      OpenElementStackOriginalPush.apply(this, args);
-      adapter._currentElement = this.current;
-
-      const after = this.items[this.stackTop];
-      if (after._pushedOnStackOfOpenElements) {
-        after._pushedOnStackOfOpenElements();
-      }
-    };
-    OpenElementStack.prototype.pop = function (...args) {
-      const before = this.items[this.stackTop];
-
-      OpenElementStackOriginalPop.apply(this, args);
-      adapter._currentElement = this.current;
-
-      if (before._poppedOffStackOfOpenElements) {
-        before._poppedOffStackOfOpenElements();
-      }
-    };
   }
 
   _ownerDocument() {


### PR DESCRIPTION
The monkey-patch for maintaining the open element stack, as modified by commit 75a921eab52c239b2468e08be9f547f46c7f86bd, maintained a reference to the most recent `JSDOMParse5Adapter` (and all its options) through the push/pop closures. This means there was always a reference from the rooted `OpenElementStack.prototype.{push,pop}` functions to the most recent `JSDOMParse5Adapter` and its related objects.

This commit instead uses the `this.treeAdapter` pointer, which already exists in parse5. Doing so also allows us to move the monkey-patch back into the top level, instead of establishing it on construction of each tree adapter.

Closes #2831. Closes #2825. Fixes https://github.com/facebook/jest/issues/9507.

---

Hi @lamhieu-vk and @terite; thank you very much for your pull requests to fix this problem, and sorry for not getting to them sooner. I think I found a slightly more elegant way of making this work, by using the `this.treeAdapter` pointer. However, I don't have any way of confirming that this fix works as well as yours do. Which brings up another problem, which is that neither of your pull requests added a regression test we could use to prevent this in the future.

Although I'm willing to merge this (or, if this doesn't work, one of your PRs) without a regression test, I'd like to get confirmation that it fixes the problem first, so if you could help verify that, it would be much appreciated. And if you were able to suggest some way of adding code to the jsdom test suite to prevent the problem in the future, that would be even better.

Thank you!