### PR TITLE
Ensure focusin/focusout fires with .focus()/.blur()

### DIFF
--- a/lib/jsdom/living/helpers/focusing.js
+++ b/lib/jsdom/living/helpers/focusing.js
@@ -65,14 +65,16 @@ exports.isFocusableAreaElement = elImpl => {
 
 // https://html.spec.whatwg.org/multipage/interaction.html#fire-a-focus-event plus the steps of
 // https://html.spec.whatwg.org/multipage/interaction.html#focus-update-steps that adjust Documents to Windows
-exports.fireFocusEventWithTargetAdjustment = (name, target, relatedTarget, bubbles) => {
+// It's extended with the bubbles option to also handle focusin/focusout, which are "defined" in
+// https://w3c.github.io/uievents/#event-type-focusin. See https://github.com/whatwg/html/issues/3514.
+exports.fireFocusEventWithTargetAdjustment = (name, target, relatedTarget, { bubbles = false } = {}) => {
   if (target === null) {
     // E.g. firing blur with nothing previously focused.
     return;
   }
 
   const event = createAnEvent(name, target._globalObject, FocusEvent, {
-    bubbles: bubbles || false,
+    bubbles,
     composed: true,
     relatedTarget,
     view: target._ownerDocument._defaultView,

--- a/lib/jsdom/living/helpers/focusing.js
+++ b/lib/jsdom/living/helpers/focusing.js
@@ -65,13 +65,14 @@ exports.isFocusableAreaElement = elImpl => {
 
 // https://html.spec.whatwg.org/multipage/interaction.html#fire-a-focus-event plus the steps of
 // https://html.spec.whatwg.org/multipage/interaction.html#focus-update-steps that adjust Documents to Windows
-exports.fireFocusEventWithTargetAdjustment = (name, target, relatedTarget) => {
+exports.fireFocusEventWithTargetAdjustment = (name, target, relatedTarget, bubbles) => {
   if (target === null) {
     // E.g. firing blur with nothing previously focused.
     return;
   }
 
   const event = createAnEvent(name, target._globalObject, FocusEvent, {
+    bubbles: bubbles || false,
     composed: true,
     relatedTarget,
     view: target._ownerDocument._defaultView,

--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -42,20 +42,31 @@ class HTMLOrSVGElementImpl {
     if (!focusing.isFocusableAreaElement(this)) {
       return;
     }
-
-    const previous = this._ownerDocument._lastFocusedElement;
+    const ownerDocument = this._ownerDocument;
+    const previous = ownerDocument._lastFocusedElement;
 
     if (previous === this) {
       return;
     }
 
-    focusing.fireFocusEventWithTargetAdjustment("blur", previous, this);
-    this._ownerDocument._lastFocusedElement = this;
-    focusing.fireFocusEventWithTargetAdjustment("focus", this, previous);
-
-    if (this._ownerDocument._defaultView._frameElement) {
-      this._ownerDocument._defaultView._frameElement.focus();
+    ownerDocument._lastFocusedElement = null;
+    if (previous) {
+      focusing.fireFocusEventWithTargetAdjustment("blur", previous, this);
+      focusing.fireFocusEventWithTargetAdjustment("focusout", previous, this, true);
+    } else {
+      const frameElement = ownerDocument._defaultView._frameElement;
+      if (frameElement) {
+        const frameLastFocusedElement = frameElement.ownerDocument._lastFocusedElement;
+        frameElement.ownerDocument._lastFocusedElement = null;
+        focusing.fireFocusEventWithTargetAdjustment("blur", frameLastFocusedElement, null);
+        focusing.fireFocusEventWithTargetAdjustment("focusout", frameLastFocusedElement, null, true);
+        frameElement.ownerDocument._lastFocusedElement = frameElement;
+      }
     }
+
+    ownerDocument._lastFocusedElement = this;
+    focusing.fireFocusEventWithTargetAdjustment("focus", this, previous);
+    focusing.fireFocusEventWithTargetAdjustment("focusin", this, previous, true);
   }
 
   blur() {
@@ -63,9 +74,11 @@ class HTMLOrSVGElementImpl {
       return;
     }
 
-    focusing.fireFocusEventWithTargetAdjustment("blur", this, this._ownerDocument);
     this._ownerDocument._lastFocusedElement = null;
+    focusing.fireFocusEventWithTargetAdjustment("blur", this, this._ownerDocument);
+    focusing.fireFocusEventWithTargetAdjustment("focusout", this, this._ownerDocument, true);
     focusing.fireFocusEventWithTargetAdjustment("focus", this._ownerDocument, this);
+    focusing.fireFocusEventWithTargetAdjustment("focusin", this._ownerDocument, this, true);
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -52,21 +52,21 @@ class HTMLOrSVGElementImpl {
     ownerDocument._lastFocusedElement = null;
     if (previous) {
       focusing.fireFocusEventWithTargetAdjustment("blur", previous, this);
-      focusing.fireFocusEventWithTargetAdjustment("focusout", previous, this, true);
+      focusing.fireFocusEventWithTargetAdjustment("focusout", previous, this, { bubbles: true });
     } else {
       const frameElement = ownerDocument._defaultView._frameElement;
       if (frameElement) {
         const frameLastFocusedElement = frameElement.ownerDocument._lastFocusedElement;
         frameElement.ownerDocument._lastFocusedElement = null;
         focusing.fireFocusEventWithTargetAdjustment("blur", frameLastFocusedElement, null);
-        focusing.fireFocusEventWithTargetAdjustment("focusout", frameLastFocusedElement, null, true);
+        focusing.fireFocusEventWithTargetAdjustment("focusout", frameLastFocusedElement, null, { bubbles: true });
         frameElement.ownerDocument._lastFocusedElement = frameElement;
       }
     }
 
     ownerDocument._lastFocusedElement = this;
     focusing.fireFocusEventWithTargetAdjustment("focus", this, previous);
-    focusing.fireFocusEventWithTargetAdjustment("focusin", this, previous, true);
+    focusing.fireFocusEventWithTargetAdjustment("focusin", this, previous, { bubbles: true });
   }
 
   blur() {
@@ -76,9 +76,9 @@ class HTMLOrSVGElementImpl {
 
     this._ownerDocument._lastFocusedElement = null;
     focusing.fireFocusEventWithTargetAdjustment("blur", this, this._ownerDocument);
-    focusing.fireFocusEventWithTargetAdjustment("focusout", this, this._ownerDocument, true);
+    focusing.fireFocusEventWithTargetAdjustment("focusout", this, this._ownerDocument, { bubbles: true });
     focusing.fireFocusEventWithTargetAdjustment("focus", this._ownerDocument, this);
-    focusing.fireFocusEventWithTargetAdjustment("focusin", this._ownerDocument, this, true);
+    focusing.fireFocusEventWithTargetAdjustment("focusin", this._ownerDocument, this, { bubbles: true});
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -78,7 +78,7 @@ class HTMLOrSVGElementImpl {
     focusing.fireFocusEventWithTargetAdjustment("blur", this, this._ownerDocument);
     focusing.fireFocusEventWithTargetAdjustment("focusout", this, this._ownerDocument, { bubbles: true });
     focusing.fireFocusEventWithTargetAdjustment("focus", this._ownerDocument, this);
-    focusing.fireFocusEventWithTargetAdjustment("focusin", this._ownerDocument, this, { bubbles: true});
+    focusing.fireFocusEventWithTargetAdjustment("focusin", this._ownerDocument, this, { bubbles: true });
   }
 }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1088,6 +1088,7 @@ idlharness.window.html: [fail, Depends on fetch]
 legacy-domevents-tests/approved/ProcessingInstruction.DOMCharacterDataModified.html: [timeout, Mutation Events not implemented]
 legacy-domevents-tests/approved/domnodeinserted.html: [timeout, Mutation Events not implemented]
 mouse/**: [timeout, Uses testdriver.js]
+order-of-events-/focus-events/focus-management-expectations.html: [timeout, Uses testdriver.js]
 order-of-events/mouse-events/*: [timeout, Unknown]
 
 ---

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1088,7 +1088,7 @@ idlharness.window.html: [fail, Depends on fetch]
 legacy-domevents-tests/approved/ProcessingInstruction.DOMCharacterDataModified.html: [timeout, Mutation Events not implemented]
 legacy-domevents-tests/approved/domnodeinserted.html: [timeout, Mutation Events not implemented]
 mouse/**: [timeout, Uses testdriver.js]
-order-of-events/**: [timeout, Unknown]
+order-of-events/mouse-events/*: [timeout, Unknown]
 
 ---
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1088,7 +1088,7 @@ idlharness.window.html: [fail, Depends on fetch]
 legacy-domevents-tests/approved/ProcessingInstruction.DOMCharacterDataModified.html: [timeout, Mutation Events not implemented]
 legacy-domevents-tests/approved/domnodeinserted.html: [timeout, Mutation Events not implemented]
 mouse/**: [timeout, Uses testdriver.js]
-order-of-events-/focus-events/focus-management-expectations.html: [timeout, Uses testdriver.js]
+order-of-events/focus-events/focus-management-expectations.html: [timeout, Uses testdriver.js]
 order-of-events/mouse-events/*: [timeout, Unknown]
 
 ---

--- a/test/web-platform-tests/to-upstream/html/interaction/focus-managment/focusing-focused-noop.html
+++ b/test/web-platform-tests/to-upstream/html/interaction/focus-managment/focusing-focused-noop.html
@@ -26,6 +26,14 @@ test(() => {
   input.addEventListener("blur", () => {
     handleBlurCallCount += 1;
   });
+  let handleFocusInCallCount = 0;
+  input.addEventListener("focusin", () => {
+    handleFocusInCallCount += 1;
+  });
+  let handleFocusOutCallCount = 0;
+  input.addEventListener("focusout", () => {
+    handleFocusOutCallCount += 1;
+  });
 
   container.appendChild(input);
 
@@ -33,7 +41,9 @@ test(() => {
   document.activeElement.focus();
 
   assert_equals(handleBlurCallCount, 0);
+  assert_equals(handleFocusOutCallCount, 0);
   assert_equals(handleFocusCallCount, 1);
+  assert_equals(handleFocusInCallCount, 1);
 }, "focusing a focused element does not dispatch focus events");
   </script>
 </body>


### PR DESCRIPTION
This PR alters how `HTMLOrSVGElement-impl` so that the `focus` and `blur` methods also dispatch the relevant `focusin` and `focusout` events in the bubble phase, as per how they occur on modern browsers. I wasn't sure where to add any tests for this change specifically, if anyone has any pointers, that would be great.