### PR TITLE
Use `InnerHTML` mixin for `innerHTML` definition

### DIFF
--- a/lib/jsdom/living/domparsing/InnerHTML-impl.js
+++ b/lib/jsdom/living/domparsing/InnerHTML-impl.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const { parseFragment } = require("../../browser/parser");
+const { HTML_NS } = require("../helpers/namespaces.js");
+const { isShadowRoot } = require("../helpers/shadow-dom.js");
+const NODE_TYPE = require("../node-type.js");
+const { fragmentSerialization } = require("./serialization.js");
+
+// https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
+exports.implementation = class InnerHTMLImpl {
+  // https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
+  get innerHTML() {
+    return fragmentSerialization(this, {
+      requireWellFormed: true,
+      globalObject: this._globalObject
+    });
+  }
+  set innerHTML(markup) {
+    const contextElement = isShadowRoot(this) ? this.host : this;
+    const fragment = parseFragment(markup, contextElement);
+
+    let contextObject = this;
+    if (this.nodeType === NODE_TYPE.ELEMENT_NODE && this.localName === "template" && this.namespaceURI === HTML_NS) {
+      contextObject = this._templateContents;
+    }
+
+    contextObject._replaceAll(fragment);
+  }
+};

--- a/lib/jsdom/living/domparsing/InnerHTML.webidl
+++ b/lib/jsdom/living/domparsing/InnerHTML.webidl
@@ -1,0 +1,7 @@
+// https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
+interface mixin InnerHTML {
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerHTML;
+};
+
+Element includes InnerHTML;
+ShadowRoot includes InnerHTML;

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -10,6 +10,7 @@ const attributes = require("../attributes");
 const namedPropertiesWindow = require("../named-properties-window");
 const NODE_TYPE = require("../node-type");
 const { parseFragment } = require("../../browser/parser");
+const InnerHTMLImpl = require("../domparsing/InnerHTML-impl").implementation;
 const { fragmentSerialization } = require("../domparsing/serialization");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const DOMException = require("domexception/webidl2js-wrapper");
@@ -187,24 +188,6 @@ class ElementImpl extends NodeImpl {
 
     const contextObjectParent = domSymbolTree.parent(this);
     contextObjectParent._replace(fragment, this);
-  }
-
-  // https://w3c.github.io/DOM-Parsing/#dfn-innerhtml
-  get innerHTML() {
-    return fragmentSerialization(this, {
-      requireWellFormed: true,
-      globalObject: this._globalObject
-    });
-  }
-  set innerHTML(markup) {
-    const fragment = parseFragment(markup, this);
-
-    let contextObject = this;
-    if (this.localName === "template" && this.namespaceURI === HTML_NS) {
-      contextObject = contextObject._templateContents;
-    }
-
-    contextObject._replaceAll(fragment);
   }
 
   get classList() {
@@ -566,6 +549,7 @@ mixin(ElementImpl.prototype, NonDocumentTypeChildNode.prototype);
 mixin(ElementImpl.prototype, ParentNodeImpl.prototype);
 mixin(ElementImpl.prototype, ChildNodeImpl.prototype);
 mixin(ElementImpl.prototype, SlotableMixinImpl.prototype);
+mixin(ElementImpl.prototype, InnerHTMLImpl.prototype);
 
 ElementImpl.prototype.getElementsByTagName = memoizeQuery(function (qualifiedName) {
   return listOfElementsWithQualifiedName(qualifiedName, this);

--- a/lib/jsdom/living/nodes/Element.webidl
+++ b/lib/jsdom/living/nodes/Element.webidl
@@ -51,7 +51,6 @@ dictionary ShadowRootInit {
 
 // https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface
 partial interface Element {
-  [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerHTML;
   [CEReactions] attribute [LegacyNullToEmptyString] DOMString outerHTML;
   [CEReactions] void insertAdjacentHTML(DOMString position, DOMString text);
 };

--- a/lib/jsdom/living/nodes/ShadowRoot-impl.js
+++ b/lib/jsdom/living/nodes/ShadowRoot-impl.js
@@ -1,12 +1,11 @@
 "use strict";
 
-const { parseFragment } = require("../../browser/parser");
-const { fragmentSerialization } = require("../domparsing/serialization.js");
 const { nodeRoot } = require("../helpers/node");
 const { mixin } = require("../../utils");
 
 const DocumentFragment = require("./DocumentFragment-impl").implementation;
 const DocumentOrShadowRootImpl = require("./DocumentOrShadowRoot-impl").implementation;
+const InnerHTMLImpl = require("../domparsing/InnerHTML-impl").implementation;
 
 class ShadowRootImpl extends DocumentFragment {
   constructor(globalObject, args, privateData) {
@@ -31,21 +30,10 @@ class ShadowRootImpl extends DocumentFragment {
   get host() {
     return this._host;
   }
-
-  // https://w3c.github.io/DOM-Parsing/#dfn-innerhtml
-  get innerHTML() {
-    return fragmentSerialization(this, {
-      requireWellFormed: true,
-      globalObject: this._globalObject
-    });
-  }
-  set innerHTML(markup) {
-    const fragment = parseFragment(markup, this._host);
-    this._replaceAll(fragment);
-  }
 }
 
 mixin(ShadowRootImpl.prototype, DocumentOrShadowRootImpl.prototype);
+mixin(ShadowRootImpl.prototype, InnerHTMLImpl.prototype);
 
 module.exports = {
   implementation: ShadowRootImpl

--- a/lib/jsdom/living/nodes/ShadowRoot.webidl
+++ b/lib/jsdom/living/nodes/ShadowRoot.webidl
@@ -3,9 +3,6 @@
 interface ShadowRoot : DocumentFragment {
   readonly attribute ShadowRootMode mode;
   readonly attribute Element host;
-
-  // https://github.com/w3c/DOM-Parsing/issues/21
-  [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerHTML;
 };
 
 enum ShadowRootMode { "open", "closed" };


### PR DESCRIPTION
<https://github.com/w3c/DOM-Parsing/issues/21> has been resolved, so this can be updated.

I’ve kept the implementations in `Element‑impl.js` and `ShadowRoot‑impl.js`, as they have little actual overlap.