### PR TITLE
Fixed some code prone to error

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -372,10 +372,12 @@ function Window(options) {
       return external;
     },
     get location() {
-      return idlUtils.wrapperForImpl(idlUtils.implForWrapper(window._document)._location);
+      const _document = idlUtils.implForWrapper(window._document) || {};
+      return idlUtils.wrapperForImpl(_document._location);
     },
     get history() {
-      return idlUtils.wrapperForImpl(idlUtils.implForWrapper(window._document)._history);
+      const _document = idlUtils.implForWrapper(window._document) || {};
+      return idlUtils.wrapperForImpl(_document._history);
     },
     get navigator() {
       return navigator;


### PR DESCRIPTION
The `idlUtils.implForWrapper` method can return null sometimes and it causes the error `Cannot read property '_location' of null`.

I'm not sure if you can use optional chaining feature, just let me know to make the changes in the PR. Another solution could be make that the `idlUtils.wrapperForImpl` method returns an empty object instead of a `null` value by default.

I think it could be related to this issue https://github.com/jsdom/jsdom/issues/2121
But, it happens when you run unit tests using jest and this library too.