### PR TITLE
Call `validateTokens` just once with all tokens to validate

### DIFF
--- a/lib/jsdom/living/nodes/DOMTokenList-impl.js
+++ b/lib/jsdom/living/nodes/DOMTokenList-impl.js
@@ -106,9 +106,7 @@ class DOMTokenListImpl {
   }
 
   add(...tokens) {
-    for (const token of tokens) {
-      validateTokens(this._globalObject, token);
-    }
+    validateTokens(this._globalObject, tokens);
     this._syncWithElement();
     for (const token of tokens) {
       this._tokenSet.append(token);
@@ -117,9 +115,7 @@ class DOMTokenListImpl {
   }
 
   remove(...tokens) {
-    for (const token of tokens) {
-      validateTokens(this._globalObject, token);
-    }
+    validateTokens(this._globalObject, tokens);
     this._syncWithElement();
     this._tokenSet.remove(...tokens);
     this._updateSteps();


### PR DESCRIPTION
This should be ever so slightly faster, but I doubt that that would be measurable. It's however more readable IMHO :) 