### PR TITLE
fix: support wildcard for access-control-allow-headers

### DIFF
--- a/lib/jsdom/living/xhr/xhr-utils.js
+++ b/lib/jsdom/living/xhr/xhr-utils.js
@@ -90,7 +90,9 @@ function validCORSPreflightHeaders(xhr, response, flag, properties) {
   }
   const acahStr = response.headers["access-control-allow-headers"];
   const acah = new Set(acahStr ? acahStr.trim().toLowerCase().split(headerListSeparatorRegexp) : []);
-  const forbiddenHeaders = acah.has("*") ? [] : Object.keys(flag.requestHeaders).filter(header => {
+  const forbiddenHeaders = acah.has("*") ?
+  [] :
+  Object.keys(flag.requestHeaders).filter(header => {
     const lcHeader = header.toLowerCase();
     return !simpleHeaders.has(lcHeader) && !acah.has(lcHeader);
   });

--- a/lib/jsdom/living/xhr/xhr-utils.js
+++ b/lib/jsdom/living/xhr/xhr-utils.js
@@ -90,7 +90,7 @@ function validCORSPreflightHeaders(xhr, response, flag, properties) {
   }
   const acahStr = response.headers["access-control-allow-headers"];
   const acah = new Set(acahStr ? acahStr.trim().toLowerCase().split(headerListSeparatorRegexp) : []);
-  const forbiddenHeaders = Object.keys(flag.requestHeaders).filter(header => {
+  const forbiddenHeaders = acah.has("*") ? [] : Object.keys(flag.requestHeaders).filter(header => {
     const lcHeader = header.toLowerCase();
     return !simpleHeaders.has(lcHeader) && !acah.has(lcHeader);
   });

--- a/test/web-platform-tests/to-upstream/xhr/access-control-preflight-request-allow-headers-returns-star.any.js
+++ b/test/web-platform-tests/to-upstream/xhr/access-control-preflight-request-allow-headers-returns-star.any.js
@@ -1,10 +1,4 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Access-Control-Request-Origin accept different origin between preflight and actual request</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script>
+// META: title=Access-Control-Allow-Headers supports *
 "use strict";
 
 async_test(t => {
@@ -29,4 +23,3 @@ function corsURL(path) {
   url.hostname = "www1." + url.hostname;
   return url.href;
 }
-</script>

--- a/test/web-platform-tests/to-upstream/xhr/access-control-preflight-request-allow-headers-returns-star.html
+++ b/test/web-platform-tests/to-upstream/xhr/access-control-preflight-request-allow-headers-returns-star.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Access-Control-Request-Origin accept different origin between preflight and actual request</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+"use strict";
+
+async_test(t => {
+  const xhr = new XMLHttpRequest();
+
+  xhr.open("GET", corsURL("resources/access-control-preflight-request-allow-headers-returns-star.py"));
+
+  xhr.setRequestHeader("X-Test", "foobar");
+
+  xhr.onerror = t.unreached_func("Error occurred.");
+
+  xhr.onload = t.step_func_done(() => {
+    assert_equals(xhr.status, 200);
+    assert_equals(xhr.responseText, "PASS");
+  });
+
+  xhr.send();
+});
+
+function corsURL(path) {
+  const url = new URL(path, location.href);
+  url.hostname = "www1." + url.hostname;
+  return url.href;
+}
+</script>

--- a/test/web-platform-tests/to-upstream/xhr/resources/access-control-preflight-request-allow-headers-returns-star.py
+++ b/test/web-platform-tests/to-upstream/xhr/resources/access-control-preflight-request-allow-headers-returns-star.py
@@ -1,12 +1,12 @@
 def main(request, response):
     if request.method == "OPTIONS":
-        response.headers.set("Access-Control-Allow-Origin", "*")
-        response.headers.set("Access-Control-Allow-Headers", "*")
+        response.headers.set(b"Access-Control-Allow-Origin", b"*")
+        response.headers.set(b"Access-Control-Allow-Headers", b"*")
         response.status = 200
     elif request.method == "GET":
-        response.headers.set("Access-Control-Allow-Origin", "*")
-        if request.headers.get("X-Test"):
-            response.headers.set("Content-Type", "text/plain")
-            response.content = "PASS"
+        response.headers.set(b"Access-Control-Allow-Origin", b"*")
+        if request.headers.get(b"X-Test"):
+            response.headers.set(b"Content-Type", b"text/plain")
+            response.content = b"PASS"
         else:
             response.status = 400

--- a/test/web-platform-tests/to-upstream/xhr/resources/access-control-preflight-request-allow-headers-returns-star.py
+++ b/test/web-platform-tests/to-upstream/xhr/resources/access-control-preflight-request-allow-headers-returns-star.py
@@ -1,0 +1,12 @@
+def main(request, response):
+    if request.method == "OPTIONS":
+        response.headers.set("Access-Control-Allow-Origin", "*")
+        response.headers.set("Access-Control-Allow-Headers", "*")
+        response.status = 200
+    elif request.method == "GET":
+        response.headers.set("Access-Control-Allow-Origin", "*")
+        if request.headers.get("X-Test"):
+            response.headers.set("Content-Type", "text/plain")
+            response.content = "PASS"
+        else:
+            response.status = 400


### PR DESCRIPTION
This PR improves on #2867 adding proper formatting. Solves #2408 

The tests fail for this PR on the latest node version [because they're failing on master](https://travis-ci.com/github/silviot/jsdom/builds/199962084).

I would love adding a test for this fix, but it looks like tests come from a different repository, and I'm not familiar at all with this codebase. If needed I can add a test, but I need some pointers about how to do it. 