### PR TITLE
Declutter ReadMe with CommonJS info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ The latest versions of jsdom require Node.js v12 or newer. (Versions of jsdom be
 
 ## Basic usage
 
-```js
-const jsdom = require("jsdom");
-const { JSDOM } = jsdom;
+```mjs
+import { JSDOM } from 'jsdom'
 ```
 
 To use jsdom, you will primarily use the `JSDOM` constructor, which is a named export of the jsdom main module. Pass the constructor a string. You will get back a `JSDOM` object, which has a number of useful properties, notably `window`:


### PR DESCRIPTION
# Summary
Declutters the ReadMe by removing information about outdated, unused, pre-historic CommonJS modules.

Requested by creator here:
https://github.com/jsdom/jsdom/pull/3289#issuecomment-973052591