### PR TITLE
Don't uppercase tagName when element is appended to XML document

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -91,6 +91,10 @@ class ElementImpl extends NodeImpl {
       attachId(id, this, this._ownerDocument);
     }
 
+    // If the element is initially in an HTML document but is later
+    // inserted in another type of document, the tagName should no
+    // longer be uppercase. Therefore the cached tagName is reset.
+    this._cachedTagName = null;
     super._attach();
   }
 

--- a/test/web-platform-tests/to-upstream/dom/nodes/Element-tagName.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Element-tagName.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Element.tagName</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+  "use strict";
+  test(() => {
+    const el = document.createElement("t");
+    const xmlEl = document.implementation
+      .createDocument("http://www.w3.org/1999/xhtml", "div", null)
+      .documentElement;
+    assert_equals(el.tagName, "T", "tagName should be uppercase in HTML document");
+    xmlEl.appendChild(el);
+    assert_equals(el.tagName, "t", "tagName should be lowercase in XML document");
+  }, "tagName should not be uppercased when appended to XML document");
+</script>


### PR DESCRIPTION
Since commit 63d24a0, the tagName is still uppercase even if the element
is inserted in a XML document.