### PR TITLE
Fix <img> onerror not called when resetting src

### DIFF
--- a/lib/jsdom/living/nodes/HTMLImageElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLImageElement-impl.js
@@ -69,14 +69,8 @@ class HTMLImageElementImpl extends HTMLElementImpl {
       return;
     }
 
-    let error;
     if (!this._image) {
       this._image = new Canvas.Image();
-      // Install an error handler that just remembers the error. It is then
-      // thrown in the callback of resourceLoader.fetch() below.
-      this._image.onerror = function (err) {
-        error = err;
-      };
     }
     this._currentSrc = null;
     const srcAttributeValue = this.getAttributeNS(null, "src");
@@ -98,7 +92,10 @@ class HTMLImageElementImpl extends HTMLElementImpl {
         if (response && response.statusCode !== undefined && response.statusCode !== 200) {
           throw new Error("Status code: " + response.statusCode);
         }
-        error = null;
+        let error = null;
+        this._image.onerror = function (err) {
+          error = err;
+        };
         this._image.src = data;
         if (error) {
           throw new Error(error);

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/reuse-img.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/the-img-element/reuse-img.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reusing an &lt;img&gt; with multiple srcs</title>
+<link rel="help" href="https://html.spec.whatwg.org/#the-img-element">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+async_test(t => {
+  const image = new window.Image();
+  const events = [];
+  image.onload = t.step_func(() => {
+    events.push("onload");
+    if (events.length === 1) {
+      image.src = "data:image/png;base64,";
+    }
+    if (events.length === 2) {
+      loadedTwice();
+    }
+  });
+  image.onerror = t.step_func(() => {
+    events.push("onerror");
+    if (events.length === 2) {
+      loadedTwice();
+    }
+  });
+
+  image.src = "data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==";
+
+  function loadedTwice() {
+    assert_array_equals(events, ["onload", "onerror"]);
+    t.done();
+  }
+
+  // JSDOM specific: when image loading is not supported (i.e. when node-canvas is not installed), skip the test.
+  t.step_timeout(() => {
+    if (events.length === 0) {
+      t.done();
+    }
+  }, 1000);
+}, "onload followed by onerror");
+</script>


### PR DESCRIPTION
HTMLImageElement reuses its internal Canvas.Image object when the <img>'s src attribute is changed. However, the Image#onerror callback is not adjusted to report the error for subsequent loads. This means that a second failing load might cause onload to be called instead of onerror.

Fix this issue by attaching an onerror handler every time we load, not just when we create the Canvas.Image.