### PR TITLE
Removed caret from tough-cookie to mitigate v4.1.0 breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "parse5": "^7.0.0",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",
-    "tough-cookie": "^4.0.0",
+    "tough-cookie": "4.0.0",
     "w3c-xmlserializer": "^3.0.0",
     "webidl-conversions": "^7.0.0",
     "whatwg-encoding": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,7 +2904,7 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-tough-cookie@^4.0.0:
+tough-cookie@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
   integrity sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==


### PR DESCRIPTION
See issues: https://github.com/jsdom/jsdom/issues/3419 and https://github.com/salesforce/tough-cookie/issues/246 for more information.

v4.1.0 of tough-cookie is a breaking change,  and has broken many jest tests and builds.
An immediate solution is to fix the version of tough-cookie to v4.0.0 which is what this PR has done.