### PR TITLE
fix(getComputedStyle): throw on Shadow DOM pseudo‑elements

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -26,8 +26,8 @@ const Selection = require("../living/generated/Selection");
 const reportException = require("../living/helpers/runtime-script-errors");
 const { fireAnEvent } = require("../living/helpers/events");
 const SessionHistory = require("../living/window/SessionHistory");
-const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented } =
-  require("../living/helpers/style-rules");
+const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented,
+  SHADOW_DOM_PSEUDO_REGEXP } = require("../living/helpers/style-rules.js");
 const CustomElementRegistry = require("../living/generated/CustomElementRegistry");
 const jsGlobals = require("./js-globals.json");
 
@@ -642,6 +642,20 @@ function Window(options) {
 
   this.getComputedStyle = function (elt) {
     elt = Element.convert(elt);
+    let pseudoElt = arguments[1];
+    if (pseudoElt !== undefined && pseudoElt !== null) {
+      pseudoElt = webIDLConversions.DOMString(pseudoElt);
+    }
+
+    if (pseudoElt !== undefined && pseudoElt !== null && pseudoElt !== "") {
+      // TODO: Parse pseudoElt
+
+      if (SHADOW_DOM_PSEUDO_REGEXP.test(pseudoElt)) {
+        throw new TypeError("Tried to get the computed style of a Shadow DOM pseudo-element.");
+      }
+
+      notImplemented("window.computedStyle(elt, pseudoElt)", this);
+    }
 
     const declaration = new CSSStyleDeclaration();
     const { forEach } = Array.prototype;

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -106,3 +106,5 @@ exports.getResolvedValue = (element, property) => {
   // So we skip to "any other property: The resolved value is the computed value."
   return getComputedValue(element, property);
 };
+
+exports.SHADOW_DOM_PSEUDO_REGEXP = /^::(?:part|slotted)\(/i;

--- a/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-pseudo-shadow.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-pseudo-shadow.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSSOM: getComputedStyle() throws on Shadow DOM pseudo-elements</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="test"></div>
+
+<script>
+"use strict";
+
+test(() => {
+  const div = document.getElementById("test");
+  assert_throws_js(
+    TypeError,
+    () => getComputedStyle(div, "::part(foo)"),
+    "getComputedStyle with ::part(...) throws"
+  );
+}, "Shadow DOM ::part(...) pseudo-element throws");
+
+test(() => {
+  const div = document.getElementById("test");
+  assert_throws_js(
+    TypeError,
+    () => getComputedStyle(div, "::slotted(foo)"),
+    "getComputedStyle with ::slotted(...) throws"
+  );
+}, "Shadow DOM ::slotted(...) pseudo-element throws");
+
+</script>


### PR DESCRIPTION
Extracted from <https://github.com/jsdom/jsdom/pull/2835>.

This makes [`getComputedStyle(…)`](https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle) call `notImplemented(…)` when trying to use the `pseudoElt` parameter, and throw when trying to get the computed style of a **Shadow DOM** pseudo‑element.

See also <https://github.com/jsdom/jsdom/issues/1928>

## Spec:
- https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle

---

review?(@TimothyGu): The build passed