### PR TITLE
Add support for ports in postmessage

### DIFF
--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -6,7 +6,7 @@ const { isValidTargetOrigin } = require("../utils");
 const { fireAnEvent } = require("./helpers/events");
 
 module.exports = function (globalObject) {
-  return function (message, targetOrigin) {
+  return function (message, targetOrigin, ports) {
     if (arguments.length < 2) {
       throw new TypeError("'postMessage' requires 2 arguments: 'message' and 'targetOrigin'");
     }
@@ -30,10 +30,9 @@ module.exports = function (globalObject) {
 
     // TODO: event.source - requires reference to source window
     // TODO: event.origin - requires reference to source window
-    // TODO: event.ports
     // TODO: event.data - structured clone message - requires cloning DOM nodes
     setTimeout(() => {
-      fireAnEvent("message", this, MessageEvent, { data: message });
+      fireAnEvent("message", this, MessageEvent, { data: message, ports });
     }, 0);
   };
 };

--- a/test/to-port-to-wpts/post-message.js
+++ b/test/to-port-to-wpts/post-message.js
@@ -36,14 +36,16 @@ describe("post-message", () => {
     const { window } = new JSDOM();
     const { document } = window;
     const iframeWindow = injectIFrame(document).contentWindow;
+    const port = {};
 
     window.addEventListener("message", event => {
       assert.ok(event.data === "ack");
       assert.ok(event.type === "message");
+      assert.ok(event.ports[0] === port);
       t.done();
     });
 
-    iframeWindow.parent.postMessage("ack", "*");
+    iframeWindow.parent.postMessage("ack", "*", [port]);
   }, {
     async: true
   });
@@ -52,15 +54,17 @@ describe("post-message", () => {
     const { window } = new JSDOM();
     const { document } = window;
     const iframeWindow = injectIFrame(document).contentWindow;
+    const port = {};
 
     window.addEventListener("message", event => {
       assert.ok(typeof event.data === "object");
       assert.ok(event.data.foo === "bar");
       assert.ok(event.type === "message");
+      assert.ok(event.ports[0] === port);
       t.done();
     });
 
-    iframeWindow.parent.postMessage({ foo: "bar" }, "*");
+    iframeWindow.parent.postMessage({ foo: "bar" }, "*", [port]);
   }, {
     async: true
   });
@@ -68,14 +72,16 @@ describe("post-message", () => {
   specify("postMessage from parent to iframe", t => {
     const { document } = (new JSDOM()).window;
     const iframeWindow = injectIFrame(document).contentWindow;
+const port = {};
 
     iframeWindow.addEventListener("message", event => {
       assert.ok(event.data === "ack");
       assert.ok(event.type === "message");
+      assert.ok(event.ports[0] === port);
       t.done();
     });
 
-    iframeWindow.postMessage("ack", "*");
+    iframeWindow.postMessage("ack", "*", [port]);
   }, {
     async: true
   });


### PR DESCRIPTION
I need to be able to transfer a MessageChannel port via postmessage

https://developer.mozilla.org/en-US/docs/Web/API/Channel_Messaging_API/Using_channel_messaging