### PR TITLE
Major performance improvements in some cases

### DIFF
--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -11,7 +11,7 @@ const { setAnExistingAttributeValue } = require("../attributes");
 
 const NodeList = require("../generated/NodeList");
 
-const { nodeRoot, nodeLength } = require("../helpers/node");
+const { nodeRoot, nodeLength, isInclusiveAncestor } = require("../helpers/node");
 const { domSymbolTree } = require("../helpers/internal-constants");
 const { documentBaseURLSerialized } = require("../helpers/document-base-url");
 const { queueTreeMutationRecord } = require("../helpers/mutation-observers");
@@ -449,13 +449,7 @@ class NodeImpl extends EventTargetImpl {
   }
 
   contains(other) {
-    while (other) {
-      if (this === other) {
-        return true;
-      }
-      other = domSymbolTree.parent(other);
-    }
-    return false;
+    return isInclusiveAncestor(this, other);
   }
 
   isEqualNode(node) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -460,12 +460,17 @@ class NodeImpl extends EventTargetImpl {
   }
 
   contains(other) {
-    if (other === null) {
-      return false;
-    } else if (this === other) {
-      return true;
+    if (isObsoleteNodeType(other) || isObsoleteNodeType(this)) {
+      throw new Error("Obsolete node type");
     }
-    return Boolean(this.compareDocumentPosition(other) & NODE_DOCUMENT_POSITION.DOCUMENT_POSITION_CONTAINED_BY);
+
+    while (other) {
+      if (this === other) {
+        return true;
+      }
+      other = domSymbolTree.parent(other);
+    }
+    return false;
   }
 
   isEqualNode(node) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -21,13 +21,6 @@ const {
   shadowIncludingInclusiveDescendantsIterator, shadowIncludingDescendantsIterator
 } = require("../helpers/shadow-dom");
 
-function isObsoleteNodeType(node) {
-  return node.nodeType === NODE_TYPE.ENTITY_NODE ||
-    node.nodeType === NODE_TYPE.ENTITY_REFERENCE_NODE ||
-    node.nodeType === NODE_TYPE.NOTATION_NODE ||
-    node.nodeType === NODE_TYPE.CDATA_SECTION_NODE;
-}
-
 function nodeEquals(a, b) {
   if (a.nodeType !== b.nodeType) {
     return false;
@@ -371,10 +364,6 @@ class NodeImpl extends EventTargetImpl {
     let node1 = other;
     let node2 = this;
 
-    if (isObsoleteNodeType(node2) || isObsoleteNodeType(node1)) {
-      throw new Error("Obsolete node type");
-    }
-
     let attr1 = null;
     let attr2 = null;
 
@@ -460,10 +449,6 @@ class NodeImpl extends EventTargetImpl {
   }
 
   contains(other) {
-    if (isObsoleteNodeType(other) || isObsoleteNodeType(this)) {
-      throw new Error("Obsolete node type");
-    }
-
     while (other) {
       if (this === other) {
         return true;

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -811,6 +811,8 @@ class NodeImpl extends EventTargetImpl {
       domSymbolTree.previousSibling(childImpl) :
       domSymbolTree.lastChild(this);
 
+    let isConnected;
+
     for (const node of nodesImpl) {
       if (!childImpl) {
         domSymbolTree.appendChild(this, node);
@@ -847,8 +849,12 @@ class NodeImpl extends EventTargetImpl {
 
       this._descendantAdded(this, node);
 
-      for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {
-        if (inclusiveDescendant.isConnected) {
+      if (isConnected === undefined) {
+        isConnected = nodeImpl.isConnected;
+      }
+
+      if (isConnected) {
+        for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {
           if (inclusiveDescendant._ceState === "custom") {
             enqueueCECallbackReaction(inclusiveDescendant, "connectedCallback", []);
           } else {


### PR DESCRIPTION
## Improve `_insert` performance from O(n^2) to O(n)

"n" here refers to the tree depth of the node being inserted, so lots of nested elements causes insertion to be extremely slow. Deep cloning, for example, calls `_insert` O(n) times, which makes cloning O(n^3) without this optimization and O(n^2) with it.

**This can make the difference between minutes and milliseconds** of synchronous blocking time for very deep node trees (which is my use case and what led me to need this optimization).

It works by only checking `isConnected` (which is O(n)) once on the node being inserted rather than checking it on every single descendant of the node being inserted. As far as I know, checking `isConnected` for every descendant isn't necessary since any node should have the same `isConnected` value as any other node in the same node tree.

## Improve `contains` performance

The current implementation of a node's `contains` method uses `compareDocumentPosition`, which runs a lot of extra features that aren't used by `contains`. I've run into a case where these extra features cost 560 ms of total synchronous blocking time, according to a CPU profile. The optimization I've implemented here has reduced that case down to 30 ms.

It works by simply checking each ancestor of the `other` node until it finds the `this` node (as in `this.contains(other)`), rather than checking a number of relationships between the two nodes but utilizing only one of them.