### PR TITLE
Implement `BeforeUnloadEvent`

### DIFF
--- a/lib/jsdom/living/events/BeforeUnloadEvent-impl.js
+++ b/lib/jsdom/living/events/BeforeUnloadEvent-impl.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const EventImpl = require("./Event-impl.js").implementation;
+
+exports.implementation = class BeforeUnloadEventImpl extends EventImpl {
+  constructor(globalObject, args, privateData) {
+    super(globalObject, args, privateData);
+
+    // We can't use `this.returnValue = ""`, as that would invoke the setter in `EventImpl`
+    Object.defineProperty(this, "returnValue", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: ""
+    });
+  }
+};

--- a/lib/jsdom/living/events/BeforeUnloadEvent.webidl
+++ b/lib/jsdom/living/events/BeforeUnloadEvent.webidl
@@ -1,0 +1,5 @@
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-beforeunloadevent-interface
+[Exposed=Window]
+interface BeforeUnloadEvent : Event {
+  attribute DOMString returnValue;
+};

--- a/lib/jsdom/living/helpers/create-event-accessor.js
+++ b/lib/jsdom/living/helpers/create-event-accessor.js
@@ -2,6 +2,7 @@
 
 const conversions = require("webidl-conversions");
 const idlUtils = require("../generated/utils");
+const BeforeUnloadEvent = require("../generated/BeforeUnloadEvent.js");
 const ErrorEvent = require("../generated/ErrorEvent");
 const reportException = require("./runtime-script-errors");
 
@@ -33,7 +34,7 @@ exports.appendHandler = function appendHandler(el, eventName) {
       }
     }
 
-    if (event.type === "beforeunload") { // TODO: we don't implement BeforeUnloadEvent so we can't brand-check here
+    if (BeforeUnloadEvent.is(event) && event.type === "beforeunload") {
       // Perform conversion which in the spec is done by the event handler return type being DOMString?
       returnValue = returnValue === undefined || returnValue === null ? null : conversions.DOMString(returnValue);
 

--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -119,6 +119,7 @@ const generatedInterfaces = {
   SVGStringList: require("./generated/SVGStringList"),
 
   Event: require("./generated/Event"),
+  BeforeUnloadEvent: require("./generated/BeforeUnloadEvent.js"),
   CloseEvent: require("./generated/CloseEvent"),
   CustomEvent: require("./generated/CustomEvent"),
   MessageEvent: require("./generated/MessageEvent"),


### PR DESCRIPTION
This implements the `BeforeUnloadEvent` interface so that we can perform brand checking in: <https://github.com/jsdom/jsdom/blob/bf5c6ce2e3a3ab6d9d79c923ee44330855f7a50d/lib/jsdom/living/helpers/create-event-accessor.js#L37>