### PR TITLE
Use clean global when setting up Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ npm-debug.log*
 benchmark/browser-bundle.js
 
 lib/jsdom/living/generated/**/*.js
-lib/jsdom/browser/js-globals.json

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -38,7 +38,12 @@ exports.createWindow = function (options) {
   return new Window(options);
 };
 
-const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in global);
+// Grab clean global to avoid issues when global APIS have been polyfilled.
+// https://github.com/jsdom/jsdom/issues/2961
+const vmGlobal = vm.runInNewContext("this");
+const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(
+  ([name]) => name in vmGlobal
+);
 
 // https://html.spec.whatwg.org/#the-window-object
 function setupWindow(windowInstance, { runScripts }) {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -29,7 +29,7 @@ const SessionHistory = require("../living/window/SessionHistory");
 const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented } =
   require("../living/helpers/style-rules");
 const CustomElementRegistry = require("../living/generated/CustomElementRegistry");
-const jsGlobals = require("./js-globals.json");
+const jsGlobals = require("./js-globals");
 
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
@@ -38,10 +38,7 @@ exports.createWindow = function (options) {
   return new Window(options);
 };
 
-// Grab clean global to avoid issues when global APIS have been polyfilled.
-// https://github.com/jsdom/jsdom/issues/2961
-const vmGlobal = vm.runInNewContext("this");
-const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in vmGlobal);
+const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in global);
 
 // https://html.spec.whatwg.org/#the-window-object
 function setupWindow(windowInstance, { runScripts }) {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -41,9 +41,7 @@ exports.createWindow = function (options) {
 // Grab clean global to avoid issues when global APIS have been polyfilled.
 // https://github.com/jsdom/jsdom/issues/2961
 const vmGlobal = vm.runInNewContext("this");
-const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(
-  ([name]) => name in vmGlobal
-);
+const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in vmGlobal);
 
 // https://html.spec.whatwg.org/#the-window-object
 function setupWindow(windowInstance, { runScripts }) {

--- a/lib/jsdom/browser/js-globals.js
+++ b/lib/jsdom/browser/js-globals.js
@@ -1,19 +1,11 @@
 "use strict";
 const vm = require("vm");
-const fs = require("fs");
-const path = require("path");
 const assert = require("assert");
 
 // Creates a list of globals from the JS environment (not the web), so that Window.js can alias them when necessary.
 // The generated list should match https://tc39.es/ecma262/#sec-global-object, to the extent V8 implements the spec.
-// We generate this at build time instead of runtime because we want to avoid the performance and memory overhead of
-// creating a new context when scripting is disabled in the JSDOM.
 
-const dest = path.resolve(__dirname, "../lib/jsdom/browser/js-globals.json");
-
-const context = vm.createContext();
-
-const globals = vm.runInContext("Object.getOwnPropertyDescriptors(this)", context);
+const globals = vm.runInNewContext("Object.getOwnPropertyDescriptors(this)");
 
 // I guess VM contexts have a console, from V8? That isn't a JS global and JSDOM will install its own, so don't include
 // that.
@@ -28,4 +20,4 @@ for (const [key, global] of Object.entries(globals)) {
   delete global.value;
 }
 
-fs.writeFileSync(dest, JSON.stringify(globals, undefined, 2) + "\n");
+module.exports = globals;

--- a/lib/jsdom/vm-shim.js
+++ b/lib/jsdom/vm-shim.js
@@ -3,7 +3,7 @@
 const acorn = require("acorn");
 const findGlobals = require("acorn-globals");
 const escodegen = require("escodegen");
-const jsGlobals = require("./browser/js-globals.json");
+const jsGlobals = require("./browser/js-globals");
 
 // We can't use the default browserify vm shim because it doesn't work in a web worker.
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "./lib/jsdom/living/websockets/WebSocket-impl.js": "./lib/jsdom/living/websockets/WebSocket-impl-browser.js"
   },
   "scripts": {
-    "prepare": "yarn convert-idl && yarn generate-js-globals",
+    "prepare": "yarn convert-idl",
     "pretest": "yarn prepare && yarn init-wpt",
     "test-wpt": "mocha test/web-platform-tests/run-wpts.js",
     "test-tuwpt": "mocha test/web-platform-tests/run-tuwpts.js",
@@ -108,8 +108,7 @@
     "update-authors": "git log --format=\"%aN <%aE>\" | sort -f | uniq > AUTHORS.txt",
     "benchmark": "node ./benchmark/runner",
     "benchmark-browser": "node ./benchmark/runner --bundle",
-    "convert-idl": "node ./scripts/webidl/convert.js",
-    "generate-js-globals": "node ./scripts/generate-js-globals.js"
+    "convert-idl": "node ./scripts/webidl/convert.js"
   },
   "main": "./lib/api.js",
   "engines": {

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -4,7 +4,7 @@ const { describe, it } = require("mocha-sugar-free");
 const { delay } = require("../util.js");
 
 const { JSDOM, VirtualConsole } = require("../..");
-const jsGlobals = Object.keys(require("../../lib/jsdom/browser/js-globals.json"));
+const jsGlobals = Object.keys(require("../../lib/jsdom/browser/js-globals"));
 
 // Node 10 has a bug with the vm module that causes some global-related tests to fail.
 const hasNode10 = process.versions.node && Number(process.versions.node.split(".")[0]) === 10;


### PR DESCRIPTION
Fixes #2961.

Use a clean instance of the global object when looking for global entries to install into the jsdom environment. This avoids issues when the global object has had APIs polyfilled that aren't available within a new vm context.

Credit goes to @SimenB for helping troubleshoot!