### PR TITLE
fix(HTMLSelectElement): Update version in value setter

### DIFF
--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -171,7 +171,9 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   set value(val) {
+    const seen = new Set([this]);
     let updated = false;
+
     for (const option of this.options) {
       updated = true;
       if (option.value === val) {
@@ -180,10 +182,27 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
       } else {
         option._selectedness = false;
       }
+
+      // `option._version` and `option._memoizedQueries` are updated here
+      // instead of in `option._modified()` to avoid O(n*m) complexity:
+      // (n = number of options, m = number of total ancestor nodes)
+      option._version++;
+      option._memoizedQueries = {};
+
+      // This ensures that we only update up to the deepest common seen ancestor node:
+      for (const node of domSymbolTree.ancestorsIterator(option)) {
+        if (node === this || seen.has(node)) {
+          break;
+        }
+        seen.add(node);
+        option._memoizedQueries = {};
+      }
     }
 
+    // This will update `this._version` and clear the `_memoizedQueries`
+    // of this and all ancestor nodes if necessary:
     if (updated) {
-      this._version++;
+      this._modified();
     }
   }
 

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -171,11 +171,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   set value(val) {
-    const seen = new Set([this]);
-    let updated = false;
-
     for (const option of this.options) {
-      updated = true;
       if (option.value === val) {
         option._selectedness = true;
         option._dirtyness = true;
@@ -183,26 +179,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
         option._selectedness = false;
       }
 
-      // `option._version` and `option._memoizedQueries` are updated here
-      // instead of in `option._modified()` to avoid O(n*m) complexity:
-      // (n = number of options, m = number of total ancestor nodes)
-      option._version++;
-      option._memoizedQueries = {};
-
-      // This ensures that we only update up to the deepest common seen ancestor node:
-      for (const node of domSymbolTree.ancestorsIterator(option)) {
-        if (node === this || seen.has(node)) {
-          break;
-        }
-        seen.add(node);
-        option._memoizedQueries = {};
-      }
-    }
-
-    // This will update `this._version` and clear the `_memoizedQueries`
-    // of this and all ancestor nodes if necessary:
-    if (updated) {
-      this._modified();
+      option._modified();
     }
   }
 

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -171,13 +171,19 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   set value(val) {
+    let updated = false;
     for (const option of this.options) {
+      updated = true;
       if (option.value === val) {
         option._selectedness = true;
         option._dirtyness = true;
       } else {
         option._selectedness = false;
       }
+    }
+
+    if (updated) {
+      this._version++;
     }
   }
 

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-value.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-value.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTMLSelectElement.selectedOptions and HTMLSelectElement.value</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#dom-select-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+
+<select id="sel">
+  <option id="opt1" value="x" data-foo="a">1st opt</option>
+  <option id="opt2" value="y" data-foo="b">2nd opt</option>
+</select>
+
+<script>
+  "use strict";
+  test(() => {
+
+    const select = document.getElementById("sel");
+    const opt1 = document.getElementById("opt1");
+    const opt2 = document.getElementById("opt2");
+
+    select.value = "x";
+    assert_equals(select.selectedOptions[0], opt1);
+
+    select.value = "y";
+    assert_equals(select.selectedOptions[0], opt2);
+
+  }, "`HTMLSelectElement.selectedOptions` is correctly updated when `HTMLSelectElement.value` changes");
+</script>


### PR DESCRIPTION
Fixes #2908, which happened because changing the `select.value` was not correctly updating the internal `_version` field, which is used to optimise `HTMLCollection`, `HTMLOptionCollection`, `NodeList` and several other things.