### PR TITLE
WIP: NotImplementedError and child exception classes

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -4,6 +4,7 @@ const webIDLConversions = require("webidl-conversions");
 const { CSSStyleDeclaration } = require("cssstyle");
 const { Performance: RawPerformance } = require("w3c-hr-time");
 const notImplemented = require("./not-implemented");
+const { NotImplementedWindowMethodError, NotImplementedMethodError } = require("./not-implemented");
 const { installInterfaces } = require("../living/interfaces");
 const { define, mixin } = require("../utils");
 const Element = require("../living/generated/Element");
@@ -790,7 +791,7 @@ function Window(options) {
         throw new TypeError("Tried to get the computed style of a Shadow DOM pseudo-element.");
       }
 
-      notImplemented("window.computedStyle(elt, pseudoElt)", this);
+      notImplemented(new NotImplementedMethodError("window.computedStyle(elt, pseudoElt)", elt, pseudoElt), this);
     }
 
     const declaration = new CSSStyleDeclaration();
@@ -861,7 +862,9 @@ function Window(options) {
 
   function notImplementedMethod(name) {
     return function () {
-      notImplemented(name, window);
+      // not using rest params in order to keep f.length === 0
+      // eslint-disable-next-line prefer-rest-params
+      notImplemented(new NotImplementedWindowMethodError(name, ...arguments), window);
     };
   }
 
@@ -882,20 +885,20 @@ function Window(options) {
     scrollX: 0,
     scrollY: 0,
 
-    alert: notImplementedMethod("window.alert"),
-    blur: notImplementedMethod("window.blur"),
-    confirm: notImplementedMethod("window.confirm"),
-    focus: notImplementedMethod("window.focus"),
-    moveBy: notImplementedMethod("window.moveBy"),
-    moveTo: notImplementedMethod("window.moveTo"),
-    open: notImplementedMethod("window.open"),
-    print: notImplementedMethod("window.print"),
-    prompt: notImplementedMethod("window.prompt"),
-    resizeBy: notImplementedMethod("window.resizeBy"),
-    resizeTo: notImplementedMethod("window.resizeTo"),
-    scroll: notImplementedMethod("window.scroll"),
-    scrollBy: notImplementedMethod("window.scrollBy"),
-    scrollTo: notImplementedMethod("window.scrollTo")
+    alert: notImplementedMethod("alert"),
+    blur: notImplementedMethod("blur"),
+    confirm: notImplementedMethod("confirm"),
+    focus: notImplementedMethod("focus"),
+    moveBy: notImplementedMethod("moveBy"),
+    moveTo: notImplementedMethod("moveTo"),
+    open: notImplementedMethod("open"),
+    print: notImplementedMethod("print"),
+    prompt: notImplementedMethod("prompt"),
+    resizeBy: notImplementedMethod("resizeBy"),
+    resizeTo: notImplementedMethod("resizeTo"),
+    scroll: notImplementedMethod("scroll"),
+    scrollBy: notImplementedMethod("scrollBy"),
+    scrollTo: notImplementedMethod("scrollTo")
   });
 
   // ### INITIALIZATION

--- a/lib/jsdom/browser/not-implemented.js
+++ b/lib/jsdom/browser/not-implemented.js
@@ -1,13 +1,141 @@
 "use strict";
 
-module.exports = function (nameForErrorMessage, window) {
+module.exports = notImplemented;
+
+class NotImplementedError extends Error {
+  constructor(nameForErrorMessage) {
+    super(`Not implemented: ${nameForErrorMessage}`);
+
+    this.nameForErrorMessage = nameForErrorMessage;
+  }
+
+  get name() {
+    return this.constructor.name;
+  }
+
+  get type() {
+    return "not implemented";
+  }
+}
+
+module.exports.NotImplementedError = NotImplementedError;
+
+class NotImplementedMethodError extends NotImplementedError {
+  constructor(qualifiedMethodName, ...callingArguments) {
+    super(qualifiedMethodName);
+
+    this.qualifiedMethodName = qualifiedMethodName;
+    this.callingArguments = callingArguments;
+  }
+}
+
+module.exports.NotImplementedMethodError = NotImplementedMethodError;
+
+class NotImplementedWindowMethodError extends NotImplementedMethodError {
+  constructor(methodName, ...callingArguments) {
+    super(`window.${methodName}`, ...callingArguments);
+
+    this.methodName = methodName;
+  }
+}
+
+module.exports.NotImplementedWindowMethodError = NotImplementedWindowMethodError;
+
+class NotImplementedNodeMethodError extends NotImplementedMethodError {
+  constructor(nodeName, methodName, targetNode, ...callingArguments) {
+    super(`HTML${nodeName[0].toUpperCase() + nodeName.slice(1)}Element.${methodName}`, ...callingArguments);
+
+    this.nodeName = nodeName;
+    this.methodName = methodName;
+    this.targetNode = targetNode;
+  }
+}
+
+module.exports.NotImplementedNodeMethodError = NotImplementedNodeMethodError;
+
+class NotImplementedCanvasElementMethodError extends NotImplementedNodeMethodError {
+  constructor(methodName, node, ...callingArguments) {
+    super("canvas", methodName, node, ...callingArguments);
+  }
+
+  get message() {
+    return super.message + " (without installing the canvas npm package)";
+  }
+}
+
+module.exports.NotImplementedCanvasElementMethodError = NotImplementedCanvasElementMethodError;
+
+class NotImplementedFormElementMethodError extends NotImplementedNodeMethodError {
+  constructor(methodName, node, ...callingArguments) {
+    super("form", methodName, node, ...callingArguments);
+  }
+}
+
+module.exports.NotImplementedFormElementMethodError = NotImplementedFormElementMethodError;
+
+class NotImplementedMediaElementMethodError extends NotImplementedNodeMethodError {
+  constructor(methodName, node, ...callingArguments) {
+    super("media", methodName, node, ...callingArguments);
+  }
+}
+
+module.exports.NotImplementedMediaElementMethodError = NotImplementedMediaElementMethodError;
+
+class NotImplementedNavigationError extends NotImplementedError {
+  constructor(message, newURL, flags) {
+    super(message);
+
+    this.newURL = newURL;
+    this.flags = flags;
+  }
+}
+
+module.exports.NotImplementedNavigationError = NotImplementedNavigationError;
+
+class NotImplementedJSResultNavigationError extends NotImplementedNavigationError {
+  constructor(result, newURL, flags) {
+    super("string results from 'javascript:' URLs", newURL, flags);
+
+    this.jsResult = result;
+  }
+}
+
+module.exports.NotImplementedJSResultNavigationError = NotImplementedJSResultNavigationError;
+
+class NotImplementedFetchNavigationError extends NotImplementedNavigationError {
+  constructor(newURL, flags) {
+    super("navigation (except hash changes)", newURL, flags);
+  }
+}
+
+module.exports.NotImplementedFetchNavigationError = NotImplementedFetchNavigationError;
+
+class NotImplementedSessionHistoryTraversalError extends NotImplementedError {
+  constructor(message, specifiedEntry, currentEntry) {
+    super(message);
+
+    this.specifiedEntry = specifiedEntry;
+    this.currentEntry = currentEntry;
+  }
+}
+
+module.exports.NotImplementedSessionHistoryTraversalError = NotImplementedSessionHistoryTraversalError;
+
+function notImplemented(nameOrError, window) {
   if (!window) {
-    // Do nothing for window-less documents.
+    // Do nothing for window-less documents.methodName
     return;
   }
 
-  const error = new Error(`Not implemented: ${nameForErrorMessage}`);
-  error.type = "not implemented";
+  let error;
+  if (typeof nameOrError === "string") {
+    error = new NotImplementedError(nameOrError);
+  } else if (nameOrError instanceof NotImplementedError) {
+    error = nameOrError;
+  } else {
+    window._virtualConsole.emit("jsdomError", new Error("Unexpected error class"));
+    error = nameOrError;
+  }
 
   window._virtualConsole.emit("jsdomError", error);
-};
+}

--- a/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
@@ -3,6 +3,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const notImplemented = require("../../browser/not-implemented");
 const idlUtils = require("../generated/utils");
 const { Canvas } = require("../../utils");
+const { NotImplementedCanvasElementMethodError } = require("../../browser/not-implemented");
 
 class HTMLCanvasElementImpl extends HTMLElementImpl {
   _attrModified(name, value, oldValue) {
@@ -40,7 +41,7 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
     }
 
     notImplemented(
-      "HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)",
+      new NotImplementedCanvasElementMethodError("getContext", idlUtils.wrapperForImpl(this), contextId),
       this._ownerDocument._defaultView
     );
     return null;
@@ -53,7 +54,11 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
     }
 
     notImplemented(
-      "HTMLCanvasElement.prototype.toDataURL (without installing the canvas npm package)",
+      new NotImplementedCanvasElementMethodError(
+        "toDataURL",
+        idlUtils.wrapperForImpl(this),
+        ...args
+      ),
       this._ownerDocument._defaultView
     );
     return null;
@@ -81,7 +86,13 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
       }, type, options);
     } else {
       notImplemented(
-        "HTMLCanvasElement.prototype.toBlob (without installing the canvas npm package)",
+        new NotImplementedCanvasElementMethodError(
+          "toBlob",
+          idlUtils.wrapperForImpl(this),
+          callback,
+          type,
+          qualityArgument
+        ),
         window
       );
     }

--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -8,7 +8,9 @@ const { fireAnEvent } = require("../helpers/events");
 const { formOwner, isListed, isSubmittable, isSubmitButton } = require("../helpers/form-controls");
 const HTMLCollection = require("../generated/HTMLCollection");
 const notImplemented = require("../../browser/not-implemented");
+const { NotImplementedFormElementMethodError } = require("../../browser/not-implemented");
 const { parseURLToResultingURLRecord } = require("../helpers/document-base-url");
+const idlUtils = require("../generated/utils");
 
 const encTypes = new Set([
   "application/x-www-form-urlencoded",
@@ -85,7 +87,10 @@ class HTMLFormElementImpl extends HTMLElementImpl {
       return;
     }
 
-    notImplemented("HTMLFormElement.prototype.submit", this._ownerDocument._defaultView);
+    notImplemented(
+      new NotImplementedFormElementMethodError("submit", idlUtils.wrapperForImpl(this)),
+      this._ownerDocument._defaultView
+    );
   }
 
   requestSubmit(submitter = undefined) {
@@ -111,7 +116,10 @@ class HTMLFormElementImpl extends HTMLElementImpl {
       return;
     }
 
-    notImplemented("HTMLFormElement.prototype.requestSubmit", this._ownerDocument._defaultView);
+    notImplemented(
+      new NotImplementedFormElementMethodError("requestSubmit", idlUtils.wrapperForImpl(this), submitter),
+      this._ownerDocument._defaultView
+    );
   }
 
   _doReset() {

--- a/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
@@ -2,7 +2,9 @@
 const DOMException = require("domexception/webidl2js-wrapper");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const notImplemented = require("../../browser/not-implemented");
+const { NotImplementedMediaElementMethodError } = require("../../browser/not-implemented");
 const { fireAnEvent } = require("../helpers/events");
+const idlUtils = require("../generated/utils");
 
 function getTimeRangeDummy() {
   return {
@@ -109,19 +111,31 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
   // Not (yet) implemented according to spec
   // Should return sane default values
   load() {
-    notImplemented("HTMLMediaElement.prototype.load", this._ownerDocument._defaultView);
+    notImplemented(
+      new NotImplementedMediaElementMethodError("load", idlUtils.wrapperForImpl(this)),
+      this._ownerDocument._defaultView
+    );
   }
   canPlayType() {
     return "";
   }
   play() {
-    notImplemented("HTMLMediaElement.prototype.play", this._ownerDocument._defaultView);
+    notImplemented(
+      new NotImplementedMediaElementMethodError("play", idlUtils.wrapperForImpl(this)),
+      this._ownerDocument._defaultView
+    );
   }
   pause() {
-    notImplemented("HTMLMediaElement.prototype.pause", this._ownerDocument._defaultView);
+    notImplemented(
+      new NotImplementedMediaElementMethodError("pause", idlUtils.wrapperForImpl(this)),
+      this._ownerDocument._defaultView
+    );
   }
   addTextTrack() {
-    notImplemented("HTMLMediaElement.prototype.addTextTrack", this._ownerDocument._defaultView);
+    notImplemented(
+      new NotImplementedMediaElementMethodError("addTextTrack", idlUtils.wrapperForImpl(this)),
+      this._ownerDocument._defaultView
+    );
   }
 
   _dispatchRateChange() {

--- a/lib/jsdom/living/window/SessionHistory.js
+++ b/lib/jsdom/living/window/SessionHistory.js
@@ -3,6 +3,7 @@ const whatwgURL = require("whatwg-url");
 const HashChangeEvent = require("../generated/HashChangeEvent.js");
 const PopStateEvent = require("../generated/PopStateEvent.js");
 const notImplemented = require("../../browser/not-implemented.js");
+const { NotImplementedSessionHistoryTraversalError } = require("../../browser/not-implemented.js");
 const idlUtils = require("../generated/utils.js");
 const { fireAnEvent } = require("../helpers/events");
 
@@ -70,7 +71,14 @@ class SessionHistory {
 
         if (specifiedEntry.document !== this.currentEntry.document) {
           // TODO: unload the active document with the recycle parameter set to false
-          notImplemented("Traversing history in a way that would change the window", this._window);
+          notImplemented(
+            new NotImplementedSessionHistoryTraversalError(
+              "Traversing history in a way that would change the window",
+              specifiedEntry,
+              this.currentEntry
+            ),
+            this._window
+          );
         }
         this.traverseHistory(specifiedEntry);
       });
@@ -82,7 +90,14 @@ class SessionHistory {
     if (!specifiedEntry.document) {
       // If entry no longer holds a Document object, then navigate the browsing context to entry's URL
       // to perform an entry update of entry, and abort these steps
-      notImplemented("Traversing the history to an entry that no longer holds a Document object", this._window);
+      notImplemented(
+        new NotImplementedSessionHistoryTraversalError(
+          "Traversing the history to an entry that no longer holds a Document object",
+          specifiedEntry,
+          this.currentEntry
+        ),
+        this._window
+      );
     }
     // Not spec compliant, just minimal. Lots of missing steps.
 
@@ -101,7 +116,14 @@ class SessionHistory {
 
     if (specifiedEntry.document !== currentEntry.document) {
       // If entry has a different Document object than the current entry, then...
-      notImplemented("Traversing the history to an entry with a different Document", this._window);
+      notImplemented(
+        new NotImplementedSessionHistoryTraversalError(
+          "Traversing the history to an entry with a different Document",
+          specifiedEntry,
+          currentEntry
+        ),
+        this._window
+      );
     }
 
     document._URL = specifiedEntry.url;

--- a/lib/jsdom/living/window/navigation.js
+++ b/lib/jsdom/living/window/navigation.js
@@ -1,8 +1,10 @@
 "use strict";
 const whatwgURL = require("whatwg-url");
 const notImplemented = require("../../browser/not-implemented.js");
+const { NotImplementedJSResultNavigationError } = require("../../browser/not-implemented.js");
 const reportException = require("../helpers/runtime-script-errors.js");
 const idlUtils = require("../generated/utils.js");
+const { NotImplementedFetchNavigationError } = require("../../browser/not-implemented");
 
 exports.evaluateJavaScriptURL = (window, urlRecord) => {
   const urlString = whatwgURL.serializeURL(urlRecord);
@@ -47,12 +49,12 @@ exports.navigate = (window, newURL, flags) => {
     setTimeout(() => {
       const result = exports.evaluateJavaScriptURL(window, newURL);
       if (typeof result === "string") {
-        notImplemented("string results from 'javascript:' URLs", window);
+        notImplemented(new NotImplementedJSResultNavigationError(result, newURL, flags), window);
       }
     }, 0);
     return;
   }
-  navigateFetch(window);
+  navigateFetch(window, newURL, flags);
 };
 
 // https://html.spec.whatwg.org/#scroll-to-fragid
@@ -72,9 +74,9 @@ function navigateToFragment(window, newURL, flags) {
 }
 
 // https://html.spec.whatwg.org/#process-a-navigate-fetch
-function navigateFetch(window) {
+function navigateFetch(window, newURL, flags) {
   // TODO:
-  notImplemented("navigation (except hash changes)", window);
+  notImplemented(new NotImplementedFetchNavigationError(newURL, flags), window);
 }
 
 // https://url.spec.whatwg.org/#concept-url-equals


### PR DESCRIPTION
Needs:

- [ ] Demo code
- [ ] Unit tests
- [ ] Ensuring that I've made the right decisions
  - Do we need such specific exceptions for nodes? Is the code repetition introduced worth it?
  - Is it OK to define "static methods" on the notImplemented function? Do we need to keep the backward compatibility in the internal API?
  - `window/notImplementedMethod()`'s argument changed kinda unnecessarily
  - `NotImplementedFormElementMethodError` vs `NotImplementedFetchNavigationError` for `HTMLFormElement.submit()`
  - Using commercial java style long class names - not really OK
- ~[ ] Replacing the most of errors I introduced with hooks~
  - WIth every call to notImplemented, hooks can still be easily introduced there - for ex. by emitting a cancelable NotImplementedError event on the window, which can prevent emitting a jsdom error in turn. (There is a lot to consider this way though.)