### PR TITLE
fix: support wildcard for access-control-allow-headers

### DIFF
--- a/lib/jsdom/living/xhr/xhr-utils.js
+++ b/lib/jsdom/living/xhr/xhr-utils.js
@@ -90,7 +90,7 @@ function validCORSPreflightHeaders(xhr, response, flag, properties) {
   }
   const acahStr = response.headers["access-control-allow-headers"];
   const acah = new Set(acahStr ? acahStr.trim().toLowerCase().split(headerListSeparatorRegexp) : []);
-  const forbiddenHeaders = Object.keys(flag.requestHeaders).filter(header => {
+  const forbiddenHeaders = acah.has("*") ? [] : Object.keys(flag.requestHeaders).filter(header => {
     const lcHeader = header.toLowerCase();
     return !simpleHeaders.has(lcHeader) && !acah.has(lcHeader);
   });


### PR DESCRIPTION
Regarding this issue: https://github.com/jsdom/jsdom/issues/2408
If `access-control-allow-headers` has `*` jsdom should allow all headers.