### PR TITLE
Update acorn to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "repository": "jsdom/jsdom",
   "dependencies": {
     "abab": "^2.0.3",
-    "acorn": "^7.1.1",
+    "acorn": "7.1.1",
     "acorn-globals": "^4.3.4",
     "cssom": "^0.4.4",
     "cssstyle": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "repository": "jsdom/jsdom",
   "dependencies": {
     "abab": "^2.0.3",
-    "acorn": "^7.1.0",
+    "acorn": "^7.1.1",
     "acorn-globals": "^4.3.4",
     "cssom": "^0.4.4",
     "cssstyle": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "repository": "jsdom/jsdom",
   "dependencies": {
     "abab": "^2.0.3",
-    "acorn": "7.1.1",
+    "acorn": "^7.1.1",
     "acorn-globals": "^4.3.4",
     "cssom": "^0.4.4",
     "cssstyle": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,11 @@ acorn-walk@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.0.0.tgz#c8ba6f0f1aac4b0a9e32d1f0af12be769528f36b"
   integrity sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==
 
+acorn@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+
 acorn@^6.0.1:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"


### PR DESCRIPTION
Fixes following error from running `npm audit`:

```
  Moderate        Regular Expression Denial of Service                          

  Package         acorn                                                         

  Patched in      >=7.1.1                                                       

  Dependency of   jsdom                                        

  Path            jsdom > acorn                               

  More info       https://npmjs.com/advisories/1488  
```