### PR TITLE
Fix #3290

### DIFF
--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -838,7 +838,7 @@ class NodeImpl extends EventTargetImpl {
       this._descendantAdded(this, node);
 
       if (isConnected === undefined) {
-        isConnected = nodeImpl.isConnected;
+        isConnected = node.isConnected;
       }
 
       if (isConnected) {

--- a/test/web-platform-tests/to-upstream/custom-elements/connected-callbacks-template.html
+++ b/test/web-platform-tests/to-upstream/custom-elements/connected-callbacks-template.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- Regression test for https://github.com/jsdom/jsdom/issues/3290 -->
+
+<body>
+<script>
+"use strict";
+
+test(() => {
+  let innerConnectedCallbackCalled = false;
+  customElements.define("inner-element", class extends HTMLElement {
+    connectedCallback() {
+      innerConnectedCallbackCalled = true;
+    }
+  });
+
+  let outerConnectedCallbackCalled = false;
+  customElements.define("outer-element", class extends HTMLElement {
+    connectedCallback() {
+      const template = document.createElement("template");
+      template.innerHTML = "<inner-element></inner-element>";
+      this.appendChild(document.importNode(template.content, true));
+      outerConnectedCallbackCalled = true;
+    }
+  });
+
+  document.body.appendChild(document.createElement("outer-element"));
+  assert_true(innerConnectedCallbackCalled, "inner connectedCallback must be called");
+  assert_true(outerConnectedCallbackCalled, "outer connectedCallback must be called");
+}, "Nested custom element connectedCallback insertion involving a template DocumentFragment");
+</script>


### PR DESCRIPTION
#3290 occurs because because the `_insert` function sets an `isConnected` variable to `nodeImpl.isConnected` and assumes the same `isConnected` value of all of `nodeImpl`'s descendants, which is not the case when `nodeImpl` is a document fragment. When a document fragment is inserted into a connected node tree, its children are inserted in its place, becoming connected, while the fragment remains unconnected.

The fix is to check the `isConnected` value of the first child `node` instead of the `nodeImpl` parent, which, unlike a document fragment, should necessarily have the same `isConnected` value as every other ex-descendant of `nodeImpl`.

I have confirmed that the example in #3290 does work as expected after this fix.