### PR TITLE
Convert JSDOM to use callback functions

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -27,6 +27,7 @@ const Screen = require("../living/generated/Screen");
 const Storage = require("../living/generated/Storage");
 const Selection = require("../living/generated/Selection");
 const reportException = require("../living/helpers/runtime-script-errors");
+const { getCurrentEventHandlerValue } = require("../living/helpers/create-event-accessor.js");
 const { fireAnEvent } = require("../living/helpers/events");
 const SessionHistory = require("../living/window/SessionHistory");
 const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented,
@@ -156,9 +157,12 @@ function setupWindow(windowInstance, { runScripts }) {
   mixin(windowInstance, GlobalEventHandlersImpl.prototype);
   windowInstance._initGlobalEvents();
 
-  // The getters are already obtained from the above mixins.
-  // eslint-disable-next-line accessor-pairs
   Object.defineProperty(windowInstance, "onbeforeunload", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(this, "beforeunload"));
+    },
     set(V) {
       if (!idlUtils.isObject(V)) {
         V = null;
@@ -171,9 +175,12 @@ function setupWindow(windowInstance, { runScripts }) {
     }
   });
 
-  // The getters are already obtained from the above mixins.
-  // eslint-disable-next-line accessor-pairs
   Object.defineProperty(windowInstance, "onerror", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(this, "error"));
+    },
     set(V) {
       if (!idlUtils.isObject(V)) {
         V = null;
@@ -187,9 +194,12 @@ function setupWindow(windowInstance, { runScripts }) {
   });
 
   for (const event of events) {
-    // The getters are already obtained from the above mixins.
-    // eslint-disable-next-line accessor-pairs
     Object.defineProperty(windowInstance, `on${event}`, {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(this, event));
+      },
       set(V) {
         if (!idlUtils.isObject(V)) {
           V = null;

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -8,6 +8,9 @@ const { installInterfaces } = require("../living/interfaces");
 const { define, mixin } = require("../utils");
 const Element = require("../living/generated/Element");
 const EventTarget = require("../living/generated/EventTarget");
+const EventHandlerNonNull = require("../living/generated/EventHandlerNonNull");
+const OnBeforeUnloadEventHandlerNonNull = require("../living/generated/OnBeforeUnloadEventHandlerNonNull");
+const OnErrorEventHandlerNonNull = require("../living/generated/OnErrorEventHandlerNonNull");
 const PageTransitionEvent = require("../living/generated/PageTransitionEvent");
 const namedPropertiesWindow = require("../living/named-properties-window");
 const postMessage = require("../living/post-message");
@@ -33,6 +36,59 @@ const jsGlobals = require("./js-globals.json");
 
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
+
+const events = new Set([
+  // GlobalEventHandlers
+  "abort", "autocomplete",
+  "autocompleteerror", "blur",
+  "cancel", "canplay", "canplaythrough",
+  "change", "click",
+  "close", "contextmenu",
+  "cuechange", "dblclick",
+  "drag", "dragend",
+  "dragenter",
+  "dragleave", "dragover",
+  "dragstart", "drop",
+  "durationchange", "emptied",
+  "ended", "focus",
+  "input", "invalid",
+  "keydown", "keypress",
+  "keyup", "load", "loadeddata",
+  "loadedmetadata", "loadstart",
+  "mousedown", "mouseenter",
+  "mouseleave", "mousemove",
+  "mouseout", "mouseover",
+  "mouseup", "wheel",
+  "pause", "play",
+  "playing", "progress",
+  "ratechange", "reset",
+  "resize", "scroll",
+  "securitypolicyviolation",
+  "seeked", "seeking",
+  "select", "sort", "stalled",
+  "submit", "suspend",
+  "timeupdate", "toggle",
+  "volumechange", "waiting",
+
+  // WindowEventHandlers
+  "afterprint",
+  "beforeprint",
+  "hashchange",
+  "languagechange",
+  "message",
+  "messageerror",
+  "offline",
+  "online",
+  "pagehide",
+  "pageshow",
+  "popstate",
+  "rejectionhandled",
+  "storage",
+  "unhandledrejection",
+  "unload"
+
+  // "error" and "beforeunload" are added separately
+]);
 
 exports.createWindow = function (options) {
   return new Window(options);
@@ -99,6 +155,53 @@ function setupWindow(windowInstance, { runScripts }) {
   mixin(windowInstance, WindowEventHandlersImpl.prototype);
   mixin(windowInstance, GlobalEventHandlersImpl.prototype);
   windowInstance._initGlobalEvents();
+
+  // The getters are already obtained from the above mixins.
+  // eslint-disable-next-line accessor-pairs
+  Object.defineProperty(windowInstance, "onbeforeunload", {
+    set(V) {
+      if (!idlUtils.isObject(V)) {
+        V = null;
+      } else {
+        V = OnBeforeUnloadEventHandlerNonNull.convert(V, {
+          context: "Failed to set the 'onbeforeunload' property on 'Window': The provided value"
+        });
+      }
+      this._setEventHandlerFor("beforeunload", V);
+    }
+  });
+
+  // The getters are already obtained from the above mixins.
+  // eslint-disable-next-line accessor-pairs
+  Object.defineProperty(windowInstance, "onerror", {
+    set(V) {
+      if (!idlUtils.isObject(V)) {
+        V = null;
+      } else {
+        V = OnErrorEventHandlerNonNull.convert(V, {
+          context: "Failed to set the 'onerror' property on 'Window': The provided value"
+        });
+      }
+      this._setEventHandlerFor("error", V);
+    }
+  });
+
+  for (const event of events) {
+    // The getters are already obtained from the above mixins.
+    // eslint-disable-next-line accessor-pairs
+    Object.defineProperty(windowInstance, `on${event}`, {
+      set(V) {
+        if (!idlUtils.isObject(V)) {
+          V = null;
+        } else {
+          V = EventHandlerNonNull.convert(V, {
+            context: `Failed to set the 'on${event}' property on 'Window': The provided value`
+          });
+        }
+        this._setEventHandlerFor(event, V);
+      }
+    });
+  }
 
   windowInstance._globalObject = windowInstance;
 }

--- a/lib/jsdom/living/custom-elements/CustomElementRegistry-impl.js
+++ b/lib/jsdom/living/custom-elements/CustomElementRegistry-impl.js
@@ -11,6 +11,7 @@ const { shadowIncludingInclusiveDescendantsIterator } = require("../helpers/shad
 const { isValidCustomElementName, tryUpgradeElement, enqueueCEUpgradeReaction } = require("../helpers/custom-elements");
 
 const idlUtils = require("../generated/utils");
+const IDLFunction = require("../generated/Function.js");
 const HTMLUnknownElement = require("../generated/HTMLUnknownElement");
 
 const LIFECYCLE_CALLBACKS = [
@@ -62,8 +63,9 @@ class CustomElementRegistryImpl {
   }
 
   // https://html.spec.whatwg.org/#dom-customelementregistry-define
-  define(name, ctor, options) {
+  define(name, constructor, options) {
     const { _globalObject } = this;
+    const ctor = constructor.objectReference;
 
     if (!isConstructor(ctor)) {
       throw new TypeError("Constructor argument is not a constructor.");
@@ -81,7 +83,7 @@ class CustomElementRegistryImpl {
       ]);
     }
 
-    const ctorAlreadyRegistered = this._customElementDefinitions.some(entry => entry.ctor === ctor);
+    const ctorAlreadyRegistered = this._customElementDefinitions.some(entry => entry.objectReference === ctor);
     if (ctorAlreadyRegistered) {
       throw DOMException.create(_globalObject, [
         "This constructor has already been registered in the registry.",
@@ -145,7 +147,9 @@ class CustomElementRegistryImpl {
         const callbackValue = prototype[callbackName];
 
         if (callbackValue !== undefined) {
-          lifecycleCallbacks[callbackName] = webIDLConversions.Function(callbackValue);
+          lifecycleCallbacks[callbackName] = IDLFunction.convert(callbackValue, {
+            context: `The lifecycle callback "${callbackName}"`
+          });
         }
       }
 
@@ -177,7 +181,8 @@ class CustomElementRegistryImpl {
     const definition = {
       name,
       localName,
-      ctor,
+      constructor,
+      objectReference: ctor,
       observedAttributes,
       lifecycleCallbacks,
       disableShadow,

--- a/lib/jsdom/living/custom-elements/CustomElementRegistry.webidl
+++ b/lib/jsdom/living/custom-elements/CustomElementRegistry.webidl
@@ -1,6 +1,6 @@
 [Exposed=Window]
 interface CustomElementRegistry {
-  [CEReactions] void define(DOMString name, CustomElementConstructor constructor, optional ElementDefinitionOptions options);
+  [CEReactions] void define(DOMString name, CustomElementConstructor constructor, optional ElementDefinitionOptions options = {});
   any get(DOMString name);
   Promise<void> whenDefined(DOMString name);
   [CEReactions] void upgrade(Node root);

--- a/lib/jsdom/living/events/CloseEvent.webidl
+++ b/lib/jsdom/living/events/CloseEvent.webidl
@@ -1,7 +1,7 @@
 // https://html.spec.whatwg.org/multipage/web-sockets.html#the-closeevent-interface
 [Exposed=(Window,Worker)]
 interface CloseEvent : Event {
-  constructor(DOMString type, optional CloseEventInit eventInitDict);
+  constructor(DOMString type, optional CloseEventInit eventInitDict = {});
 
   readonly attribute boolean wasClean;
   readonly attribute unsigned short code;

--- a/lib/jsdom/living/events/event-handlers.webidl
+++ b/lib/jsdom/living/events/event-handlers.webidl
@@ -1,0 +1,20 @@
+// https://html.spec.whatwg.org/multipage/webappapis.html#eventhandlernonnull
+[LegacyTreatNonObjectAsNull]
+callback EventHandlerNonNull = any (Event event);
+typedef EventHandlerNonNull? EventHandler;
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#onerroreventhandlernonnull
+[LegacyTreatNonObjectAsNull]
+callback OnErrorEventHandlerNonNull = any (
+  (Event or DOMString) event,
+  optional DOMString source,
+  optional unsigned long lineno,
+  optional unsigned long colno,
+  optional any error
+);
+typedef OnErrorEventHandlerNonNull? OnErrorEventHandler;
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#onbeforeunloadeventhandlernonnull
+[LegacyTreatNonObjectAsNull]
+callback OnBeforeUnloadEventHandlerNonNull = DOMString? (Event event);
+typedef OnBeforeUnloadEventHandlerNonNull? OnBeforeUnloadEventHandler;

--- a/lib/jsdom/living/helpers/create-element.js
+++ b/lib/jsdom/living/helpers/create-element.js
@@ -199,9 +199,9 @@ function createElement(
   } else if (definition !== null) {
     if (synchronousCE) {
       try {
-        const C = definition.ctor;
+        const C = definition.constructor;
 
-        const resultWrapper = new C();
+        const resultWrapper = C.construct();
         result = implForWrapper(resultWrapper);
 
         if (!result._ceState || !result._ceDefinition || result._namespaceURI !== HTML_NS) {

--- a/lib/jsdom/living/helpers/create-event-accessor.js
+++ b/lib/jsdom/living/helpers/create-event-accessor.js
@@ -7,11 +7,11 @@ const OnBeforeUnloadEventHandlerNonNull = require("../generated/OnBeforeUnloadEv
 const OnErrorEventHandlerNonNull = require("../generated/OnErrorEventHandlerNonNull.js");
 const reportException = require("./runtime-script-errors");
 
-exports.appendHandler = function appendHandler(el, eventName) {
+exports.appendHandler = (el, eventName) => {
   // tryImplForWrapper() is currently required due to use in Window.js
   idlUtils.tryImplForWrapper(el).addEventListener(eventName, event => {
     // https://html.spec.whatwg.org/#the-event-handler-processing-algorithm
-    const callback = el["on" + eventName];
+    const callback = exports.getCurrentEventHandlerValue(el, eventName);
     if (callback === null) {
       return;
     }
@@ -74,103 +74,106 @@ exports.setupForSimpleEventAccessors = (prototype, events) => {
   }
 };
 
-// https://html.spec.whatwg.org/#event-handler-idl-attributes
-exports.createEventAccessor = function createEventAccessor(obj, event) {
+// https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler
+exports.getCurrentEventHandlerValue = (target, event) => {
+  const value = target._getEventHandlerFor(event);
+  if (!value) {
+    return null;
+  }
+
+  if (value.body !== undefined) {
+    let element;
+    let document;
+    if (target.constructor.name === "Window") {
+      element = null;
+      document = idlUtils.implForWrapper(target.document);
+    } else {
+      element = target;
+      document = element.ownerDocument;
+    }
+    const { body } = value;
+
+    const formOwner = element !== null && element.form ? element.form : null;
+    const window = target.constructor.name === "Window" && target._document ? target : document.defaultView;
+
+    try {
+      // eslint-disable-next-line no-new-func
+      Function(body); // properly error out on syntax errors
+      // Note: this won't execute body; that would require `Function(body)()`.
+    } catch (e) {
+      if (window) {
+        reportException(window, e);
+      }
+      target._setEventHandlerFor(event, null);
+      return null;
+    }
+
+    // Note: the with (window) { } is not necessary in Node, but is necessary in a browserified environment.
+
+    let fn;
+    const createFunction = document.defaultView.Function;
+    if (event === "error" && element === null) {
+      const wrapperBody = document ? body + `\n//# sourceURL=${document.URL}` : body;
+
+      // eslint-disable-next-line no-new-func
+      fn = createFunction("window", `with (window) { return function onerror(event, source, lineno, colno, error) {
+  ${wrapperBody}
+}; }`)(window);
+
+      fn = OnErrorEventHandlerNonNull.convert(fn);
+    } else {
+      const argNames = [];
+      const args = [];
+
+      argNames.push("window");
+      args.push(window);
+
+      if (element !== null) {
+        argNames.push("document");
+        args.push(idlUtils.wrapperForImpl(document));
+      }
+      if (formOwner !== null) {
+        argNames.push("formOwner");
+        args.push(idlUtils.wrapperForImpl(formOwner));
+      }
+      if (element !== null) {
+        argNames.push("element");
+        args.push(idlUtils.wrapperForImpl(element));
+      }
+      let wrapperBody = `
+return function on${event}(event) {
+  ${body}
+};`;
+      for (let i = argNames.length - 1; i >= 0; --i) {
+        wrapperBody = `with (${argNames[i]}) { ${wrapperBody} }`;
+      }
+      if (document) {
+        wrapperBody += `\n//# sourceURL=${document.URL}`;
+      }
+      argNames.push(wrapperBody);
+      fn = createFunction(...argNames)(...args);
+
+      if (event === "beforeunload") {
+        fn = OnBeforeUnloadEventHandlerNonNull.convert(fn);
+      } else {
+        fn = EventHandlerNonNull.convert(fn);
+      }
+    }
+
+    target._setEventHandlerFor(event, fn);
+  }
+
+  return target._getEventHandlerFor(event);
+};
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes
+// TODO: Consider replacing this with `[ReflectEvent]`
+exports.createEventAccessor = (obj, event) => {
   Object.defineProperty(obj, "on" + event, {
     configurable: true,
     enumerable: true,
     get() {
-      // TODO: Extract this into a helper function
-      // https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler
-      const value = this._getEventHandlerFor(event);
-      if (!value) {
-        return null;
-      }
-
-      if (value.body !== undefined) {
-        let element;
-        let document;
-        if (this.constructor.name === "Window") {
-          element = null;
-          document = idlUtils.implForWrapper(this.document);
-        } else {
-          element = this;
-          document = element.ownerDocument;
-        }
-        const { body } = value;
-
-        const formOwner = element !== null && element.form ? element.form : null;
-        const window = this.constructor.name === "Window" && this._document ? this : document.defaultView;
-
-        try {
-          // eslint-disable-next-line no-new-func
-          Function(body); // properly error out on syntax errors
-          // Note: this won't execute body; that would require `Function(body)()`.
-        } catch (e) {
-          if (window) {
-            reportException(window, e);
-          }
-          this._setEventHandlerFor(event, null);
-          return null;
-        }
-
-        // Note: the with (window) { } is not necessary in Node, but is necessary in a browserified environment.
-
-        let fn;
-        const createFunction = document.defaultView.Function;
-        if (event === "error" && element === null) {
-          const wrapperBody = document ? body + `\n//# sourceURL=${document.URL}` : body;
-
-          // eslint-disable-next-line no-new-func
-          fn = createFunction("window", `with (window) { return function onerror(event, source, lineno, colno, error) {
-  ${wrapperBody}
-}; }`)(window);
-
-          fn = OnErrorEventHandlerNonNull.convert(fn);
-        } else {
-          const argNames = [];
-          const args = [];
-
-          argNames.push("window");
-          args.push(window);
-
-          if (element !== null) {
-            argNames.push("document");
-            args.push(idlUtils.wrapperForImpl(document));
-          }
-          if (formOwner !== null) {
-            argNames.push("formOwner");
-            args.push(idlUtils.wrapperForImpl(formOwner));
-          }
-          if (element !== null) {
-            argNames.push("element");
-            args.push(idlUtils.wrapperForImpl(element));
-          }
-          let wrapperBody = `
-return function on${event}(event) {
-  ${body}
-};`;
-          for (let i = argNames.length - 1; i >= 0; --i) {
-            wrapperBody = `with (${argNames[i]}) { ${wrapperBody} }`;
-          }
-          if (document) {
-            wrapperBody += `\n//# sourceURL=${document.URL}`;
-          }
-          argNames.push(wrapperBody);
-          fn = createFunction(...argNames)(...args);
-
-          if (event === "beforeunload") {
-            fn = OnBeforeUnloadEventHandlerNonNull.convert(fn);
-          } else {
-            fn = EventHandlerNonNull.convert(fn);
-          }
-        }
-
-        this._setEventHandlerFor(event, fn);
-      }
-
-      // tryWrapperForImpl() is currently required due to use in Window.js
-      return idlUtils.tryWrapperForImpl(this._getEventHandlerFor(event));
+      return exports.getCurrentEventHandlerValue(this, event);
     },
     set(val) {
       this._setEventHandlerFor(event, val);

--- a/lib/jsdom/living/helpers/create-event-accessor.js
+++ b/lib/jsdom/living/helpers/create-event-accessor.js
@@ -1,8 +1,10 @@
 "use strict";
 
-const conversions = require("webidl-conversions");
 const idlUtils = require("../generated/utils");
 const ErrorEvent = require("../generated/ErrorEvent");
+const EventHandlerNonNull = require("../generated/EventHandlerNonNull.js");
+const OnBeforeUnloadEventHandlerNonNull = require("../generated/OnBeforeUnloadEventHandlerNonNull.js");
+const OnErrorEventHandlerNonNull = require("../generated/OnErrorEventHandlerNonNull.js");
 const reportException = require("./runtime-script-errors");
 
 exports.appendHandler = function appendHandler(el, eventName) {
@@ -18,25 +20,20 @@ exports.appendHandler = function appendHandler(el, eventName) {
       event.currentTarget.constructor.name === "Window";
 
     let returnValue = null;
-    const thisValue = idlUtils.tryWrapperForImpl(event.currentTarget);
     // https://heycam.github.io/webidl/#es-invoking-callback-functions
     if (typeof callback === "function") {
       if (specialError) {
         returnValue = callback.call(
-          thisValue, event.message,
+          event.currentTarget, event.message,
           event.filename, event.lineno, event.colno, event.error
         );
       } else {
-        // This will no longer be necessary once EventHandler and Window are implemented in IDL:
-        const eventWrapper = idlUtils.wrapperForImpl(event);
-        returnValue = callback.call(thisValue, eventWrapper);
+        returnValue = callback.call(event.currentTarget, event);
       }
     }
 
-    if (event.type === "beforeunload") { // TODO: we don't implement BeforeUnloadEvent so we can't brand-check here
-      // Perform conversion which in the spec is done by the event handler return type being DOMString?
-      returnValue = returnValue === undefined || returnValue === null ? null : conversions.DOMString(returnValue);
-
+    // TODO: we don't implement BeforeUnloadEvent so we can't brand-check here
+    if (event.type === "beforeunload") {
       if (returnValue !== null) {
         event._canceledFlag = true;
         if (event.returnValue === "") {
@@ -82,7 +79,9 @@ exports.createEventAccessor = function createEventAccessor(obj, event) {
   Object.defineProperty(obj, "on" + event, {
     configurable: true,
     enumerable: true,
-    get() { // https://html.spec.whatwg.org/#getting-the-current-value-of-the-event-handler
+    get() {
+      // TODO: Extract this into a helper function
+      // https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler
       const value = this._getEventHandlerFor(event);
       if (!value) {
         return null;
@@ -126,6 +125,8 @@ exports.createEventAccessor = function createEventAccessor(obj, event) {
           fn = createFunction("window", `with (window) { return function onerror(event, source, lineno, colno, error) {
   ${wrapperBody}
 }; }`)(window);
+
+          fn = OnErrorEventHandlerNonNull.convert(fn);
         } else {
           const argNames = [];
           const args = [];
@@ -157,34 +158,22 @@ return function on${event}(event) {
           }
           argNames.push(wrapperBody);
           fn = createFunction(...argNames)(...args);
+
+          if (event === "beforeunload") {
+            fn = OnBeforeUnloadEventHandlerNonNull.convert(fn);
+          } else {
+            fn = EventHandlerNonNull.convert(fn);
+          }
         }
 
         this._setEventHandlerFor(event, fn);
       }
-      return this._getEventHandlerFor(event);
+
+      // tryWrapperForImpl() is currently required due to use in Window.js
+      return idlUtils.tryWrapperForImpl(this._getEventHandlerFor(event));
     },
     set(val) {
-      val = eventHandlerArgCoercion(val);
       this._setEventHandlerFor(event, val);
     }
   });
 };
-
-function typeIsObject(v) {
-  return (typeof v === "object" && v !== null) || typeof v === "function";
-}
-
-// Implements:
-//     [TreatNonObjectAsNull]
-//     callback EventHandlerNonNull = any (Event event);
-//     typedef EventHandlerNonNull? EventHandler;
-// Also implements the part of https://heycam.github.io/webidl/#es-invoking-callback-functions which treats
-// non-callable callback functions as callback functions that return undefined.
-// TODO: replace with webidl2js typechecking when it has sufficient callback support
-function eventHandlerArgCoercion(val) {
-  if (!typeIsObject(val)) {
-    return null;
-  }
-
-  return val;
-}

--- a/lib/jsdom/living/helpers/custom-elements.js
+++ b/lib/jsdom/living/helpers/custom-elements.js
@@ -94,7 +94,7 @@ function upgradeElement(definition, element) {
 
   definition.constructionStack.push(element);
 
-  const { constructionStack, ctor: C } = definition;
+  const { constructionStack, constructor: C } = definition;
 
   let constructionError;
   try {
@@ -105,7 +105,7 @@ function upgradeElement(definition, element) {
       ]);
     }
 
-    const constructionResult = new C();
+    const constructionResult = C.construct();
     const constructionResultImpl = implForWrapper(constructionResult);
 
     if (constructionResultImpl !== element) {

--- a/lib/jsdom/living/helpers/html-constructor.js
+++ b/lib/jsdom/living/helpers/html-constructor.js
@@ -15,7 +15,7 @@ function HTMLConstructor(globalObject, constructorName, newTarget) {
     throw new TypeError("Invalid constructor");
   }
 
-  const definition = registry._customElementDefinitions.find(entry => entry.ctor === newTarget);
+  const definition = registry._customElementDefinitions.find(entry => entry.objectReference === newTarget);
   if (definition === undefined) {
     throw new TypeError("Invalid constructor, the constructor is not part of the custom element registry");
   }

--- a/lib/jsdom/living/mutation-observer/MutationObserver.webidl
+++ b/lib/jsdom/living/mutation-observer/MutationObserver.webidl
@@ -3,7 +3,7 @@
 interface MutationObserver {
   constructor(MutationCallback callback);
 
-  void observe(Node target, optional MutationObserverInit options);
+  void observe(Node target, optional MutationObserverInit options = {});
   void disconnect();
   sequence<MutationRecord> takeRecords();
 };

--- a/lib/jsdom/living/nodes/DOMStringMap.webidl
+++ b/lib/jsdom/living/nodes/DOMStringMap.webidl
@@ -2,7 +2,7 @@
 [Exposed=Window,
  LegacyOverrideBuiltins]
 interface DOMStringMap {
-  [WebIDL2JSValueAsUnsupported=undefined] getter DOMString (DOMString name);
+  [WebIDL2JSValueAsUnsupported=_undefined] getter DOMString (DOMString name);
   [CEReactions] setter void (DOMString name, DOMString value);
   [CEReactions] deleter void (DOMString name);
 };

--- a/lib/jsdom/living/nodes/Element.webidl
+++ b/lib/jsdom/living/nodes/Element.webidl
@@ -74,11 +74,11 @@ partial interface Element {
   DOMRectList getClientRects();
   [NewObject] DOMRect getBoundingClientRect();
 //  void scrollIntoView(optional (boolean or ScrollIntoViewOptions) arg);
-//  void scroll(optional ScrollToOptions options);
+//  void scroll(optional ScrollToOptions options = {});
 //  void scroll(unrestricted double x, unrestricted double y);
-//  void scrollTo(optional ScrollToOptions options);
+//  void scrollTo(optional ScrollToOptions options = {});
 //  void scrollTo(unrestricted double x, unrestricted double y);
-//  void scrollBy(optional ScrollToOptions options);
+//  void scrollBy(optional ScrollToOptions options = {});
 //  void scrollBy(unrestricted double x, unrestricted double y);
   attribute unrestricted double scrollTop;
   attribute unrestricted double scrollLeft;

--- a/lib/jsdom/living/nodes/HTMLOrSVGElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement.webidl
@@ -5,7 +5,7 @@ interface mixin HTMLOrSVGElement {
 
   [CEReactions] attribute long tabIndex;
 //  We don't support FocusOptions yet
-//  void focus(optional FocusOptions options);
+//  void focus(optional FocusOptions options = {});
   void focus();
   void blur();
 };

--- a/lib/jsdom/living/nodes/HTMLSlotElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLSlotElement.webidl
@@ -2,8 +2,8 @@
  HTMLConstructor]
 interface HTMLSlotElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString name;
-  sequence<Node> assignedNodes(optional AssignedNodesOptions options);
-  sequence<Element> assignedElements(optional AssignedNodesOptions options);
+  sequence<Node> assignedNodes(optional AssignedNodesOptions options = {});
+  sequence<Element> assignedElements(optional AssignedNodesOptions options = {});
 };
 
 dictionary AssignedNodesOptions {

--- a/lib/jsdom/living/nodes/Node.webidl
+++ b/lib/jsdom/living/nodes/Node.webidl
@@ -19,7 +19,7 @@ interface Node : EventTarget {
 
   readonly attribute boolean isConnected;
   readonly attribute Document? ownerDocument;
-  Node getRootNode(optional GetRootNodeOptions options);
+  Node getRootNode(optional GetRootNodeOptions options = {});
   readonly attribute Node? parentNode;
   readonly attribute Element? parentElement;
   boolean hasChildNodes();

--- a/lib/jsdom/living/nodes/SVGGraphicsElement.webidl
+++ b/lib/jsdom/living/nodes/SVGGraphicsElement.webidl
@@ -10,7 +10,7 @@ dictionary SVGBoundingBoxOptions {
 interface SVGGraphicsElement : SVGElement {
   // [SameObject] readonly attribute SVGAnimatedTransformList transform;
 
-  // DOMRect getBBox(optional SVGBoundingBoxOptions options);
+  // DOMRect getBBox(optional SVGBoundingBoxOptions options = {});
   // DOMMatrix? getCTM();
   // DOMMatrix? getScreenCTM();
 };

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "st": "^2.0.0",
     "watchify": "^3.11.1",
     "wd": "^1.12.1",
-    "webidl2js": "^16.0.0"
+    "webidl2js": "^16.2.0"
   },
   "browser": {
     "canvas": false,

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -468,7 +468,6 @@ DIR: html/dom/elements/elements-in-the-dom
 
 DIR: html/dom/elements/global-attributes
 
-dataset-binding.window.html: [fail, Unknown]
 dataset-prototype.html: [fail, Tests Object.prototype which jsdom has trouble with due to VM globals]
 the-lang-attribute-001.html: [fail, Unknown]
 the-lang-attribute-002.html: [fail, Unknown]
@@ -1133,7 +1132,6 @@ unload-a-document/*: [timeout, Requires window.open]
 DIR: webstorage
 
 event_no_duplicates.html: [needs-node11, Earlier Node.js timers did not match browser behaviour, https://github.com/nodejs/node/pull/22842]
-set.window.html: [fail, Unknown]
 storage_local_window_open.html: [timeout, Depends on window.open()]
 storage_session_window_noopener.html: [fail, Depends on BroadcastChannel]
 storage_session_window_open.html: [timeout, Depends on window.open()]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4697,19 +4697,19 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webidl2@^23.11.0:
-  version "23.11.0"
-  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.11.0.tgz#3c3d492877c6b90171de4174e16b1e2b87f99267"
-  integrity sha512-JLWqpTKJZ9xMwool+DFLuDA+BPu44FRJunsmZeiPH2y2xRZwN8TGa7yryA5L2lTha+0C2PwLeROsWE2SDePjFw==
+webidl2@^23.12.1:
+  version "23.13.1"
+  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.13.1.tgz#e95aa32e40b2ef71c0f683ea16ddac9202956d98"
+  integrity sha512-u5njf3ZyqPr/4K8D6Cxm3B6MwSgwAdtrzxqHklwKaUdP1aQTmtKN5b65k4wlweJ/pRM6fpKUKYz8RlCJ9tka+w==
 
-webidl2js@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/webidl2js/-/webidl2js-16.0.0.tgz#21f304313e7665e24427f648ec46ac2346445f08"
-  integrity sha512-cgboeEe6297x9QSRp8CXKLKjADWHDIyTxFYs9ky63Ztui8tMOJxGpEpvYmHDikBkCHNwzeRBWSF40Dc0uCZMEg==
+webidl2js@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/webidl2js/-/webidl2js-16.2.0.tgz#70ec1e6877d42fd79ada24b574f60210bb7cc410"
+  integrity sha512-+ujeVqKYxe1efW1xmhS0rM4O1rqtoXOqBM3J96v/8SqID65Chwc9QotVaqCJtaIYqGa0B7lBn1kqUIXk52mgPw==
   dependencies:
     prettier "^2.0.4"
     webidl-conversions "^6.1.0"
-    webidl2 "^23.11.0"
+    webidl2 "^23.12.1"
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Depends on:

- [x] <https://github.com/jsdom/webidl2js/pull/194> (merged)
- [x] indirectly on <https://github.com/jsdom/jsdom/pull/2958> (as a result of <https://github.com/jsdom/webidl2js/pull/206> getting merged before <https://github.com/jsdom/webidl2js/pull/194>)

---

<details>
<summary><strong>Benchmark results</strong></summary>

| benchmark                                                                                    | `master`                                                                                        | `feat/use‑callback‑functions`
| ---------                                                                                    | --------                                                                                        | --------------------------------------
| dom/compare-document-position/compare&nbsp;ancestor                                          | jsdom  ×&nbsp;31,761&nbsp;ops/sec ±2.80%&nbsp;(10&nbsp;runs&nbsp;sampled)                       | jsdom  ×&nbsp;30,750&nbsp;ops/sec ±5.61%&nbsp;(9&nbsp;runs&nbsp;sampled)
| dom/compare-document-position/compare&nbsp;descendant                                        | jsdom  ×&nbsp;32,439&nbsp;ops/sec ±1.92%&nbsp;(10&nbsp;runs&nbsp;sampled)                       | jsdom  ×&nbsp;30,535&nbsp;ops/sec ±3.14%&nbsp;(9&nbsp;runs&nbsp;sampled)
| dom/compare-document-position/compare&nbsp;siblings                                          | jsdom  ×&nbsp;1,224,691&nbsp;ops/sec ±13.62%&nbsp;(10&nbsp;runs&nbsp;sampled)                   | jsdom  ×&nbsp;1,352,267&nbsp;ops/sec ±2.21%&nbsp;(10&nbsp;runs&nbsp;sampled)
| dom/construction/createComment                                                               | jsdom  ×&nbsp;1,243,110&nbsp;ops/sec ±0.58%&nbsp;(97&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,219,938&nbsp;ops/sec ±0.31%&nbsp;(98&nbsp;runs&nbsp;sampled)
| dom/construction/createDocumentFragment                                                      | jsdom  ×&nbsp;1,132,790&nbsp;ops/sec ±1.83%&nbsp;(96&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,165,658&nbsp;ops/sec ±0.45%&nbsp;(97&nbsp;runs&nbsp;sampled)
| dom/construction/createElement                                                               | jsdom  ×&nbsp;295,458&nbsp;ops/sec ±0.43%&nbsp;(96&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;293,850&nbsp;ops/sec ±0.27%&nbsp;(100&nbsp;runs&nbsp;sampled)
| dom/construction/createEvent                                                                 | jsdom  ×&nbsp;204,673&nbsp;ops/sec ±0.97%&nbsp;(94&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;208,309&nbsp;ops/sec ±0.48%&nbsp;(98&nbsp;runs&nbsp;sampled)
| dom/construction/createNodeIterator                                                          | jsdom  ×&nbsp;1,257,055&nbsp;ops/sec ±0.67%&nbsp;(97&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,233,311&nbsp;ops/sec ±0.31%&nbsp;(92&nbsp;runs&nbsp;sampled)
| dom/construction/createProcessingInstruction                                                 | jsdom  ×&nbsp;625,897&nbsp;ops/sec ±0.54%&nbsp;(94&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;625,065&nbsp;ops/sec ±1.97%&nbsp;(94&nbsp;runs&nbsp;sampled)
| dom/construction/createTextNode                                                              | jsdom  ×&nbsp;1,014,577&nbsp;ops/sec ±2.88%&nbsp;(91&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,036,870&nbsp;ops/sec ±0.40%&nbsp;(96&nbsp;runs&nbsp;sampled)
| dom/inner-html/tables                                                                        | jsdom  ×&nbsp;0.33&nbsp;ops/sec ±5.08%&nbsp;(5&nbsp;runs&nbsp;sampled)                          | jsdom  ×&nbsp;0.32&nbsp;ops/sec ±4.12%&nbsp;(5&nbsp;runs&nbsp;sampled)
| dom/named-properties/setAttribute(): Remove&nbsp;a&nbsp;named&nbsp;property from&nbsp;window | jsdom  ×&nbsp;3,033&nbsp;ops/sec ±1.27%&nbsp;(58&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;3,094&nbsp;ops/sec ±5.09%&nbsp;(54&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: many&nbsp;parents                                         | jsdom  ×&nbsp;24.64&nbsp;ops/sec ±0.57%&nbsp;(43&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;27.23&nbsp;ops/sec ±0.60%&nbsp;(47&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: many&nbsp;siblings                                        | jsdom  ×&nbsp;243,263&nbsp;ops/sec ±11.94%&nbsp;(18&nbsp;runs&nbsp;sampled)                     | jsdom  ×&nbsp;240,553&nbsp;ops/sec ±12.88%&nbsp;(18&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: no&nbsp;siblings                                          | jsdom  ×&nbsp;234,538&nbsp;ops/sec ±5.76%&nbsp;(26&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;233,948&nbsp;ops/sec ±6.95%&nbsp;(25&nbsp;runs&nbsp;sampled)
| dom/tree-modification/insertBefore: many&nbsp;siblings                                       | jsdom  ×&nbsp;206,035&nbsp;ops/sec ±28.30%&nbsp;(18&nbsp;runs&nbsp;sampled)                     | jsdom  ×&nbsp;222,148&nbsp;ops/sec ±15.60%&nbsp;(16&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: many&nbsp;parents                                         | jsdom  ×&nbsp;126&nbsp;ops/sec ±2.90%&nbsp;(63&nbsp;runs&nbsp;sampled)                          | jsdom  ×&nbsp;134&nbsp;ops/sec ±0.57%&nbsp;(62&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: many&nbsp;siblings                                        | jsdom  ×&nbsp;150,933&nbsp;ops/sec ±6.34%&nbsp;(39&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;160,629&nbsp;ops/sec ±6.72%&nbsp;(42&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: no&nbsp;siblings                                          | jsdom  ×&nbsp;143,544&nbsp;ops/sec ±5.47%&nbsp;(30&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;138,649&nbsp;ops/sec ±8.73%&nbsp;(29&nbsp;runs&nbsp;sampled)
| html/parsing/text                                                                            | jsdom  ×&nbsp;15.80&nbsp;ops/sec ±1.44%&nbsp;(44&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;15.49&nbsp;ops/sec ±1.27%&nbsp;(43&nbsp;runs&nbsp;sampled)
| jsdom/api/new&nbsp;JSDOM() defaults                                                          | &lt;Test&nbsp;#&#x2060;10&gt; ×&nbsp;278&nbsp;ops/sec ±3.24%&nbsp;(81&nbsp;runs&nbsp;sampled)   | &lt;Test&nbsp;#&#x2060;10&gt; ×&nbsp;282&nbsp;ops/sec ±2.23%&nbsp;(84&nbsp;runs&nbsp;sampled)
| jsdom/api/new&nbsp;JSDOM() with&nbsp;many&nbsp;elements                                      | &lt;Test&nbsp;#&#x2060;11&gt; ×&nbsp;29.25&nbsp;ops/sec ±5.29%&nbsp;(54&nbsp;runs&nbsp;sampled) | &lt;Test&nbsp;#&#x2060;11&gt; ×&nbsp;29.05&nbsp;ops/sec ±8.35%&nbsp;(53&nbsp;runs&nbsp;sampled)
</details>