### PR TITLE
Add part as a global HTML Element attribute

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -545,6 +545,16 @@ class ElementImpl extends NodeImpl {
     const matcher = addNwsapi(this);
     return matcher.closest(selectors, idlUtils.wrapperForImpl(this));
   }
+
+  get part() {
+    if (this._part === undefined) {
+      this._part = DOMTokenList.createImpl(this._globalObject, [], {
+        element: this,
+        attributeLocalName: "part"
+      });
+    }
+    return this._part;
+  }
 }
 
 mixin(ElementImpl.prototype, NonDocumentTypeChildNode.prototype);

--- a/lib/jsdom/living/nodes/Element.webidl
+++ b/lib/jsdom/living/nodes/Element.webidl
@@ -88,3 +88,8 @@ partial interface Element {
   readonly attribute long clientWidth;
   readonly attribute long clientHeight;
 };
+
+// https://www.w3.org/TR/css-shadow-parts-1/#idl
+partial interface Element {
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList part;
+};

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -61,6 +61,41 @@ simple-requests.htm: [timeout, Maybe https://github.com/jsdom/jsdom/issues/1833 
 
 ---
 
+DIR: css/css-shadow-parts
+
+all-hosts.html: [fail, CSS-shadow part style mapping not implemented]
+chaining-invalid-selector.html: [fail, CSS-shadow part style mapping not implemented]
+complex-matching.html: [fail, CSS-shadow part style mapping not implemented]
+complex-non-matching.html: [fail, CSS-shadow part style mapping not implemented]
+different-host.html: [fail, CSS-shadow part style mapping not implemented]
+double-forward.html: [fail, CSS-shadow part style mapping not implemented]
+exportparts-multiple.html: [fail, CSS-shadow part style mapping not implemented]
+host-part-001.html: [fail, CSS-shadow part style mapping not implemented]
+host-stylesheet.html: [fail, CSS-shadow part style mapping not implemented]
+idlharness.html: [fail, CSS-shadow part style mapping not implemented]
+inner-host.html: [fail, CSS-shadow part style mapping not implemented]
+interaction-with-pseudo-elements.html: [fail, CSS-shadow part style mapping not implemented]
+invalidation-change-exportparts-forward.html: [fail, CSS-shadow part style mapping not implemented]
+invalidation-change-part-name-forward.html: [fail, CSS-shadow part style mapping not implemented]
+invalidation-change-part-name-idl-domtokenlist.html: [fail, CSS-shadow part style mapping not implemented]
+invalidation-change-part-name-idl-setter.html: [fail, CSS-shadow part style mapping not implemented]
+invalidation-change-part-name.html: [fail, CSS-shadow part style mapping not implemented]
+invalidation-complex-selector-forward.html: [fail, CSS-shadow part style mapping not implemented]
+invalidation-complex-selector.html: [fail, CSS-shadow part style mapping not implemented]
+multiple-parts.html: [fail, CSS-shadow part style mapping not implemented]
+precedence-part-vs-part.html: [fail, CSS-shadow part style mapping not implemented]
+serialization.html: [fail, CSS-shadow part style mapping not implemented]
+simple-forward-shorthand.html: [fail, CSS-shadow part style mapping not implemented]
+simple-forward.html: [fail, CSS-shadow part style mapping not implemented]
+simple-important-important.html: [fail, CSS-shadow part style mapping not implemented]
+simple-important-inline.html: [fail, CSS-shadow part style mapping not implemented]
+simple-important.html: [fail, CSS-shadow part style mapping not implemented]
+simple-inline.html: [fail, CSS-shadow part style mapping not implemented]
+simple.html: [fail, CSS-shadow part style mapping not implemented]
+style-sharing.html: [fail, CSS-shadow part style mapping not implemented]
+
+---
+
 DIR: css/cssom-view
 
 CaretPosition-001.html: [fail, Unknown]


### PR DESCRIPTION
This PR resolves #3366 by adding the [part](https://developer.mozilla.org/en-US/docs/Web/API/Element/part) attribute as a global attribute to the HTML Element interface. 

While this PR does not include an implementation of the [css-shadow-parts spec](https://www.w3.org/TR/css-shadow-parts-1/#element-part-name-map), the [WPT's for css-shadow-parts](https://github.com/web-platform-tests/wpt/tree/master/css/css-shadow-parts) has been included as there is a test to check for the [part name in the idl](https://github.com/web-platform-tests/wpt/blob/master/css/css-shadow-parts/part-name-idl.html).