### PR TITLE
add exception param to catch block to fix syntax error

### DIFF
--- a/lib/jsdom/living/helpers/dates-and-times.js
+++ b/lib/jsdom/living/helpers/dates-and-times.js
@@ -232,7 +232,7 @@ function isDate(obj) {
   try {
     Date.prototype.valueOf.call(obj);
     return true;
-  } catch {
+  } catch (e) {
     return false;
   }
 }


### PR DESCRIPTION
The missing "(e)" parameter on the catch block is causing a syntax error when attempting deploy the module to Google Cloud Functions.