### PR TITLE
Fix :root pseudo-selector

### DIFF
--- a/lib/jsdom/living/helpers/selectors.js
+++ b/lib/jsdom/living/helpers/selectors.js
@@ -8,7 +8,7 @@ function initNwsapi(node) {
   const { _globalObject, _ownerDocument } = node;
 
   return nwsapi({
-    document: _ownerDocument,
+    document: idlUtils.wrapperForImpl(_ownerDocument),
     DOMException: _globalObject.DOMException
   });
 }

--- a/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-root.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-root.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSSOM: :root selector parsed in getComputedStyle()</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#root-pseudo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  :root {
+      --a: red;
+  }
+</style>
+
+<script>
+"use strict";
+
+test(() => {
+  const a = getComputedStyle(document.documentElement).getPropertyValue("--a");
+  assert_equals(a, "red");
+  
+}, "Accessing variables in :root pseudo-selector");
+
+</script>

--- a/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-root.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-root.html
@@ -17,7 +17,7 @@
 test(() => {
   const a = getComputedStyle(document.documentElement).getPropertyValue("--a");
   assert_equals(a, "red");
-  
+
 }, "Accessing variables in :root pseudo-selector");
 
 </script>


### PR DESCRIPTION
The :root pseudo-selector isn't currently working correctly. For example, if custom properties are defined in :root, they will not be available to the rest of the document or through "getComputedStyle(document.documentElement)."

It looks like this is due to the way nwsapi determines whether something matches the :root selector. It does a equality (===) comparison between the document.documentElement and the element provided to match(). These both need to be the "wrapper" class for the comparison to work correctly. As currently implemented, the "wrapper" is compared to the "implementation".

The proposed change provides the "wrapper" to nwsapi as the document. I've also added another test to verify the change.