### PR TITLE
Fix appending text to Text node's data in parse5 adaptor

### DIFF
--- a/lib/jsdom/browser/parser/html.js
+++ b/lib/jsdom/browser/parser/html.js
@@ -139,7 +139,7 @@ class JSDOMParse5Adapter {
   insertText(parentNode, text) {
     const { lastChild } = parentNode;
     if (lastChild && lastChild.nodeType === nodeTypes.TEXT_NODE) {
-      lastChild.data += text;
+      lastChild._replaceData(lastChild.length, 0, text, true);
     } else {
       const ownerDocument = this._ownerDocument();
       const textNode = Text.createImpl(this._globalObject, [], { data: text, ownerDocument });
@@ -150,7 +150,7 @@ class JSDOMParse5Adapter {
   insertTextBefore(parentNode, text, referenceNode) {
     const { previousSibling } = referenceNode;
     if (previousSibling && previousSibling.nodeType === nodeTypes.TEXT_NODE) {
-      previousSibling.data += text;
+      previousSibling._replaceData(previousSibling.length, 0, text, true);
     } else {
       const ownerDocument = this._ownerDocument();
       const textNode = Text.createImpl(this._globalObject, [], { data: text, ownerDocument });

--- a/lib/jsdom/living/nodes/CharacterData-impl.js
+++ b/lib/jsdom/living/nodes/CharacterData-impl.js
@@ -62,8 +62,12 @@ class CharacterDataImpl extends NodeImpl {
   }
 
   // https://dom.spec.whatwg.org/#dom-characterdata-replacedata
-  // https://dom.spec.whatwg.org/#concept-cd-replace
   replaceData(offset, count, data) {
+    this._replaceData(offset, count, data);
+  }
+
+  // https://dom.spec.whatwg.org/#concept-cd-replace
+  _replaceData(offset, count, data, suppressObservers = false) {
     const { length } = this;
 
     if (offset > length) {
@@ -77,7 +81,9 @@ class CharacterDataImpl extends NodeImpl {
       count = length - offset;
     }
 
-    queueMutationRecord(MUTATION_TYPE.CHARACTER_DATA, this, null, null, this._data, [], [], null, null);
+    if (!suppressObservers) {
+      queueMutationRecord(MUTATION_TYPE.CHARACTER_DATA, this, null, null, this._data, [], [], null, null);
+    }
 
     const start = this._data.slice(0, offset);
     const end = this._data.slice(offset + count);

--- a/test/web-platform-tests/to-upstream/html/syntax/parsing/parser-append-data.html
+++ b/test/web-platform-tests/to-upstream/html/syntax/parsing/parser-append-data.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Appending parser-inserted character data</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-a-character">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-cd-replace">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+function createTestDocument(t) {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  t.add_cleanup(() => iframe.remove());
+
+  iframe.contentDocument.open();
+  return iframe.contentDocument;
+}
+
+test(t => {
+  const document = createTestDocument(t);
+  document.write("<textarea>textarea value\nwith linebreaks set to LF</textarea>");
+  document.close();
+
+  assert_equals(document.querySelector("textarea").value, "textarea value\nwith linebreaks set to LF");
+}, "Appending parser-inserted data runs children changed steps");
+
+test(t => {
+  const document = createTestDocument(t);
+  document.write("A<script>" +
+    "const text = document.body.firstChild;" +
+    "window.parserRange = document.createRange();" +
+    "window.parserRange.selectNodeContents(text);" +
+    "document.currentScript.remove();" +
+    "\u003C/script>B");
+  document.close();
+
+  const text = document.body.firstChild;
+  const { parserRange } = document.defaultView;
+  assert_equals(document.body.childNodes.length, 1, "number of body children");
+  assert_equals(text.data, "AB", "text data");
+  assert_equals(parserRange.startContainer, text, "range start container");
+  assert_equals(parserRange.startOffset, 0, "range start offset");
+  assert_equals(parserRange.endContainer, text, "range end container");
+  assert_equals(parserRange.endOffset, 1, "range end offset");
+  assert_equals(parserRange.toString(), "A", "range contents");
+}, "Appending parser-inserted data preserves live ranges");
+</script>

--- a/test/web-platform-tests/to-upstream/html/webappapis/dynamic-markup-insertion/document-write/mutation-observer-character-data.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/dynamic-markup-insertion/document-write/mutation-observer-character-data.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>document.write() does not queue character data mutation records while parsing</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#insert-a-character">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+test(t => {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  t.add_cleanup(() => iframe.remove());
+
+  const { contentDocument, contentWindow } = iframe;
+  contentDocument.open();
+
+  const observer = new contentWindow.MutationObserver(() => {});
+  observer.observe(contentDocument, { characterData: true, subtree: true });
+
+  contentDocument.write("a b c d");
+  contentDocument.close();
+
+  assert_equals(observer.takeRecords().length, 0);
+}, "The HTML parser does not queue character data mutation records when appending to a Text node");
+</script>


### PR DESCRIPTION
The ["insert a character"][1] algorithm in the HTML parser is clear on appending directly to the Text node's data rather than using the replace data algorithm (which creates mutation records).

[1]: https://html.spec.whatwg.org/multipage/parsing.html#insert-a-character

Fixes: #3261
