### PR TITLE
Upgrade saxes to version 5.0.0.

### DIFF
--- a/lib/jsdom/browser/parser/xml.js
+++ b/lib/jsdom/browser/parser/xml.js
@@ -78,7 +78,7 @@ function createParser(rootNode, globalObject, saxesOptions) {
     }
   }
 
-  parser.ontext = saxesOptions.fragment ?
+  parser.on("text", saxesOptions.fragment ?
     // In a fragment, all text events produced by saxes must result in a text
     // node.
     data => {
@@ -93,14 +93,14 @@ function createParser(rootNode, globalObject, saxesOptions) {
         const ownerDocument = getOwnerDocument();
         appendChild(Text.createImpl(globalObject, [], { data, ownerDocument }));
       }
-    };
+    });
 
-  parser.oncdata = data => {
+  parser.on("cdata", data => {
     const ownerDocument = getOwnerDocument();
     appendChild(CDATASection.createImpl(globalObject, [], { data, ownerDocument }));
-  };
+  });
 
-  parser.onopentag = tag => {
+  parser.on("opentag", tag => {
     const { local: tagLocal, attributes: tagAttributes } = tag;
 
     const ownerDocument = getOwnerDocument();
@@ -126,27 +126,27 @@ function createParser(rootNode, globalObject, saxesOptions) {
 
     appendChild(elem);
     openStack.push(elem);
-  };
+  });
 
-  parser.onclosetag = () => {
+  parser.on("closetag", () => {
     const elem = openStack.pop();
     // Once a script is populated, we can execute it.
     if (elem.localName === "script" && elem.namespaceURI === HTML_NS) {
       elem._eval();
     }
-  };
+  });
 
-  parser.oncomment = data => {
+  parser.on("comment", data => {
     const ownerDocument = getOwnerDocument();
     appendChild(Comment.createImpl(globalObject, [], { data, ownerDocument }));
-  };
+  });
 
-  parser.onprocessinginstruction = ({ target, body }) => {
+  parser.on("processinginstruction", ({ target, body }) => {
     const ownerDocument = getOwnerDocument();
     appendChild(ProcessingInstruction.createImpl(globalObject, [], { target, data: body, ownerDocument }));
-  };
+  });
 
-  parser.ondoctype = dt => {
+  parser.on("doctype", dt => {
     const ownerDocument = getOwnerDocument();
     appendChild(parseDocType(globalObject, ownerDocument, `<!doctype ${dt}>`));
 
@@ -158,11 +158,11 @@ function createParser(rootNode, globalObject, saxesOptions) {
         parser.ENTITIES[name] = value;
       }
     }
-  };
+  });
 
-  parser.onerror = err => {
+  parser.on("error", err => {
     throw DOMException.create(globalObject, [err.message, "SyntaxError"]);
-  };
+  });
 
   return parser;
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "parse5": "5.1.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
-    "saxes": "^4.0.2",
+    "saxes": "^5.0.0",
     "symbol-tree": "^3.2.4",
     "tough-cookie": "^3.0.1",
     "w3c-hr-time": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3816,10 +3816,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-saxes@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/saxes/-/saxes-4.0.2.tgz#76f8e762efc96ec4af5f885d8151c50426103165"
-  integrity sha512-EZOTeQ4bgkOaGCDaTKux+LaRNcLNbdbvMH7R3/yjEEULPEmqvkFbFub6DJhJTub2iGMT93CfpZ5LTdKZmAbVeQ==
+saxes@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.0.tgz#b7d30284d7583a5ca6ad0248b56d8889da53788b"
+  integrity sha512-LXTZygxhf8lfwKaTP/8N9CsVdjTlea3teze4lL6u37ivbgGbV0GGMuNtS/I9rnD/HC2/txUM7Df4S2LVl1qhiA==
   dependencies:
     xmlchars "^2.2.0"
 


### PR DESCRIPTION
This PR upgrades saxes to version 5.0.0.

Why upgrade? Other than keeping up with the latest version, there's a BOM bug that is fixed in saxes 5.0.0 which in theory could be triggered in jsdom as long as jsdom remains on 4.x. (The other bug fixes in 5.0.0 fix issues that don't affect jsdom.)