### PR TITLE
Make WPT server startup non‑blocking

### DIFF
--- a/test/web-platform-tests/run-tuwpts.js
+++ b/test/web-platform-tests/run-tuwpts.js
@@ -21,18 +21,20 @@ const possibleTestFilePaths = getPossibleTestFilePaths(manifest);
 let wptServerURL;
 let serverProcess;
 const runSingleWPT = require("./run-single-wpt.js")(() => wptServerURL);
-before({ timeout: 30 * 1000 }, async () => {
+const wptServerPromise = (async () => {
   const { urls, subprocess } = await startWPTServer({ toUpstream: true });
   wptServerURL = urls[0];
   serverProcess = subprocess;
-});
-
-after(() => {
-  serverProcess.kill();
-});
+})();
 
 describe("Local tests in web-platform-test format (to-upstream)", () => {
+  before({ timeout: 30 * 1000 }, () => wptServerPromise);
+
   for (const test of possibleTestFilePaths) {
     runSingleWPT(test);
   }
+
+  after(() => {
+    serverProcess.kill();
+  });
 });

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -41,17 +41,15 @@ checkToRun();
 let wptServerURL;
 let serverProcess;
 const runSingleWPT = require("./run-single-wpt.js")(() => wptServerURL);
-before({ timeout: 30 * 1000 }, async () => {
+const wptServerPromise = (async () => {
   const { urls, subprocess } = await startWPTServer({ toUpstream: false });
   wptServerURL = urls[0];
   serverProcess = subprocess;
-});
-
-after(() => {
-  serverProcess.kill();
-});
+})();
 
 describe("web-platform-tests", () => {
+  before({ timeout: 30 * 1000 }, () => wptServerPromise);
+
   for (const toRunDoc of toRunDocs) {
     describe(toRunDoc.DIR, () => {
       for (const testFilePath of possibleTestFilePaths) {
@@ -83,6 +81,10 @@ describe("web-platform-tests", () => {
       }
     });
   }
+
+  after(() => {
+    serverProcess.kill();
+  });
 });
 
 function checkToRun() {

--- a/test/web-platform-tests/start-wpt-server.js
+++ b/test/web-platform-tests/start-wpt-server.js
@@ -52,14 +52,12 @@ module.exports = ({ toUpstream = false } = {}) => {
 
     dnsLookup("web-platform.test")
       .then(
-        () => {
-          return Promise.all([
-            pollForServer(`http://${config.browser_host}:${config.ports.http[0]}/`),
-            pollForServer(`https://${config.browser_host}:${config.ports.https[0]}/`),
-            pollForServer(`http://${config.browser_host}:${config.ports.ws[0]}/`),
-            pollForServer(`https://${config.browser_host}:${config.ports.wss[0]}/`)
-          ]);
-        },
+        () => Promise.all([
+          pollForServer(`http://${config.browser_host}:${config.ports.http[0]}/`),
+          pollForServer(`https://${config.browser_host}:${config.ports.https[0]}/`),
+          pollForServer(`http://${config.browser_host}:${config.ports.ws[0]}/`),
+          pollForServer(`https://${config.browser_host}:${config.ports.wss[0]}/`)
+        ]),
         () => {
           throw new Error("Host entries not present for web platform tests. See " +
                           "https://github.com/web-platform-tests/wpt#running-the-tests");


### PR DESCRIPTION
This makes the **WPT** server startup not block non‑WPT tests, allowing the tests to start faster.

~~It also closes the **WPT** server process as soon as it’s no longer needed.~~ (See <https://github.com/jsdom/jsdom/pull/2905#discussion_r394082401> for the reason why this doesn’t quite work.

---

Extracted from <https://github.com/jsdom/jsdom/pull/2892>.