### PR TITLE
feat: Cache Element.prototype.tagName

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -78,6 +78,8 @@ class ElementImpl extends NodeImpl {
     this._attributes = NamedNodeMap.createImpl(this._globalObject, [], {
       element: this
     });
+
+    this._cachedTagName = null;
   }
 
   _attach() {
@@ -133,11 +135,17 @@ class ElementImpl extends NodeImpl {
     return this._prefix !== null ? this._prefix + ":" + this._localName : this._localName;
   }
   get tagName() {
-    let qualifiedName = this._qualifiedName;
-    if (this.namespaceURI === HTML_NS && this._ownerDocument._parsingMode === "html") {
-      qualifiedName = asciiUppercase(qualifiedName);
+    // This getter can be a hotpath in getComputedStyle.
+    // All these are invariants during the instance lifetime so we can safely cache the computed tagName.
+    // We could create it during construction but since we already identified this as potentially slow we do it lazily.
+    if (this._cachedTagName === null) {
+      if (this.namespaceURI === HTML_NS && this._ownerDocument._parsingMode === "html") {
+        this._cachedTagName = asciiUppercase(this._qualifiedName);
+      } else {
+        this._cachedTagName = this._qualifiedName;
+      }
     }
-    return qualifiedName;
+    return this._cachedTagName;
   }
 
   get attributes() {


### PR DESCRIPTION
`ByRole` from `@testing-library/dom` makes heavy use of window.getComputedStyle. This makes Element.prototype.tagName a hotpath in certain DOM trees. Where `asciiUppercase` can take up to 40% of the total time. Since all the conditions checked in `get tagName()` seem invariant we can cache the result and return that instead after the first computation.

For our specific benchmark we saw a drop of the median runtime down to 261.3774ms from 538.9752ms (which corresponds to the 40% of total time of `asciiUppercase`.

Benchmark repo: https://github.com/eps1lon/jsdom-tagName-cache