### PR TITLE
Fix SSL certificate checking for WebSockets

### DIFF
--- a/lib/jsdom/living/websockets/WebSocket-impl.js
+++ b/lib/jsdom/living/websockets/WebSocket-impl.js
@@ -132,7 +132,7 @@ class WebSocketImpl extends EventTargetImpl {
           "cookie": this._ownerDocument._cookieJar.getCookieStringSync(nodeParsedURL, { http: true }),
           "origin": globalObject._origin
         },
-        rejectUnauthorized: this._ownerDocument._strictSSL
+        rejectUnauthorized: globalObject._resourceLoader._strictSSL
       });
       this._ws.once("open", () => {
         resolve();

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "whatwg-encoding": "^1.0.5",
     "whatwg-mimetype": "^2.3.0",
     "whatwg-url": "^9.0.0",
-    "ws": "^8.0.0",
+    "ws": "^8.2.2",
     "xml-name-validator": "^3.0.0"
   },
   "_dependenciesComments": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,10 +3270,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.0.0.tgz#550605d13dfc1437c9ec1396975709c6d7ffc57d"
-  integrity sha512-6AcSIXpBlS0QvCVKk+3cWnWElLsA6SzC0lkQ43ciEglgXJXiCWK3/CGFEJ+Ybgp006CMibamAsqOlxE9s4AvYA==
+ws@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.2.tgz#ca684330c6dd6076a737250ed81ac1606cb0a63e"
+  integrity sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==
 
 ws@~7.4.2:
   version "7.4.6"


### PR DESCRIPTION
Previously, it was ignoring the strictSSL option and always sending `rejectUnauthorized: undefined` to the ws module (which eventually sends it to Node.js). The meaning of `rejectUnauthorized: undefined` changed in https://github.com/nodejs/node/commit/6c7fff6f1d (Node.js v16.6.2), which caused this problem to suddenly be visible on CI.

Also updates the ws module since I did that anyway while debugging.

Closes #3243.

(I guess I'll put this bug into the category of issues TypeScript could have saved us from...)