### PR TITLE
Convert skipped inline event handlers on body test to WPT

### DIFF
--- a/test/to-port-to-wpts/misc2.js
+++ b/test/to-port-to-wpts/misc2.js
@@ -385,37 +385,6 @@ describe("jsdom/miscellaneous", () => {
     assert.ok(a.getAttribute("style").match(/^\s*width\s*:\s*100%\s*;?\s*$/), "style attribute must contain width");
   });
 
-  // Test inline event handlers set on the body.
-  // TODO this currently fails!?
-  specify.skip("test_body_event_handler_inline", { skipIfBrowser: true, async: true }, t => {
-    // currently skipped in browsers because of an issue:
-    // TODO: https://github.com/jsdom/jsdom/issues/1379
-    const html = `
-      <html>
-        <head>
-          <script>
-            function loader () {
-              window.loader_called = true;
-            }
-          </script>
-        </head>
-        <body onload="loader()"></body>
-      </html>`;
-    const doc = (new JSDOM(html, { runScripts: "dangerously" })).window.document;
-    const window = doc.defaultView;
-    // In JSDOM, listeners registered with addEventListener are called before
-    // "traditional" listeners, so listening for "load" will fire before our
-    // inline listener.  This means we have to check the value on the next
-    // tick.
-    window.addEventListener("load", () => {
-      process.nextTick(() => {
-        assert.equal(window.loader_called, true);
-        t.done();
-      });
-    });
-    doc.close();
-  });
-
   specify("get_element_by_id", () => {
     const doc = (new JSDOM()).window.document;
     const el = doc.createElement("div");

--- a/test/web-platform-tests/to-upstream/jsdom/misc/test_body_event_handler_inline.html
+++ b/test/web-platform-tests/to-upstream/jsdom/misc/test_body_event_handler_inline.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test inline event handlers set on the body.</title>
+<link rel="author" title="Timothy Gu" href="mailto:timothygu99@gmail.com">
+<link rel="help" href="https://github.com/jsdom/jsdom/issues/1379">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+  "use strict";
+  setup({ single_test: true });
+
+  // eslint-disable-next-line no-unused-vars
+  function onloadHandler() {
+    window.loader_called = true;
+  }
+</script>
+
+<body onload="onloadHandler()">
+  <div id=log></div>
+  <script>
+    "use strict";
+    window.addEventListener("load", () => {
+      assert_true(window.loader_called);
+      done();
+    });
+  </script>
+</body>


### PR DESCRIPTION
It’s been bothering me that this is the only non‑**WPT** test that is skipped, so I decided to take a crack at fixing it.

---

This still fails in the browser, this time with a `TypeError` stack trace:
```
Error: Uncaught TypeError: Cannot read property '_ownerDocument' of undefined
    /tmp/lib/jsdom/living/events/EventTarget-impl.js:340:1 <- /tmp/d02cce143d09f2d44600f80c43efc350.browserify.js:6911
```

The line is in: <https://github.com/jsdom/jsdom/blob/19884d85f9c8f3e7ce2f3ad68c7b86d00674bef8/lib/jsdom/living/events/EventTarget-impl.js#L333-L343>