### PR TITLE
Pass ports along with postMessage, allow non '*' target origins.

### DIFF
--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -1,14 +1,16 @@
-"use strict";
-const DOMException = require("domexception/webidl2js-wrapper");
-const MessageEvent = require("./generated/MessageEvent");
-const idlUtils = require("./generated/utils");
-const { isValidTargetOrigin } = require("../utils");
-const { fireAnEvent } = require("./helpers/events");
+'use strict';
+const DOMException = require('domexception/webidl2js-wrapper');
+const MessageEvent = require('./generated/MessageEvent');
+// const idlUtils = require('./generated/utils');
+const { isValidTargetOrigin } = require('../utils');
+const { fireAnEvent } = require('./helpers/events');
 
 module.exports = function (globalObject) {
-  return function (message, targetOrigin) {
+  return function (message, targetOrigin, ports) {
     if (arguments.length < 2) {
-      throw new TypeError("'postMessage' requires 2 arguments: 'message' and 'targetOrigin'");
+      throw new TypeError(
+        "'postMessage' requires 2 arguments: 'message' and 'targetOrigin'"
+      );
     }
 
     targetOrigin = String(targetOrigin);
@@ -17,23 +19,31 @@ module.exports = function (globalObject) {
       // TODO: Fix me
       throw DOMException.create(globalObject, [
         "Failed to execute 'postMessage' on 'Window': " +
-        "Invalid target origin '" + targetOrigin + "' in a call to 'postMessage'.",
-        "SyntaxError"
+          "Invalid target origin '" +
+          targetOrigin +
+          "' in a call to 'postMessage'.",
+        'SyntaxError',
       ]);
     }
 
     // TODO: targetOrigin === '/' - requires reference to source window
     // See https://github.com/jsdom/jsdom/pull/1140#issuecomment-111587499
-    if (targetOrigin !== "*" && targetOrigin !== idlUtils.implForWrapper(globalObject._document)._origin) {
-      return;
-    }
+    // if (
+    //   targetOrigin !== '*' &&
+    //   targetOrigin !== idlUtils.implForWrapper(globalObject._document)._origin
+    // ) {
+    //   return;
+    // }
 
     // TODO: event.source - requires reference to source window
     // TODO: event.origin - requires reference to source window
-    // TODO: event.ports
     // TODO: event.data - structured clone message - requires cloning DOM nodes
     setTimeout(() => {
-      fireAnEvent("message", this, MessageEvent, { data: message });
+      fireAnEvent('message', this, MessageEvent, {
+        data: message,
+        ports,
+        origin: targetOrigin,
+      });
     }, 0);
   };
 };


### PR DESCRIPTION
See #3284. This PR does that, an also lets you pass target origins besides just `*`. 

This is a bit of a hack though - for use in my own unit tests, not fit for merging.