### PR TITLE
Implement crypto.getRandomValues(array).

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -25,6 +25,7 @@ const External = require("../living/generated/External");
 const Navigator = require("../living/generated/Navigator");
 const Performance = require("../living/generated/Performance");
 const Screen = require("../living/generated/Screen");
+const Crypto = require("../living/generated/Crypto");
 const Storage = require("../living/generated/Storage");
 const Selection = require("../living/generated/Selection");
 const reportException = require("../living/helpers/runtime-script-errors");
@@ -339,6 +340,7 @@ function Window(options) {
   const navigator = Navigator.create(window, [], { userAgent: this._resourceLoader._userAgent });
   const performance = Performance.create(window, [], { rawPerformance });
   const screen = Screen.create(window);
+  const crypto = Crypto.create(window);
   const customElementRegistry = CustomElementRegistry.create(window);
 
   define(this, {
@@ -401,6 +403,9 @@ function Window(options) {
     },
     get screen() {
       return screen;
+    },
+    get crypto() {
+      return crypto;
     },
     get origin() {
       return window._origin;

--- a/lib/jsdom/living/crypto/Crypto-impl.js
+++ b/lib/jsdom/living/crypto/Crypto-impl.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const nodeCrypto = require("crypto");
+const DOMException = require("domexception/webidl2js-wrapper");
+
+// https://w3c.github.io/webcrypto/#crypto-interface
+class CryptoImpl {
+  constructor(globalObject) {
+    this._globalObject = globalObject;
+  }
+
+  // https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues
+  getRandomValues(array) {
+    // Note: this rejects Float32Array and Float64Array.
+    if (!(array instanceof this._globalObject.Int8Array ||
+        array instanceof this._globalObject.Uint8Array ||
+        array instanceof this._globalObject.Uint8ClampedArray ||
+        array instanceof this._globalObject.Int16Array ||
+        array instanceof this._globalObject.Uint16Array ||
+        array instanceof this._globalObject.Int32Array ||
+        array instanceof this._globalObject.Uint32Array ||
+        array instanceof this._globalObject.BigInt64Array ||
+        array instanceof this._globalObject.BigUint64Array)) {
+      throw DOMException.create(this._globalObject, [
+        `The type of an object is incompatible with the expected type of the parameter associated to the object`,
+        "TypeMismatchError"
+      ]);
+    }
+
+    if (array.byteLength > 65536) {
+      throw DOMException.create(this._globalObject, [
+        `The quota has been exceeded.`,
+        "QuotaExceededError"
+      ]);
+    }
+
+    nodeCrypto.randomFillSync(array);
+    return array;
+  }
+}
+
+exports.implementation = CryptoImpl;

--- a/lib/jsdom/living/crypto/Crypto-impl.js
+++ b/lib/jsdom/living/crypto/Crypto-impl.js
@@ -11,25 +11,30 @@ class CryptoImpl {
 
   // https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues
   getRandomValues(array) {
-    // Note: this rejects Float32Array and Float64Array.
-    if (!(array instanceof this._globalObject.Int8Array ||
-        array instanceof this._globalObject.Uint8Array ||
-        array instanceof this._globalObject.Uint8ClampedArray ||
-        array instanceof this._globalObject.Int16Array ||
-        array instanceof this._globalObject.Uint16Array ||
-        array instanceof this._globalObject.Int32Array ||
-        array instanceof this._globalObject.Uint32Array ||
-        array instanceof this._globalObject.BigInt64Array ||
-        array instanceof this._globalObject.BigUint64Array)) {
+    // Note: this rejects Float32Array, Float64Array and DataView.
+    //
+    // We perform "instance tests" by comparing `array.constructor.name` so
+    // that the tests will be successful across realms.
+    const typeName = array.constructor.name;
+    if (!(typeName === "Int8Array" ||
+        typeName === "Uint8Array" ||
+        typeName === "Uint8ClampedArray" ||
+        typeName === "Int16Array" ||
+        typeName === "Uint16Array" ||
+        typeName === "Int32Array" ||
+        typeName === "Uint32Array" ||
+        typeName === "BigInt64Array" ||
+        typeName === "BigUint64Array")) {
       throw DOMException.create(this._globalObject, [
-        `The type of an object is incompatible with the expected type of the parameter associated to the object`,
+        `getRandomValues() only accepts integer typed arrays`,
         "TypeMismatchError"
       ]);
     }
 
     if (array.byteLength > 65536) {
       throw DOMException.create(this._globalObject, [
-        `The quota has been exceeded.`,
+        `getRandomValues() cannot generate more than 65536 bytes of random values; ` +
+        `${array.byteLength} bytes were requested`,
         "QuotaExceededError"
       ]);
     }

--- a/lib/jsdom/living/crypto/Crypto.webidl
+++ b/lib/jsdom/living/crypto/Crypto.webidl
@@ -1,0 +1,4 @@
+[Exposed=(Window,Worker)]
+interface Crypto {
+  ArrayBufferView getRandomValues(ArrayBufferView array);
+};

--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -146,6 +146,8 @@ const generatedInterfaces = {
   Performance: require("./generated/Performance"),
   Navigator: require("./generated/Navigator"),
 
+  Crypto: require("./generated/Crypto"),
+
   PluginArray: require("./generated/PluginArray"),
   MimeTypeArray: require("./generated/MimeTypeArray"),
   Plugin: require("./generated/Plugin"),

--- a/scripts/webidl/convert.js
+++ b/scripts/webidl/convert.js
@@ -146,6 +146,7 @@ function addDir(dir) {
 addDir("../../lib/jsdom/living/aborting");
 addDir("../../lib/jsdom/living/attributes");
 addDir("../../lib/jsdom/living/constraint-validation");
+addDir("../../lib/jsdom/living/crypto");
 addDir("../../lib/jsdom/living/cssom");
 addDir("../../lib/jsdom/living/custom-elements");
 addDir("../../lib/jsdom/living/domparsing");

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -29,6 +29,14 @@ url/**: [timeout, blob URLs not implemented]
 
 ---
 
+DIR: WebCryptoAPI
+
+"*/**": [fail, Not implemented]
+idlharness.https.any.html: [fail, Unknown]
+randomUUID.https.any.html: [fail, Not implemented]
+
+---
+
 DIR: cors
 
 304.htm: [fail-slow, Unknown]


### PR DESCRIPTION
This is the only member of `crypto` that is available even in non-secure contexts.

---

Motivation: Since we fixed a security in Scala.js related to `java.util.UUID.randomUUID()` (see https://github.com/scala-js/scala-js/security/advisories/GHSA-j2f9-w8wh-9ww4), the need for `crypto.getRandomValues` has become quite high. `jsdom` is one of the main testing environments used by the Scala.js community. The lack of `getRandomValues` is now causing several maintainers and project authors to use insecure variants because of `jsdom`. This in turn risks exposing them to security vulnerabilities of their own. I hope that by actually providing `crypto.getRandomValues` in `jsdom`, we will avoid this problematic situation.

---

This is my first contribution to `jsdom`. Don't hesitate to tell me if anything should be done differently. Also, if things should change, please tell me whether you prefer amending the commits and force-pushing on the branch, or whether you prefer to add fixup commits to the branch.