### PR TITLE
Performance of appending option to select

### DIFF
--- a/benchmark/html/index.js
+++ b/benchmark/html/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
 module.exports = {
-  parsing: require("./parsing")
+  parsing: require("./parsing"),
+  select: require("./select")
 };

--- a/benchmark/html/select.js
+++ b/benchmark/html/select.js
@@ -1,0 +1,9 @@
+"use strict";
+const suite = require("../document-suite");
+
+exports.text = suite(document => {
+  document.body.innerHTML = `
+  <select>
+    ${"<option value=\"volvo\">Volvo</option>".repeat(5000)}
+  </select>`;
+});

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -15,19 +15,6 @@ const { domSymbolTree } = require("../helpers/internal-constants");
 const { getLabelsForLabelable, formOwner, isDisabled } = require("../helpers/form-controls");
 const { parseNonNegativeInteger } = require("../helpers/strings");
 
-function toOptionArray(child) {
-  const array = [];
-  if (child._localName === "option" && !child.hasAttributeNS(null, "disabled")) {
-    array.push(child);
-  } else if (child._localName === "optgroup") {
-    for (const childOfGroup of domSymbolTree.childrenIterator(child)) {
-      if (childOfGroup._localName === "option" && !childOfGroup.hasAttributeNS(null, "disabled")) {
-        array.push(childOfGroup);
-      }
-    }
-  }
-  return array;
-}
 class HTMLSelectElementImpl extends HTMLElementImpl {
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
@@ -56,8 +43,8 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 
     this._labels = null;
 
-    // Essentially a cache for the current selected element for use while building a select by appending options
-    // See #_selectednessSettingAlgorithmWithKnownNewAddition
+    // Essentially a cache for the current selected element for use while building a select by appending options.
+    // See _selectednessSettingAlgorithmWithKnownNewAddition().
     this._lastSelectedOptionForFastPath = null;
   }
 
@@ -336,6 +323,20 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 }
 
 mixin(HTMLSelectElementImpl.prototype, DefaultConstraintValidationImpl.prototype);
+
+function toOptionArray(child) {
+  const array = [];
+  if (child._localName === "option" && !child.hasAttributeNS(null, "disabled")) {
+    array.push(child);
+  } else if (child._localName === "optgroup") {
+    for (const childOfGroup of domSymbolTree.childrenIterator(child)) {
+      if (childOfGroup._localName === "option" && !childOfGroup.hasAttributeNS(null, "disabled")) {
+        array.push(childOfGroup);
+      }
+    }
+  }
+  return array;
+}
 
 module.exports = {
   implementation: HTMLSelectElementImpl

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -15,6 +15,19 @@ const { domSymbolTree } = require("../helpers/internal-constants");
 const { getLabelsForLabelable, formOwner, isDisabled } = require("../helpers/form-controls");
 const { parseNonNegativeInteger } = require("../helpers/strings");
 
+function toOptionArray(child) {
+  const array = [];
+  if (child._localName === "option" && !child.hasAttributeNS(null, "disabled")) {
+    array.push(child);
+  } else if (child._localName === "optgroup") {
+    for (const childOfGroup of domSymbolTree.childrenIterator(child)) {
+      if (childOfGroup._localName === "option" && !childOfGroup.hasAttributeNS(null, "disabled")) {
+        array.push(childOfGroup);
+      }
+    }
+  }
+  return array;
+}
 class HTMLSelectElementImpl extends HTMLElementImpl {
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
@@ -42,6 +55,10 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     this._customValidityErrorMessage = "";
 
     this._labels = null;
+
+    // Essentially a cache for the current selected element for use while building a select by appending options
+    // See #_selectednessSettingAlgorithmWithKnownNewAddition
+    this._lastSelectedOptionForFastPath = null;
   }
 
   _formReset() {
@@ -53,6 +70,10 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   _askedForAReset() {
+    this._selectednessSettingAlgorithm();
+  }
+
+  _selectednessSettingAlgorithm() {
     if (this.hasAttributeNS(null, "multiple")) {
       return;
     }
@@ -74,6 +95,7 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
         if (!disabled) {
           // (do not set dirty)
           option._selectedness = true;
+          this._lastSelectedOptionForFastPath = option;
           break;
         }
       }
@@ -82,12 +104,46 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
       selected.forEach((option, index) => {
         option._selectedness = index === selected.length - 1;
       });
+      this._lastSelectedOptionForFastPath = selected[selected.length - 1];
+    }
+  }
+
+  _selectednessSettingAlgorithmWithKnownNewAddition(child) {
+    if (this.hasAttributeNS(null, "multiple")) {
+      return;
+    }
+    if (child.hasAttributeNS(null, "disabled")) {
+      return;
+    }
+    const optArr = toOptionArray(child);
+    if (optArr.length === 0) {
+      return;
+    }
+    const selectedOptions = optArr.filter(opt => opt._selectedness);
+    // If any selected is last selected
+    if (selectedOptions.length > 0) {
+      // pushed at least one element with selected=true, reset
+      this._askedForAReset();
+      return;
+    }
+
+    // No selection so first option is selected
+    if ((!this._lastSelectedOptionForFastPath || !this._lastSelectedOptionForFastPath._selectedness) &&
+        this._displaySize === 1) {
+      this._lastSelectedOptionForFastPath = optArr[0];
+      this._lastSelectedOptionForFastPath._selectedness = true;
     }
   }
 
   _descendantAdded(parent, child) {
     if (child.nodeType === NODE_TYPE.ELEMENT_NODE) {
-      this._askedForAReset();
+      if (parent === this) {
+        this._selectednessSettingAlgorithmWithKnownNewAddition(child);
+      } else if (parent._localName === "optgroup") {
+        this._selectednessSettingAlgorithmWithKnownNewAddition(parent);
+      } else {
+        this._askedForAReset();
+      }
     }
 
     super._descendantAdded(parent, child);
@@ -95,6 +151,9 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 
   _descendantRemoved(parent, child) {
     if (child.nodeType === NODE_TYPE.ELEMENT_NODE) {
+      if (this._lastSelectedOptionForFastPath === child) {
+        this._lastSelectedOptionForFastPath = null;
+      }
       this._askedForAReset();
     }
 


### PR DESCRIPTION
Previous implementation of adding 'option' elements to 'select' elements caused an '(N*N/2)' issue where all previous elements would be added to an array to find either the last selected or first non disabled. Now this logic is run on just the 'option' element being appended.    

## Before

```
yarn benchmark -suites=html
yarn run v1.22.19
$ node ./benchmark/runner -suites=html
# html/select/text #
jsdom  x 1.56 ops/sec ±3.61% (8 runs sampled)
Done in 11.29s.
```

## After

```
yarn benchmark -suites=html
yarn run v1.22.19
$ node ./benchmark/runner -suites=html
# html/select/text #
jsdom  x 10.15 ops/sec ±6.53% (31 runs sampled)
Done in 7.23s.
```

Discovered this when I passed some html with a select with 20k option elements to JDSOM.

First pass at a fix and first time writing anything for nodejs so any and all feedback welcome including this not being the right way to solve the problem.