### PR TITLE
Prevent infinite loop when mutation observer calls observe within the callback

### DIFF
--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -147,7 +147,7 @@ function notifyMutationObservers() {
   for (const mo of notifyList) {
     const records = [...mo._recordQueue];
     mo._recordQueue = [];
-    
+
     // Clone the nodes list since the user callback might add to it while executing.
     // This would trap us in an infinite loop.
     const nodes = [...mo._nodeList];

--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -147,8 +147,12 @@ function notifyMutationObservers() {
   for (const mo of notifyList) {
     const records = [...mo._recordQueue];
     mo._recordQueue = [];
+    
+    // Clone the nodes list since the user callback might add to it while executing.
+    // This would trap us in an infinite loop.
+    const nodes = [...mo._nodeList];
 
-    for (const node of mo._nodeList) {
+    for (const node of nodes) {
       node._registeredObserverList = node._registeredObserverList.filter(registeredObserver => {
         return registeredObserver.source !== mo;
       });


### PR DESCRIPTION
> Disclaimer: I haven’t carefully thought this change through. Probably consider this more like an issue with the change that fixed the issue for me.

While using jsdom I ran into a test that wouldn’t terminate. After debugging I discovered some code that fired in a mutation observer which was effectively:

```js
const observer = new MutationObserver(mutations => {
  // Many layers of abstraction...

  // In a totally different file:
  if (someCondition) {
    observer.disconnect();
    // Do some stuff...
    observer.observe();
  }

  // Many more layers of abstraction...
});
```

Since this happens during `notifyMutationObservers()` the new `observer.observe()` call added to the `_nodeList` which caused the for-loop to then execute on the new node, however that called the callback which added to `_nodeList` and so on forever.