### PR TITLE
Update resource-loader.js

### DIFF
--- a/lib/jsdom/browser/resources/resource-loader.js
+++ b/lib/jsdom/browser/resources/resource-loader.js
@@ -134,6 +134,12 @@ module.exports = class ResourceLoader {
         }
       }
 
+      case "blob": {
+        return resolveObjectURL(urlString).arrayBuffer().then((arrayBuffer) => {
+          return Buffer.from(arrayBuffer, 'binary');
+        })
+      }
+
       default: {
         return Promise.reject(new Error(`Tried to fetch URL ${urlString} with invalid scheme ${url.scheme}`));
       }


### PR DESCRIPTION
Node.js has supported Blob url since v16.0.7, should we add a blob case here?