### PR TITLE
feat: Add TextEncoder and TextDecoder 

### DIFF
--- a/lib/jsdom/living/encoding/TextDecoder-impl.js
+++ b/lib/jsdom/living/encoding/TextDecoder-impl.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const hasNode10 = process.versions.node && Number(process.versions.node.split(".")[0]) === 10;
+const { TextDecoder } = !hasNode10 ? global : require("text-encoding");
+
+exports.implementation = class TextDecoderImpl {
+  constructor(globalObject, args) {
+    this._internal = new TextDecoder(...args);
+  }
+
+  get encoding() {
+    return this._internal._encoding;
+  }
+
+  get fatal() {
+    return this._internal._fatal;
+  }
+
+  get ignoreBOM() {
+    return this._internal._ignoreBOM;
+  }
+
+  decode(input, options) {
+    return this._internal.decode(input, options);
+  }
+};

--- a/lib/jsdom/living/encoding/TextDecoder.webidl
+++ b/lib/jsdom/living/encoding/TextDecoder.webidl
@@ -1,0 +1,18 @@
+// https://www.w3.org/TR/encoding/#interface-textdecoder
+[Exposed=(Window,Worker)]
+interface TextDecoder {
+  constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options);
+  readonly attribute DOMString encoding;
+  readonly attribute boolean fatal;
+  readonly attribute boolean ignoreBOM;
+  USVString decode(optional BufferSource input, optional TextDecodeOptions options);
+};
+
+dictionary TextDecoderOptions {
+  boolean fatal = false;
+  boolean ignoreBOM = false;
+};
+
+dictionary TextDecodeOptions {
+  boolean stream = false;
+};

--- a/lib/jsdom/living/encoding/TextEncoder-impl.js
+++ b/lib/jsdom/living/encoding/TextEncoder-impl.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const hasNode10 = process.versions.node && Number(process.versions.node.split(".")[0]) === 10;
+const { TextEncoder } = !hasNode10 ? global : require("text-encoding");
+
+exports.implementation = class TextEncoderImpl {
+  constructor() {
+    this._internal = new TextEncoder();
+  }
+
+  get encoding() {
+    return this._internal.encoding;
+  }
+
+  encode(input = "") {
+    return this._internal.encode(input);
+  }
+};

--- a/lib/jsdom/living/encoding/TextEncoder.webidl
+++ b/lib/jsdom/living/encoding/TextEncoder.webidl
@@ -1,0 +1,7 @@
+// https://www.w3.org/TR/encoding/#interface-textencoder
+[Exposed=(Window,Worker)]
+interface TextEncoder {
+  constructor();
+  readonly attribute DOMString encoding;
+  [NewObject] Uint8Array encode(optional USVString input = "");
+};

--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -185,7 +185,10 @@ const generatedInterfaces = {
 
   Headers: require("./generated/Headers"),
   AbortController: require("./generated/AbortController"),
-  AbortSignal: require("./generated/AbortSignal")
+  AbortSignal: require("./generated/AbortSignal"),
+
+  TextEncoder: require("./generated/TextEncoder"),
+  TextDecoder: require("./generated/TextDecoder")
 };
 
 function install(window, name, interfaceConstructor) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "request-promise-native": "^1.0.8",
     "saxes": "^5.0.0",
     "symbol-tree": "^3.2.4",
+    "text-encoding": "^0.7.0",
     "tough-cookie": "^3.0.1",
     "w3c-hr-time": "^1.0.2",
     "w3c-xmlserializer": "^2.0.0",

--- a/scripts/webidl/convert.js
+++ b/scripts/webidl/convert.js
@@ -159,6 +159,7 @@ addDir("../../lib/jsdom/living/nodes");
 addDir("../../lib/jsdom/living/range");
 addDir("../../lib/jsdom/living/selection");
 addDir("../../lib/jsdom/living/svg");
+addDir("../../lib/jsdom/living/encoding");
 addDir("../../lib/jsdom/living/traversal");
 addDir("../../lib/jsdom/living/websockets");
 addDir("../../lib/jsdom/living/webstorage");

--- a/test/api/text-encoding.js
+++ b/test/api/text-encoding.js
@@ -1,0 +1,47 @@
+"use strict";
+const { assert } = require("chai");
+const { describe, it } = require("mocha-sugar-free");
+const { JSDOM } = require("../..");
+
+const testString = "Hello, World";
+const testBuffer = new Uint8Array([72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100]);
+
+function equalBuffer(buf1, buf2) {
+  if (buf1.byteLength !== buf2.byteLength) {
+    return false;
+  }
+  for (let i = 0; i !== buf1.byteLength; i++) {
+    if (buf1[i] !== buf2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+describe("API: encoding", { skipIfBrowser: true }, () => {
+  it("should have encoding set to 'utf-8'", () => {
+    const dom = new JSDOM();
+
+    const { TextEncoder } = dom.window;
+    const textEncoder = new TextEncoder();
+    assert.strictEqual(textEncoder.encoding, "utf-8");
+  });
+  it("should encode correctly to Uint8Array", () => {
+    const dom = new JSDOM();
+
+    const { TextEncoder } = dom.window;
+    const textEncoder = new TextEncoder();
+    const buffer = textEncoder.encode(testString);
+    assert.strictEqual(equalBuffer(buffer, testBuffer), true);
+    assert.strictEqual(equalBuffer(buffer, new Uint8Array()), false);
+  });
+  it("should decode correctly from Uint8Array", () => {
+    const dom = new JSDOM();
+
+    const { TextDecoder } = dom.window;
+    const textDecoder = new TextDecoder("utf-8");
+    const str = textDecoder.decode(testBuffer);
+    assert.strictEqual(str, testString);
+    assert.notEqual(str, "testString");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4390,6 +4390,11 @@ tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+text-encoding@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
+  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
This aims at addressing the lack of TextEncoder and TextDecoder.
This PR relies on the Node native object when present and utilises `text-encoding` package for Node 10. 

Closes #2524