### PR TITLE
Document need for URLs when loading subresources

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ By default, jsdom will not load any subresources such as scripts, stylesheets, i
 * Scripts, via `<script>`, but only if `runScripts: "dangerously"` is also set
 * Images, via `<img>`, but only if the `canvas` npm package is also installed (see "[Canvas Support](#canvas-support)" below)
 
+Resources must have a fully-qualified URL or `url` option must be set in `JSDOM` constructor if URLs are relative.
+
 #### Advanced configuration
 
 _This resource loader system is new as of jsdom v12.0.0, and we'd love your feedback on whether it meets your needs and how easy it is to use. Please file an issue to discuss!_


### PR DESCRIPTION
This PR adds a line to README stating that when loading subresources, they must be fully qualified URLs, or `url` option in JS DOM constructor must be used.

This may seem obvious, but it wasn't the case in JSDOM 15, so it tripped me up when I upgraded.

In JSDOM 15 `<script src="/bundle.js"></script>` in a DOM instance with no `url` defined would cause a custom `ResourceLoader` to have its `.fetch()` method called with url `/bundle.js`.

In JSDOM 16 `.fetch()` is not called and there is no error or console output to indicate that/why it's failed.

I'm not sure if silent failure is the desired behavior or not, but since it's changed, I thought it'd be good to document it so others don't hit the same problem when upgrading.

But if you feel the docs are too crowded already, feel free to reject this PR.