### PR TITLE
feat: add support for window override

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -37,7 +37,11 @@ class JSDOM {
 
     const documentImpl = idlUtils.implForWrapper(this[window]._document);
 
-    options.beforeParse(this[window]._globalProxy);
+    const windowParseResult = options.beforeParse(this[window]._globalProxy);
+    // supports override window for proxy situations.
+    if (windowParseResult && windowParseResult.constructor === this.window.constructor) {
+      this[window]._globalProxy = windowParseResult;
+    }
 
     parseIntoDocument(html, documentImpl);
 


### PR DESCRIPTION
In my case I want to add Proxy to the `window` object to intercept property access to `window` from js code, however I find it almost impossible to override the `window` object with the new object which is wrapped by `Proxy`. So I suggest maybe through the return value of `options.beforeParse`, it could return a new override `window` object?

Suggest usage like following:

```js
const $ = new JSDOM(`<!DOCTYPE html><html>${htmlCode}</html>`, {
    runScripts: "dangerously",
    pretendToBeVisual: true
    beforeParse(window) {
      const handler = {
        get: function(obj, prop) {
            console.log(`reading window property: ${prop.toString()}`);
            return obj[prop];
        },
        getOwnPropertyDescriptor(target, prop) {
          console.log(`reading getOwnPropertyDescriptor ${prop}`);
          return target[prop];
        }
      };
      return new Proxy(window, handler);
    }
  }
);
```

Or maybe is there any more reasonable solution for this situation?