### PR TITLE
ci: semantic release

### DIFF
--- a/.github/workflows/jsdom-ci.yml
+++ b/.github/workflows/jsdom-ci.yml
@@ -94,3 +94,19 @@ jobs:
       run: yarn --frozen-lockfile
     - name: Run tests
       run: yarn test --retries 1
+
+  release:
+    if: github.event_name == 'push'
+    needs:
+      - lint
+      - build-with-canvas
+      - build-with-browser
+      - build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bahmutov/npm-install@v1
+    - uses: ph-fritsche/action-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Run [semantic release](https://github.com/semantic-release/semantic-release) as Github Action

Running this on every [`push`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context) automatically releases commits landing on one of the release branches.
Defaults to `['+([0-9])?(.{+([0-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`

Per [`needs`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds) directive it only runs the release action when the ci tests passed for that commit.

It defaults to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) preset for commit messages, but you can override this per
```yml
      uses: ph-fritsche/action-release@v1
      with:
        config: '{"preset":"angular"}'
```

Check the [action-release readme](https://github.com/ph-fritsche/action-release) and [semantic release docs](https://semantic-release.gitbook.io/)