### PR TITLE
Do not track location information for nodes created by innerHTML

### DIFF
--- a/lib/jsdom/browser/parser/html.js
+++ b/lib/jsdom/browser/parser/html.js
@@ -202,6 +202,7 @@ function parseFragment(markup, contextElement) {
 
   const config = {
     ...ownerDocument._parseOptions,
+    sourceCodeLocationInfo: false,
     treeAdapter: new JSDOMParse5Adapter(ownerDocument, { fragment: true })
   };
 

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -133,6 +133,39 @@ describe("API: JSDOM class's methods", () => {
         endOffset: 36
       });
     });
+
+    it("should return undefined for nodes created by innerHTML", () => {
+      const dom = new JSDOM(`<p>Hello</p>`, { includeNodeLocations: true });
+      const para = dom.window.document.querySelector("p");
+
+      para.innerHTML = `<div></div>`;
+
+      const div = dom.window.document.querySelector("div");
+
+      assert.deepEqual(dom.nodeLocation(div), undefined);
+    });
+
+    it("should return undefined for nodes created by outerHTML", () => {
+      const dom = new JSDOM(`<p>Hello</p>`, { includeNodeLocations: true });
+      const para = dom.window.document.querySelector("p");
+
+      para.outerHTML = `<div></div>`;
+
+      const div = dom.window.document.querySelector("div");
+
+      assert.deepEqual(dom.nodeLocation(div), undefined);
+    });
+
+    it("should return undefined for nodes created by createContextualFragment", () => {
+      const dom = new JSDOM("", { includeNodeLocations: true });
+      const range = dom.window.document.createRange();
+
+      const fragment = range.createContextualFragment(`<p>Hello</p>`);
+
+      const node = fragment.querySelector("p");
+
+      assert.deepEqual(dom.nodeLocation(node), undefined);
+    });
   });
 
   describe("getInternalVMContext", { skipIfBrowser: true }, () => {


### PR DESCRIPTION
Fixes #2968.

Specifically, this disables location information for nodes created by the HTML parser's `parseFragment`, which is used for `innerHTML`, `outerHTML`, and `createContextualFragment`. It does not change anything for nodes created by `parseIntoDocument`. Note that `nodeLocation` will return `undefined` rather than throwing for these nodes, which matches the behavior prior to https://github.com/jsdom/jsdom/commit/49353e224b6c59e48c3cc7da3700dbe93a2286ac.

In https://github.com/jsdom/jsdom/issues/2968#issuecomment-980497117 I mentioned three other APIs. Those all use `parseIntoDocument` and so are unaffected, but for reference:

- DOMParser's `parseFromString` is [not forwarding along `parseOptions`](https://github.com/jsdom/jsdom/blob/a61fdb886a30fce6a3aa68002e1af6e5bcb4c372/lib/jsdom/living/domparsing/DOMParser-impl.js#L42-L49), so it uses the default behavior of not tracking
-  XHR's `responseXML` [does forward `parseOptions`](https://github.com/jsdom/jsdom/blob/a61fdb886a30fce6a3aa68002e1af6e5bcb4c372/lib/jsdom/living/xhr/XMLHttpRequest-impl.js#L304), so it does track node locations. 
- I haven't checked frames because I couldn't figure out how to get them to work, but [looking at the source](https://github.com/jsdom/jsdom/blob/a61fdb886a30fce6a3aa68002e1af6e5bcb4c372/lib/jsdom/living/nodes/HTMLFrameElement-impl.js#L129-L139) I don't think `parseOptions` is forwarded, i.e. I think it will not track locations.
