### PR TITLE
Use `IterableWeakSet` for `NodeIterator` tracking when supported

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -282,8 +282,6 @@ function transformOptions(options, encoding, mimeType) {
     transformed.windowOptions.storageQuota = Number(options.storageQuota);
   }
 
-  // concurrentNodeIterators??
-
   return transformed;
 }
 

--- a/lib/jsdom/living/helpers/iterable-weak-set.js
+++ b/lib/jsdom/living/helpers/iterable-weak-set.js
@@ -1,0 +1,57 @@
+"use strict";
+
+// This is a static function to improve memory usage when multiple
+// `IterableWeakSet` instances are created, so that each `FinalizationRegistry`
+// uses the same shared function:
+function cleanup({ ref, set }) {
+  set.delete(ref);
+}
+
+// An iterable WeakSet implementation inspired by the iterable WeakMap
+// example code in the WeakRefs specification:
+//
+// @see https://github.com/tc39/proposal-weakrefs#iterable-weakmaps
+module.exports = class IterableWeakSet {
+  constructor() {
+    this._refSet = new Set();
+    this._refMap = new WeakMap();
+    this._finalizationRegistry = new FinalizationRegistry(cleanup);
+  }
+
+  add(value) {
+    if (!this._refMap.has(value)) {
+      const ref = new WeakRef(value);
+      this._refMap.set(value, ref);
+      this._refSet.add(ref);
+      this._finalizationRegistry.register(value, { ref, set: this._refSet }, ref);
+    }
+
+    return this;
+  }
+
+  delete(value) {
+    const ref = this._refMap.get(value);
+    if (!ref) {
+      return false;
+    }
+
+    this._refMap.delete(value);
+    this._refSet.delete(ref);
+    this._finalizationRegistry.unregister(ref);
+    return true;
+  }
+
+  has(value) {
+    return this._refMap.has(value);
+  }
+
+  * [Symbol.iterator]() {
+    for (const ref of this._refSet) {
+      const value = ref.deref();
+      if (value === undefined) {
+        continue;
+      }
+      yield value;
+    }
+  }
+};

--- a/lib/jsdom/living/helpers/iterable-weak-set.js
+++ b/lib/jsdom/living/helpers/iterable-weak-set.js
@@ -1,21 +1,12 @@
 "use strict";
 
-// This is a static function to improve memory usage when multiple
-// `IterableWeakSet` instances are created, so that each `FinalizationRegistry`
-// uses the same shared function:
-function cleanup({ ref, set }) {
-  set.delete(ref);
-}
-
-// An iterable WeakSet implementation inspired by the iterable WeakMap
-// example code in the WeakRefs specification:
-//
-// @see https://github.com/tc39/proposal-weakrefs#iterable-weakmaps
+// An iterable WeakSet implementation inspired by the iterable WeakMap example code in the WeakRefs specification:
+// https://github.com/tc39/proposal-weakrefs#iterable-weakmaps
 module.exports = class IterableWeakSet {
   constructor() {
     this._refSet = new Set();
     this._refMap = new WeakMap();
-    this._finalizationRegistry = new FinalizationRegistry(cleanup);
+    this._finalizationRegistry = new FinalizationRegistry(({ ref, set }) => set.delete(ref));
   }
 
   add(value) {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -5,7 +5,7 @@ const { CookieJar } = require("tough-cookie");
 const NodeImpl = require("./Node-impl").implementation;
 const idlUtils = require("../generated/utils");
 const NODE_TYPE = require("../node-type");
-const { mixin, memoizeQuery } = require("../../utils");
+const { hasWeakRefs, mixin, memoizeQuery } = require("../../utils");
 const { firstChildWithLocalName, firstChildWithLocalNames, firstDescendantWithLocalName } =
   require("../helpers/traversal");
 const whatwgURL = require("whatwg-url");
@@ -27,6 +27,7 @@ const { fireAnEvent } = require("../helpers/events");
 const { shadowIncludingInclusiveDescendantsIterator } = require("../helpers/shadow-dom");
 const { enqueueCECallbackReaction } = require("../helpers/custom-elements");
 const { createElement, internalCreateElementNSSteps } = require("../helpers/create-element");
+const IterableWeakSet = require("../helpers/iterable-weak-set");
 
 const DocumentOrShadowRootImpl = require("./DocumentOrShadowRoot-impl").implementation;
 const GlobalEventHandlersImpl = require("./GlobalEventHandlers-impl").implementation;
@@ -173,17 +174,10 @@ class DocumentImpl extends NodeImpl {
       actAsIfLocationReloadCalled: () => this._location.reload()
     });
 
-    this._workingNodeIterators = [];
-    this._workingNodeIteratorsMax = privateData.options.concurrentNodeIterators === undefined ?
-                                    10 :
-                                    Number(privateData.options.concurrentNodeIterators);
-
-    if (isNaN(this._workingNodeIteratorsMax)) {
-      throw new TypeError("The 'concurrentNodeIterators' option must be a Number");
-    }
-
-    if (this._workingNodeIteratorsMax < 0) {
-      throw new RangeError("The 'concurrentNodeIterators' option must be a non negative Number");
+    if (hasWeakRefs) {
+      this._workingNodeIterators = new IterableWeakSet();
+    } else {
+      this._workingNodeIterators = [];
     }
 
     this._referrer = privateData.options.referrer || "";
@@ -782,10 +776,14 @@ class DocumentImpl extends NodeImpl {
   createNodeIterator(root, whatToShow, filter) {
     const nodeIterator = NodeIterator.createImpl(this._globalObject, [], { root, whatToShow, filter });
 
-    this._workingNodeIterators.push(nodeIterator);
-    while (this._workingNodeIterators.length > this._workingNodeIteratorsMax) {
-      const toInactivate = this._workingNodeIterators.shift();
-      toInactivate._working = false;
+    if (hasWeakRefs) {
+      this._workingNodeIterators.add(nodeIterator);
+    } else {
+      this._workingNodeIterators.push(nodeIterator);
+      while (this._workingNodeIterators.length > 10) {
+        const toInactivate = this._workingNodeIterators.shift();
+        toInactivate._working = false;
+      }
     }
 
     return nodeIterator;

--- a/lib/jsdom/living/traversal/NodeIterator-impl.js
+++ b/lib/jsdom/living/traversal/NodeIterator-impl.js
@@ -1,4 +1,5 @@
 "use strict";
+const { hasWeakRefs } = require("../../utils");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const { filter, FILTER_ACCEPT } = require("./helpers");
 
@@ -12,11 +13,12 @@ exports.implementation = class NodeIteratorImpl {
     this._referenceNode = this.root;
     this._pointerBeforeReferenceNode = true;
 
-    // This is used to deactive the NodeIterator if there are too many working in a Document at the same time.
+    // This is used to deactivate the NodeIterator if there are too many working in a Document at the same time.
     // Without weak references, a JS implementation of NodeIterator will leak, since we can't know when to clean it up.
     // This ensures we force a clean up of those beyond some maximum (specified by the Document).
-    this._working = true;
-    this._workingNodeIteratorsMax = privateData.workingNodeIteratorsMax;
+    if (!hasWeakRefs) {
+      this._working = true;
+    }
 
     this._globalObject = globalObject;
   }
@@ -79,9 +81,9 @@ exports.implementation = class NodeIteratorImpl {
 
   // Only called by getters and methods that are affected by the pre-removing steps
   _throwIfNotWorking() {
-    if (!this._working) {
-      throw Error(`This NodeIterator is no longer working. More than ${this._workingNodeIteratorsMax} iterators are ` +
-        `being used concurrently. You can increase the 'concurrentNodeIterators' option to make this error go away.`);
+    if (!hasWeakRefs && !this._working) {
+      throw Error(`This NodeIterator is no longer working. More than 10 iterators are being used concurrently. ` +
+        `Using more than 10 node iterators requires WeakRef support.`);
     }
   }
 

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -4,6 +4,8 @@ const whatwgURL = require("whatwg-url");
 const { domSymbolTree } = require("./living/helpers/internal-constants");
 const SYMBOL_TREE_POSITION = require("symbol-tree").TreePosition;
 
+exports.hasWeakRefs = typeof WeakRef === "function";
+
 exports.toFileUrl = function (fileName) {
   // Beyond just the `path.resolve`, this is mostly for the benefit of Windows,
   // where we need to convert "\" to "/" and add an extra "/" prefix before the


### PR DESCRIPTION
When `WeakRef`s are supported (**Node ≥14.6.0**), then it’s possible to keep track of active `NodeIterator`s without leaking memory.

---

**Refs:** <https://github.com/tc39/proposal-weakrefs/issues/17#issue-292572565>