### PR TITLE
test(web‑platform‑tests): Fix `run‑tuwpts.js` on Windows

### DIFF
--- a/test/web-platform-tests/run-tuwpts.js
+++ b/test/web-platform-tests/run-tuwpts.js
@@ -13,7 +13,7 @@ const manifestFilename = path.resolve(__dirname, "tuwpt-manifest.json");
 const testsRootArg = path.relative(wptPath, testsPath);
 const pathArg = path.relative(wptPath, manifestFilename);
 const args = ["./wpt.py", "manifest", "--tests-root", testsRootArg, "--path", pathArg];
-spawnSync("python", args, { cwd: wptPath, stdio: "inherit" });
+spawnSync("python2", args, { cwd: wptPath, stdio: "inherit" });
 
 const manifest = readManifest(manifestFilename);
 const possibleTestFilePaths = getPossibleTestFilePaths(manifest);

--- a/test/web-platform-tests/start-wpt-server.js
+++ b/test/web-platform-tests/start-wpt-server.js
@@ -34,7 +34,7 @@ module.exports = ({ toUpstream = false } = {}) => {
     () => {
       const configArg = path.relative(path.resolve(wptDir), configPath);
       const args = ["./wpt.py", "serve", "--config", configArg];
-      const subprocess = childProcess.spawn("python", args, {
+      const subprocess = childProcess.spawn("python2", args, {
         cwd: wptDir,
         stdio: "inherit"
       });


### PR DESCRIPTION
On **Windows**, `python.exe` is an alias for `python3.exe`, which differs from ~~**Linux**~~ **Ubuntu**, where `python` is an alias for `python2`.

`run‑tuwpts.js` therefore fails to run on **Windows** because `wpt manifest` doesn’t currently work in **Python 3**: <https://github.com/web-platform-tests/wpt/issues/19836>.