### PR TITLE
Be robust against global polyfills

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -107,8 +107,14 @@ function setupWindow(windowInstance, { runScripts }) {
 
     // Without this, these globals will only appear to scripts running inside the context using vm.runScript; they will
     // not appear to scripts running from the outside, including to JSDOM implementation code.
-    for (const [globalName, globalPropDesc] of jsGlobalEntriesToInstall) {
-      const propDesc = { ...globalPropDesc, value: vm.runInContext(globalName, windowInstance) };
+    for (const [globalName] of jsGlobalEntriesToInstall) {
+      // jsGlobalEntriesToInstall may already be contaminated by polyfills and such, so we check whether windowInstance
+      // has the globalName first.
+      const propDesc =
+        vm.runInContext(`Object.getOwnPropertyDescriptor(this, ${JSON.stringify(globalName)})`, windowInstance);
+      if (!propDesc) {
+        continue;
+      }
       Object.defineProperty(windowInstance, globalName, propDesc);
     }
   } else {


### PR DESCRIPTION
If we are running on a JavaScript engine that does not natively support a global in lib/jsdom/browser/js-globals.json, but the user loaded a polyfill prior to loading jsdom, then we could be tricked into assuming that global is available in new VM contexts.

Do not assume such a thing, and always check for each global's availability in the VM context.

One could test this by running the following script on Node.js v14.x, which does not implement AggregateError natively:

```js
global.AggregateError = class AggregateError extends Error {};
const { JSDOM } = require("jsdom");
new JSDOM("", { runScripts: "dangerously" });
```

Fixes #3205.

----

This is unfortunately hard to test on CI, since we regenerate js-globals.json as part of the `prepare` step after installing dependencies. We could switch to generating js-globals.json manually though, or as part of a `prepublishOnly` step.
