### PR TITLE
Fix event handler ObjectEnvironment instantiation

### DIFF
--- a/lib/jsdom/living/helpers/create-event-accessor.js
+++ b/lib/jsdom/living/helpers/create-event-accessor.js
@@ -115,45 +115,49 @@ exports.getCurrentEventHandlerValue = (target, event) => {
 
     const createFunction = document.defaultView.Function;
     if (event === "error" && element === null) {
-      const wrapperBody = document ? body + `\n//# sourceURL=${document.URL}` : body;
+      const sourceURL = document ? `\n//# sourceURL=${document.URL}` : "";
 
-      // eslint-disable-next-line no-new-func
-      fn = createFunction("window", `with (window) { return function onerror(event, source, lineno, colno, error) {
-  ${wrapperBody}
-}; }`)(window);
+      fn = createFunction(`\
+with (arguments[0]) { return function onerror(event, source, lineno, colno, error) {
+${body}
+}; }${sourceURL}`)(window);
 
       fn = OnErrorEventHandlerNonNull.convert(fn);
     } else {
-      const argNames = [];
-      const args = [];
-
-      argNames.push("window");
-      args.push(window);
-
+      const calls = [];
       if (element !== null) {
-        argNames.push("document");
-        args.push(idlUtils.wrapperForImpl(document));
+        calls.push(idlUtils.wrapperForImpl(document));
       }
+
       if (formOwner !== null) {
-        argNames.push("formOwner");
-        args.push(idlUtils.wrapperForImpl(formOwner));
+        calls.push(idlUtils.wrapperForImpl(formOwner));
       }
+
       if (element !== null) {
-        argNames.push("element");
-        args.push(idlUtils.wrapperForImpl(element));
+        calls.push(idlUtils.wrapperForImpl(element));
       }
-      let wrapperBody = `
-return function on${event}(event) {
-  ${body}
-};`;
-      for (let i = argNames.length - 1; i >= 0; --i) {
-        wrapperBody = `with (${argNames[i]}) { ${wrapperBody} }`;
+
+      let wrapperBody = `\
+with (arguments[0]) { return function on${event}(event) {
+${body}
+}; }`;
+
+      // eslint-disable-next-line no-unused-vars
+      for (const call of calls) {
+        wrapperBody = `\
+with (arguments[0]) { return function () {
+${wrapperBody}
+}; }`;
       }
+
       if (document) {
         wrapperBody += `\n//# sourceURL=${document.URL}`;
       }
-      argNames.push(wrapperBody);
-      fn = createFunction(...argNames)(...args);
+
+      fn = createFunction(wrapperBody)(window);
+      for (const call of calls) {
+        fn = fn(call);
+      }
 
       if (event === "beforeunload") {
         fn = OnBeforeUnloadEventHandlerNonNull.convert(fn);

--- a/test/web-platform-tests/to-upstream/html/webappapis/events/event-handler-object-environment-instantiation.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/events/event-handler-object-environment-instantiation.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="UTF-8" />
+<title>Inline handler correct ObjectEnvironment instantiation</title>
+<link rel="author" title="ExE Boss" href="https://ExE-Boss.tech" />
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  "use strict";
+
+  window.element = document.element = {
+    get [Symbol.unscopables]() {
+      return assert_unreached("get element[Symbol.unscopables]()");
+    },
+    onclickCalled: null
+  };
+
+</script>
+<div id="foo" onclick='
+  assert_equals(element, window.element, "element === window.element");
+  assert_equals(onclickCalled, false);
+  onclickCalled = true;
+'></div>
+<script>
+  "use strict";
+
+  test(() => {
+    const foo = document.getElementById("foo");
+    foo.onclickCalled = false;
+    foo.click();
+    assert_equals(foo.onclickCalled, true);
+  });
+
+</script>


### PR DESCRIPTION
This uses a method similar to what’s done by [the **Realms** shim](https://github.com/Agoric/realms-shim/blob/067bdd9404013e95b9603379cb1fb597f0bfdc50/src/evaluators.js#L60-L68).

It also works around the bug that prevents using a `Proxy` for the [named properties object](https://heycam.github.io/webidl/#named-properties-object): <https://github.com/jsdom/webidl2js/pull/167> and prevents a global `element` or `formOwner` variable from breaking the inner `with`s and also ensures that if there isn’t such a variable, it’s not added to the scope due to being passed as a named parameter.

## Depends on:
- [x] <https://github.com/web-platform-tests/wpt/pull/26091> (merged)
- [x] <https://github.com/jsdom/jsdom/pull/3156> (merged)

## See also:
- <https://github.com/whatwg/html/issues/6079>
- <https://github.com/whatwg/html/pull/6086>