### PR TITLE
Better activation behavior for <label> elements

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -244,7 +244,7 @@ class EventTargetImpl {
 
     if (activationTarget !== null) {
       if (!eventImpl._canceledFlag) {
-        activationTarget._activationBehavior();
+        activationTarget._activationBehavior(eventImpl);
       } else if (activationTarget._legacyCanceledActivationBehavior) {
         activationTarget._legacyCanceledActivationBehavior();
       }

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -80,22 +80,63 @@ exports.normalizeToCRLF = string => {
     .replace(/^\n/, "\r\n");
 };
 
-exports.isLabelable = node => {
-  // labelable logic defined at: https://html.spec.whatwg.org/multipage/forms.html#category-label
+// https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2
+exports.isInteractiveContent = node => {
   if (node.nodeType !== NODE_TYPE.ELEMENT_NODE) {
     return false;
   }
+  if (node.namespaceURI !== HTML_NS) {
+    return false;
+  }
+  if (node.hasAttributeNS(null, "tabindex")) {
+    return true;
+  }
+  switch (node.localName) {
+    case "a":
+      return node.hasAttributeNS(null, "href");
 
-  switch (node.tagName) {
-    case "BUTTON":
-    case "METER":
-    case "OUTPUT":
-    case "PROGRESS":
-    case "SELECT":
-    case "TEXTAREA":
+    case "audio":
+    case "video":
+      return node.hasAttributeNS(null, "controls");
+
+    case "img":
+    case "object":
+      return node.hasAttributeNS(null, "usemap");
+
+    case "input":
+      return node.type !== "hidden";
+
+    case "button":
+    case "details":
+    case "embed":
+    case "iframe":
+    case "label":
+    case "select":
+    case "textarea":
+      return true;
+  }
+
+  return false;
+};
+
+// https://html.spec.whatwg.org/multipage/forms.html#category-label
+exports.isLabelable = node => {
+  if (node.nodeType !== NODE_TYPE.ELEMENT_NODE) {
+    return false;
+  }
+  if (node.namespaceURI !== HTML_NS) {
+    return false;
+  }
+  switch (node.localName) {
+    case "button":
+    case "meter":
+    case "output":
+    case "progress":
+    case "select":
+    case "textarea":
       return true;
 
-    case "INPUT":
+    case "input":
       return node.type !== "hidden";
   }
 

--- a/lib/jsdom/living/helpers/number-and-date-inputs.js
+++ b/lib/jsdom/living/helpers/number-and-date-inputs.js
@@ -166,7 +166,7 @@ exports.convertNumberToStringByType = {
   month(input) {
     const year = 1970 + Math.floor(input / 12);
     const month = input % 12;
-    const date = new Date();
+    const date = new Date(0);
     date.setUTCFullYear(year);
     date.setUTCMonth(month);
 

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -4,7 +4,8 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const NODE_TYPE = require("../node-type");
-const { isLabelable, isDisabled } = require("../helpers/form-controls");
+const { isLabelable, isDisabled, isInteractiveContent } = require("../helpers/form-controls");
+const { isInclusiveAncestor } = require("../helpers/node");
 const { fireAnEvent } = require("../helpers/events");
 
 function sendClickToAssociatedNode(node) {
@@ -60,9 +61,29 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
     return null;
   }
 
-  _activationBehavior() {
+  _activationBehavior(event) {
+    // Check if the event's target is an inclusive descendant of any interactive content descendant of this <label>.
+    // If so, do nothing.
+    if (event.target && event.target !== this && isInclusiveAncestor(this, event.target)) {
+      for (const ancestor of domSymbolTree.ancestorsIterator(event.target)) {
+        if (ancestor === this) {
+          break;
+        }
+        if (isInteractiveContent(ancestor)) {
+          return;
+        }
+      }
+    }
+
     const node = this.control;
     if (node && !isDisabled(node)) {
+      // Check if the control is an inclusive ancestor of the event's target (and has already received this event).
+      // If so, do nothing.
+      // See https://github.com/whatwg/html/issues/5415.
+      if (event.target && isInclusiveAncestor(node, event.target)) {
+        return;
+      }
+
       sendClickToAssociatedNode(node);
     }
   }

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/clicking-interactive-content.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/clicking-interactive-content.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Label event handling when a descendant interactive content is clicked</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<label id=label></label>
+<template id=interactive-content>
+  <a href="about:blank" onclick="event.preventDefault()"></a>
+  <audio controls></audio>
+  <button></button>
+  <details></details>
+  <embed>
+  <iframe></iframe>
+  <img usemap="">
+  <input>
+  <label>label</label>
+  <object usemap=""></object>
+  <select></select>
+  <textarea></textarea>
+  <video controls></video>
+
+  <div tabindex=0></div>
+</template>
+
+<script>
+"use strict";
+
+const interactiveContent = document.getElementById("interactive-content");
+const interactiveElements = Array.from(interactiveContent.content.children);
+const label = document.getElementById("label");
+
+for (const srcInteractiveElement of interactiveElements) {
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const interactiveElement = srcInteractiveElement.cloneNode();
+    label.appendChild(interactiveElement);
+
+    let clicked = 0;
+    interactiveElement.addEventListener("click", () => {
+      clicked++;
+    });
+    interactiveElement.click();
+    assert_equals(clicked, 1, "clicking interactive content");
+
+    clicked = 0;
+    const span = document.createElement("span");
+    interactiveElement.appendChild(span);
+    span.click();
+    assert_equals(clicked, 1, "clicking descendant of interactive content");
+  }, `interactive content ${srcInteractiveElement.outerHTML} as first child of <label>`);
+
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const interactiveElement = srcInteractiveElement.cloneNode();
+    const div = document.createElement("div");
+    div.appendChild(interactiveElement);
+    label.appendChild(div);
+
+    let clicked = 0;
+    interactiveElement.addEventListener("click", () => {
+      clicked++;
+    });
+    interactiveElement.click();
+    assert_equals(clicked, 1, "clicking nested interactive content");
+
+    clicked = 0;
+    const span = document.createElement("span");
+    interactiveElement.appendChild(span);
+    span.click();
+    assert_equals(clicked, 1, "clicking descendant of nested interactive content");
+  }, `interactive content ${srcInteractiveElement.outerHTML} deeply nested under <label>`);
+
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const button = document.createElement("button");
+    label.appendChild(button);
+
+    const interactiveElement = srcInteractiveElement.cloneNode();
+    label.appendChild(interactiveElement);
+
+    let buttonClicked = 0;
+    button.addEventListener("click", () => {
+      buttonClicked++;
+    });
+
+    let clicked = 0;
+    interactiveElement.addEventListener("click", () => {
+      clicked++;
+    });
+    interactiveElement.click();
+    assert_equals(clicked, 1, "clicking nested interactive content");
+    assert_equals(buttonClicked, 0, "clicking nested interactive content should not click button");
+
+    clicked = 0;
+    const span = document.createElement("span");
+    interactiveElement.appendChild(span);
+    span.click();
+    assert_equals(clicked, 1, "clicking descendant of nested interactive content");
+    assert_equals(buttonClicked, 0, "clicking descendant of nested interactive content should not click button");
+  }, `interactive content ${srcInteractiveElement.outerHTML} as second child under <label>`);
+}
+
+</script>
+</body>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/clicking-noninteractive-labelable-content.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/clicking-noninteractive-labelable-content.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Label event handling when a descendant labelable but not interactive element is clicked</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<label id=label></label>
+<template id=labelable-not-interactive-content>
+  <meter></meter>
+  <output></output>
+  <progress></progress>
+</template>
+
+<script>
+"use strict";
+
+const labelableNotInteractiveElements =
+  Array.from(document.getElementById("labelable-not-interactive-content").content.children);
+const label = document.getElementById("label");
+
+// This part is may be subject to platform-dependent operations in the spec, so we only check for obvious errors.
+// (Clicking once should register at least one click, but less than 30 clicks.)
+// See https://github.com/whatwg/html/issues/5415 for tightening this up.
+function checkClickCount(clicked, description) {
+  assert_greater_than(clicked, 0, description);
+  assert_less_than(clicked, 30, description);
+}
+
+for (const srcElement of labelableNotInteractiveElements) {
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const element = srcElement.cloneNode();
+    label.appendChild(element);
+
+    let clicked = 0;
+    element.addEventListener("click", () => {
+      clicked++;
+    });
+    element.click();
+    checkClickCount(clicked, "clicking labelable content");
+
+    clicked = 0;
+    const span = document.createElement("span");
+    element.appendChild(span);
+    span.click();
+    checkClickCount(clicked, "clicking descendant of labelable content");
+  }, `labelable element ${srcElement.outerHTML} as first child of <label>`);
+
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const element = srcElement.cloneNode();
+    const div = document.createElement("div");
+    div.appendChild(element);
+    label.appendChild(div);
+
+    let clicked = 0;
+    element.addEventListener("click", () => {
+      clicked++;
+    });
+    element.click();
+    checkClickCount(clicked, "clicking nested labelable content");
+
+    clicked = 0;
+    const span = document.createElement("span");
+    element.appendChild(span);
+    span.click();
+    checkClickCount(clicked, "clicking descendant of nested labelable content");
+  }, `labelable element ${srcElement.outerHTML} deeply nested under <label>`);
+
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const button = document.createElement("button");
+    label.appendChild(button);
+
+    const element = srcElement.cloneNode();
+    label.appendChild(element);
+
+    let buttonClicked = 0;
+    button.addEventListener("click", () => {
+      buttonClicked++;
+    });
+
+    let clicked = 0;
+    element.addEventListener("click", () => {
+      clicked++;
+    });
+    element.click();
+    assert_equals(clicked, 1, "clicking nested labelable content");
+    assert_equals(buttonClicked, 1, "clicking nested labelable content should click button");
+
+    buttonClicked = 0;
+    clicked = 0;
+    const span = document.createElement("span");
+    element.appendChild(span);
+    span.click();
+    assert_equals(clicked, 1, "clicking descendant of nested labelable content");
+    assert_equals(buttonClicked, 1, "clicking descendant of nested labelable content should not click button");
+  }, `labelable element ${srcElement.outerHTML} as second child under <label>`);
+}
+
+</script>
+</body>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/clicking-noninteractive-unlabelable-content.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/clicking-noninteractive-unlabelable-content.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Label event handling when a descendant noninteractive and unlabelable content is clicked</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<label id=label></label>
+<template id=noninteractive-unlabelable-content>
+  <div></div>
+  <svg></svg>
+</template>
+
+<script>
+"use strict";
+
+const template = document.getElementById("noninteractive-unlabelable-content");
+{
+  const details = document.createElementNS("http://www.w3.org/2000/svg", "details");
+  template.content.appendChild(details);
+}
+
+const elements = Array.from(template.content.children);
+const label = document.getElementById("label");
+
+for (const srcElement of elements) {
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const element = srcElement.cloneNode();
+    label.appendChild(element);
+
+    let clicked = 0;
+    element.addEventListener("click", () => {
+      clicked++;
+    });
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    assert_equals(clicked, 1, "clicking interactive content");
+
+    clicked = 0;
+    const span = document.createElement("span");
+    element.appendChild(span);
+    span.click();
+    assert_equals(clicked, 1, "clicking descendant of interactive content");
+  }, `noninteractive unlabelable content ${srcElement.outerHTML} as first child of <label>`);
+
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const element = srcElement.cloneNode();
+    const div = document.createElement("div");
+    div.appendChild(element);
+    label.appendChild(div);
+
+    let clicked = 0;
+    element.addEventListener("click", () => {
+      clicked++;
+    });
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    assert_equals(clicked, 1, "clicking nested interactive content");
+
+    clicked = 0;
+    const span = document.createElement("span");
+    element.appendChild(span);
+    span.click();
+    assert_equals(clicked, 1, "clicking descendant of nested interactive content");
+  }, `noninteractive unlabelable content ${srcElement.outerHTML} deeply nested under <label>`);
+
+  test(t => {
+    t.add_cleanup(() => {
+      label.innerHTML = "";
+    });
+
+    const button = document.createElement("button");
+    label.appendChild(button);
+
+    const element = srcElement.cloneNode();
+    label.appendChild(element);
+
+    let buttonClicked = 0;
+    button.addEventListener("click", () => {
+      buttonClicked++;
+    });
+
+    let clicked = 0;
+    element.addEventListener("click", () => {
+      clicked++;
+    });
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    assert_equals(clicked, 1, "clicking noninteractive unlabelable content");
+    assert_equals(buttonClicked, 1, "clicking noninteractive unlabelable content should click button");
+
+    buttonClicked = 0;
+    clicked = 0;
+    const span = document.createElement("span");
+    element.appendChild(span);
+    span.click();
+    assert_equals(clicked, 1, "clicking descendant of nested noninteractive unlabelable content");
+    assert_equals(
+      buttonClicked, 1,
+      "clicking descendant of nested noninteractive unlabelable content should click button"
+    );
+  }, `noninteractive unlabelable content ${srcElement.outerHTML} as second child under <label>`);
+}
+
+</script>
+</body>
+


### PR DESCRIPTION
This commit deals with two cases where the current activation behavior for `<label>` elements is deficient:

- When the target of the event that triggered said activation behavior is in fact part of some interactive content descendant of the `<label>`, then nothing should be done.

- When the target of the event is an inclusive descendant of the labeled control, then the control presumably has already received this event, so nothing more should be done by the `<label>` element.

The former case is specifically treated by the spec as a no-op case, under https://html.spec.whatwg.org/C/#the-label-element. This applies to such trees as

```html
<label>
  <button>Click me!</button>
</label>
```

Since the `<button>` is labelable, if upon clicking the button the `<label>` element tries to click the button once again, then an infinite recursion would result. This is indeed the essence of #2717.

The latter case is not mentioned in the spec directly, but is implemented by all major browsers. Consider instead the following tree:

```html
<label>
  <progress>Click me too!</progress>
</label>
```

The `<progress>` element is not interactive, and therefore does not fall under the jurisdiction of the previous case. But it is still labelable, and is the labeled control of the `<label>` element. So when the `<progress>` element is clicked, the `<label>` should also avoid trying to click the `<progress>` in a way that would result in infinite recursion.

It may first appear that the first case is a special case of the second; indeed, the example above with a single button would fall into the second case also. But this is not true in general. Consider instead:

```html
<label>
  <button>Don't click me!</button>
  <button>Click me!</button>
</label>
```

If the second button is clicked, then this falls into the first case but not the second. But we still need to prevent the `<label>` from clicking the first button (the actual labeled control) instead.

Fixes #2717.

---

Tests will be upstreamed through the Chromium project.