### PR TITLE
Add tests for cleaning up global 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ npm-debug.log*
 benchmark/browser-bundle.js
 
 lib/jsdom/living/generated/**/*.js
-lib/jsdom/browser/js-globals.json

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -33,7 +33,7 @@ const SessionHistory = require("../living/window/SessionHistory");
 const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented,
   SHADOW_DOM_PSEUDO_REGEXP } = require("../living/helpers/style-rules.js");
 const CustomElementRegistry = require("../living/generated/CustomElementRegistry");
-const jsGlobals = require("./js-globals.json");
+const jsGlobals = require("./js-globals");
 
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
@@ -95,10 +95,7 @@ exports.createWindow = function (options) {
   return new Window(options);
 };
 
-// Grab clean global to avoid issues when global APIS have been polyfilled.
-// https://github.com/jsdom/jsdom/issues/2961
-const vmGlobal = vm.runInNewContext("this");
-const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in vmGlobal);
+const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in global);
 
 // TODO remove when we drop Node v10 support.
 const anyNodeVersionQueueMicrotask = typeof queueMicrotask === "function" ? queueMicrotask : process.nextTick;

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -98,9 +98,7 @@ exports.createWindow = function (options) {
 // Grab clean global to avoid issues when global APIS have been polyfilled.
 // https://github.com/jsdom/jsdom/issues/2961
 const vmGlobal = vm.runInNewContext("this");
-const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(
-  ([name]) => name in vmGlobal
-);
+const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in vmGlobal);
 
 // TODO remove when we drop Node v10 support.
 const anyNodeVersionQueueMicrotask = typeof queueMicrotask === "function" ? queueMicrotask : process.nextTick;

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -95,7 +95,12 @@ exports.createWindow = function (options) {
   return new Window(options);
 };
 
-const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in global);
+// Grab clean global to avoid issues when global APIS have been polyfilled.
+// https://github.com/jsdom/jsdom/issues/2961
+const vmGlobal = vm.runInNewContext("this");
+const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(
+  ([name]) => name in vmGlobal
+);
 
 // TODO remove when we drop Node v10 support.
 const anyNodeVersionQueueMicrotask = typeof queueMicrotask === "function" ? queueMicrotask : process.nextTick;

--- a/lib/jsdom/browser/js-globals.js
+++ b/lib/jsdom/browser/js-globals.js
@@ -1,19 +1,11 @@
 "use strict";
 const vm = require("vm");
-const fs = require("fs");
-const path = require("path");
 const assert = require("assert");
 
 // Creates a list of globals from the JS environment (not the web), so that Window.js can alias them when necessary.
 // The generated list should match https://tc39.es/ecma262/#sec-global-object, to the extent V8 implements the spec.
-// We generate this at build time instead of runtime because we want to avoid the performance and memory overhead of
-// creating a new context when scripting is disabled in the JSDOM.
 
-const dest = path.resolve(__dirname, "../lib/jsdom/browser/js-globals.json");
-
-const context = vm.createContext();
-
-const globals = vm.runInContext("Object.getOwnPropertyDescriptors(this)", context);
+const globals = vm.runInNewContext("Object.getOwnPropertyDescriptors(this)");
 
 // I guess VM contexts have a console, from V8? That isn't a JS global and JSDOM will install its own, so don't include
 // that.
@@ -28,4 +20,4 @@ for (const [key, global] of Object.entries(globals)) {
   delete global.value;
 }
 
-fs.writeFileSync(dest, JSON.stringify(globals, undefined, 2) + "\n");
+module.exports = globals;

--- a/lib/jsdom/vm-shim.js
+++ b/lib/jsdom/vm-shim.js
@@ -3,7 +3,7 @@
 const acorn = require("acorn");
 const findGlobals = require("acorn-globals");
 const escodegen = require("escodegen");
-const jsGlobals = require("./browser/js-globals.json");
+const jsGlobals = require("./browser/js-globals");
 
 // We can't use the default browserify vm shim because it doesn't work in a web worker.
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "test-wpt": "mocha test/web-platform-tests/run-wpts.js",
     "test-tuwpt": "mocha test/web-platform-tests/run-tuwpts.js",
     "test-mocha": "mocha",
-    "test-api": "mocha test/api",
+    "test-api": "mocha test/api && node ./test/api/js-globals-aggregateError.js && node ./test/api/js-globals-globalThis.js",
     "test": "mocha test/index.js",
     "test-browser-iframe": "karma start test/karma.conf.js",
     "test-browser-worker": "karma start test/karma-webworker.conf.js",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "./lib/jsdom/living/websockets/WebSocket-impl.js": "./lib/jsdom/living/websockets/WebSocket-impl-browser.js"
   },
   "scripts": {
-    "prepare": "yarn convert-idl && yarn generate-js-globals",
+    "prepare": "yarn convert-idl",
     "pretest": "yarn prepare && yarn init-wpt",
     "test-wpt": "mocha test/web-platform-tests/run-wpts.js",
     "test-tuwpt": "mocha test/web-platform-tests/run-tuwpts.js",
@@ -106,8 +106,7 @@
     "update-authors": "git log --format=\"%aN <%aE>\" | sort -f | uniq > AUTHORS.txt",
     "benchmark": "node ./benchmark/runner",
     "benchmark-browser": "node ./benchmark/runner --bundle",
-    "convert-idl": "node ./scripts/webidl/convert.js",
-    "generate-js-globals": "node ./scripts/generate-js-globals.js"
+    "convert-idl": "node ./scripts/webidl/convert.js"
   },
   "main": "./lib/api.js",
   "engines": {

--- a/test/api/js-globals-aggregateError.js
+++ b/test/api/js-globals-aggregateError.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+  * This test script is NOT included in index.js. It is ran from `yarn test`
+  * directly to prevent the contamination of gloablThis in the Mocha test
+  * environment. The test passes if this script executes without error.
+ */
+
+// Attempts to polyfill AggregateError.
+global.AggregateError = class AggregateError extends Error {};
+const { JSDOM } = require("../..");
+// eslint-disable-next-line no-new
+new JSDOM("", { runScripts: "dangerously" });

--- a/test/api/js-globals-globalThis.js
+++ b/test/api/js-globals-globalThis.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+  * This test script is NOT included in index.js. It is ran from `yarn test`
+  * directly to prevent the contamination of gloablThis in the Mocha test
+  * environment. The test passes if this script executes without error.
+ */
+
+// Attempts to polyfill globalThis.
+global.globalThis = global;
+const { JSDOM } = require("../..");
+// eslint-disable-next-line no-new
+new JSDOM("", { runScripts: "dangerously" });

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -4,7 +4,7 @@ const { describe, it } = require("mocha-sugar-free");
 const { delay } = require("../util.js");
 
 const { JSDOM, VirtualConsole } = require("../..");
-const jsGlobals = Object.keys(require("../../lib/jsdom/browser/js-globals.json"));
+const jsGlobals = Object.keys(require("../../lib/jsdom/browser/js-globals"));
 
 // Node 10 has a bug with the vm module that causes some global-related tests to fail.
 const hasNode10 = process.versions.node && Number(process.versions.node.split(".")[0]) === 10;


### PR DESCRIPTION
Adding tests for #2975. The tests pass if the two scripts execute without error. The scripts exist outside of Mocha and just run in a plain node environment. 