### PR TITLE
feat(events): Use `vm.compileFunction(…)`

### DIFF
--- a/lib/jsdom/living/helpers/create-event-accessor.js
+++ b/lib/jsdom/living/helpers/create-event-accessor.js
@@ -4,6 +4,7 @@ const conversions = require("webidl-conversions");
 const idlUtils = require("../generated/utils");
 const ErrorEvent = require("../generated/ErrorEvent");
 const reportException = require("./runtime-script-errors");
+const vm = require("vm");
 
 exports.appendHandler = function appendHandler(el, eventName) {
   el.addEventListener(eventName, event => {
@@ -115,23 +116,16 @@ exports.createEventAccessor = function createEventAccessor(obj, event) {
           return null;
         }
 
-        // Note: the with (window) { } is not necessary in Node, but is necessary in a browserified environment.
-
         let fn;
-        const createFunction = document.defaultView.Function;
         if (event === "error" && element === null) {
-          const wrapperBody = document ? body + `\n//# sourceURL=${document.URL}` : body;
-
-          // eslint-disable-next-line no-new-func
-          fn = createFunction("window", `with (window) { return function onerror(event, source, lineno, colno, error) {
-  ${wrapperBody}
-}; }`)(window);
+          fn = vm.compileFunction(body, ["event", "source", "lineno", "colno", "error"], {
+            parsingContext: window,
+            filename: document && document.URL
+          });
+          Object.defineProperty(fn, "name", { value: "onerror", configurable: true });
         } else {
           const argNames = [];
           const args = [];
-
-          argNames.push("window");
-          args.push(window);
 
           if (element !== null) {
             argNames.push("document");
@@ -156,7 +150,10 @@ return function on${event}(event) {
             wrapperBody += `\n//# sourceURL=${document.URL}`;
           }
           argNames.push(wrapperBody);
-          fn = createFunction(...argNames)(...args);
+          fn = vm.compileFunction(wrapperBody, argNames, {
+            parsingContext: window,
+            filename: document && document.URL
+          })(...args);
         }
 
         this._setEventHandlerFor(event, fn);

--- a/lib/jsdom/vm-shim.js
+++ b/lib/jsdom/vm-shim.js
@@ -18,6 +18,17 @@ const otherBuiltIns = [
   "Reflect", "escape", "unescape"
 ];
 
+exports.compileFunction = (code, params = [], options = {}) => {
+  const contextifiedSandbox = options.parsingContext;
+  if (contextifiedSandbox === undefined) {
+    return Function(...params, code);
+  }
+
+  return exports.runInContext(`with (window) {
+  return function (${params.join(",")}) {${code}};
+}`, contextifiedSandbox, options);
+};
+
 exports.createContext = function (sandbox) {
   Object.defineProperty(sandbox, "__isVMShimContext", {
     value: true,
@@ -58,7 +69,7 @@ exports.isContext = function (sandbox) {
   return sandbox.__isVMShimContext;
 };
 
-exports.runInContext = function (code, contextifiedSandbox, options) {
+exports.runInContext = (code, contextifiedSandbox, options) => {
   if (code === "this") {
     // Special case for during window creation.
     return contextifiedSandbox;
@@ -111,7 +122,7 @@ exports.runInContext = function (code, contextifiedSandbox, options) {
   const rewrittenCode = escodegen.generate(ast, { comment: true });
   const suffix = options.filename !== undefined ? "\n//# sourceURL=" + options.filename : "";
 
-  return Function("window", rewrittenCode + suffix).bind(contextifiedSandbox)(contextifiedSandbox);
+  return Function("window", rewrittenCode + suffix).call(contextifiedSandbox, contextifiedSandbox);
 };
 
 exports.Script = class VMShimScript {


### PR DESCRIPTION
**Node v10** introduced [the `vm.compileFunction(…)` method](https://nodejs.org/api/vm.html#vm_vm_compilefunction_code_params_options), which compiles a function in the correct context.

This also moves the `with (window) { … }` wrapper into `vm‑shim.js`.

---

Extracted from: #2835