### PR TITLE
Tests for querySelector(All) with comma separated :scope pseudo selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
     "is-potential-custom-element-name": "^1.0.1",
-    "nwsapi": "^2.2.0",
+    "nwsapi": "^2.2.2",
     "parse5": "^7.0.0",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1106,7 +1106,6 @@ template-element/template-content-hierarcy.html: [fail, "We do not implement htt
 
 DIR: html/semantics/selectors
 
-pseudo-classes/autofill.html: [fail, https://github.com/dperini/nwsapi/issues/44]
 pseudo-classes/checked-type-change.html: [fail, CSS computed style computation]
 pseudo-classes/dir-html-input-dynamic-text.html: [fail, need nwsapi fix]
 pseudo-classes/dir.html: [fail, https://github.com/dperini/nwsapi/issues/45]
@@ -1115,7 +1114,6 @@ pseudo-classes/focus.html: [timeout, Unknown]
 pseudo-classes/indeterminate-radio.html: [fail, CSS computed style computation]
 pseudo-classes/indeterminate-type-change.html: [fail, CSS computed style computation]
 pseudo-classes/inrange-outofrange-type-change.html: [fail, CSS computed style computation]
-pseudo-classes/link.html: [fail, https://github.com/dperini/nwsapi/issues/43]
 pseudo-classes/placeholder-shown-type-change.html: [fail, CSS computed style computation]
 pseudo-classes/readwrite-readonly-type-change.html: [fail, CSS computed style computation]
 pseudo-classes/readwrite-readonly.html: [fail, Unknown]

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelector-All-scope.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelector-All-scope.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>
+  querySelector(All) must work with comma seperated :scope pseudo selector
+</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- Regression test for https://github.com/jsdom/jsdom/issues/2359 -->
+
+<div>
+  <p><span>hello</span></p>
+  <p id="p2">hey</p>
+  <div>div</div>
+</div>
+
+<script>
+  "use strict";
+  const div = document.querySelector("div");
+  const p = document.querySelector("p");
+  const p2 = document.querySelector("#p2");
+
+  test(() => {
+    assert_equals(div.querySelector(":scope > p"), p);
+    assert_equals(div.querySelector(":scope > span"), null);
+  }, "querySelector");
+
+  test(() => {
+    assert_array_equals(div.querySelectorAll(":scope > p"), [p, p2]);
+    assert_array_equals(div.querySelectorAll(":scope > span"), []);
+  }, "querySelectorAll");
+
+  test(() => {
+    assert_equals(div.querySelector(":scope > p, :scope > div"), p);
+  }, "querySelector comma separted");
+
+  test(() => {
+    assert_array_equals(div.querySelectorAll(":scope > p, :scope > div"), [p, p2, div]);
+  }, "querySelectorAll comma separted");
+</script>

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelector-All-scope.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelector-All-scope.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>
   querySelector(All) must work with comma seperated :scope pseudo selector
 </title>
@@ -10,30 +10,31 @@
 <div>
   <p><span>hello</span></p>
   <p id="p2">hey</p>
-  <div>div</div>
+  <div id="d2">div</div>
 </div>
 
 <script>
-  "use strict";
-  const div = document.querySelector("div");
-  const p = document.querySelector("p");
-  const p2 = document.querySelector("#p2");
+"use strict";
+const div = document.querySelector("div");
+const div2 = document.querySelector("#d2");
+const p = document.querySelector("p");
+const p2 = document.querySelector("#p2");
 
-  test(() => {
-    assert_equals(div.querySelector(":scope > p"), p);
-    assert_equals(div.querySelector(":scope > span"), null);
-  }, "querySelector");
+test(() => {
+  assert_equals(div.querySelector(":scope > p"), p);
+  assert_equals(div.querySelector(":scope > span"), null);
+}, "querySelector");
 
-  test(() => {
-    assert_array_equals(div.querySelectorAll(":scope > p"), [p, p2]);
-    assert_array_equals(div.querySelectorAll(":scope > span"), []);
-  }, "querySelectorAll");
+test(() => {
+  assert_array_equals(div.querySelectorAll(":scope > p"), [p, p2]);
+  assert_array_equals(div.querySelectorAll(":scope > span"), []);
+}, "querySelectorAll");
 
-  test(() => {
-    assert_equals(div.querySelector(":scope > p, :scope > div"), p);
-  }, "querySelector comma separted");
+test(() => {
+  assert_equals(div.querySelector(":scope > p, :scope > div"), p);
+}, "querySelector comma separated");
 
-  test(() => {
-    assert_array_equals(div.querySelectorAll(":scope > p, :scope > div"), [p, p2, div]);
-  }, "querySelectorAll comma separted");
+test(() => {
+  assert_array_equals(div.querySelectorAll(":scope > p, :scope > div"), [p, p2, div2]);
+}, "querySelectorAll comma separated");
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,10 +2174,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-nwsapi@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
-  integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
+nwsapi@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
+  integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
 object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Here are the tests reproducing the errors from https://github.com/jsdom/jsdom/issues/3141

Current behavior
---

Simple :scope selectors work as expected.
```
div.querySelector(":scope > p");
div.querySelectorAll(":scope > p"),
```

Comma separated :scope selectors throw an exception.
```
div.querySelector(":scope > p, :scope > div");
div.querySelectorAll(":scope > p, :scope > div");
```

Output
```
Failed in "querySelector comma separted":
unknown pseudo-class selector ':scope>*'

SyntaxError: unknown pseudo-class selector ':scope>*'
    at emit (../jsdom/node_modules/nwsapi/src/nwsapi.js:565:17)
    at compileSelector (../jsdom/node_modules/nwsapi/src/nwsapi.js:1292:17)
    at compile (../jsdom/node_modules/nwsapi/src/nwsapi.js:753:16)
    at collect (../jsdom/node_modules/nwsapi/src/nwsapi.js:1553:24)
    at _querySelectorAll (../jsdom/node_modules/nwsapi/src/nwsapi.js:1518:36)
    at Object._querySelector [as first] (../jsdom/node_modules/nwsapi/src/nwsapi.js:1424:14)
    at HTMLDivElementImpl.querySelector (../jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:69:44)
    at HTMLDivElement.querySelector (../jsdom/lib/jsdom/living/generated/Element.js:1094:58)
    at Test.<anonymous> (http://web-platform.test:10000/dom/nodes/ParentNode-querySelector-All-scope.html:18:23)
    at Test.step (http://web-platform.test:10000/resources/testharness.js:2087:25)
    at test (http://web-platform.test:10000/resources/testharness.js:557:30)
    at http://web-platform.test:10000/dom/nodes/ParentNode-querySelector-All-scope.html:17:3
    at Script.runInContext (node:vm:139:12)
    at Object.runInContext (node:vm:289:6)
    at processJavaScript (../jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:241:10)
    at HTMLScriptElementImpl._innerEval (../jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:176:5)
    at ../jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:115:12
    at Object.check (../jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23)
    at ../jsdom/lib/jsdom/browser/resources/resource-queue.js:83:27
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

Failed in "querySelectorAll comma separted":
unknown pseudo-class selector ':scope>*'

SyntaxError: unknown pseudo-class selector ':scope>*'
    at emit (../jsdom/node_modules/nwsapi/src/nwsapi.js:565:17)
    at compileSelector (../jsdom/node_modules/nwsapi/src/nwsapi.js:1292:17)
    at compile (../jsdom/node_modules/nwsapi/src/nwsapi.js:753:16)
    at collect (../jsdom/node_modules/nwsapi/src/nwsapi.js:1553:24)
    at Object._querySelectorAll [as select] (../jsdom/node_modules/nwsapi/src/nwsapi.js:1518:36)
    at HTMLDivElementImpl.querySelectorAll (../jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:78:26)
    at HTMLDivElement.querySelectorAll (../jsdom/lib/jsdom/living/generated/Element.js:1119:58)
    at Test.<anonymous> (http://web-platform.test:10000/dom/nodes/ParentNode-querySelector-All-scope.html:22:29)
    at Test.step (http://web-platform.test:10000/resources/testharness.js:2087:25)
    at test (http://web-platform.test:10000/resources/testharness.js:557:30)
    at http://web-platform.test:10000/dom/nodes/ParentNode-querySelector-All-scope.html:21:3
    at Script.runInContext (node:vm:139:12)
    at Object.runInContext (node:vm:289:6)
    at processJavaScript (../jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:241:10)
    at HTMLScriptElementImpl._innerEval (../jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:176:5)
    at ../jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:115:12
    at Object.check (../jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23)
    at ../jsdom/lib/jsdom/browser/resources/resource-queue.js:83:27
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

Expected behavior in Chrome
---
<img width="364" alt="Bildschirmfoto 2022-07-08 um 10 55 06" src="https://user-images.githubusercontent.com/4380295/177956079-529b5218-640c-4590-b7ed-48d289338fde.png">

