### PR TITLE
Fix location.pathname getter on opaque-path URLs

### DIFF
--- a/lib/jsdom/living/window/History-impl.js
+++ b/lib/jsdom/living/window/History-impl.js
@@ -86,8 +86,7 @@ exports.implementation = class HistoryImpl {
           newURL.username !== this._document._URL.username ||
           newURL.password !== this._document._URL.password ||
           newURL.host !== this._document._URL.host ||
-          newURL.port !== this._document._URL.port ||
-          newURL.cannotBeABaseURL !== this._document._URL.cannotBeABaseURL) {
+          newURL.port !== this._document._URL.port) {
         throw DOMException.create(this._globalObject, [
           `${methodName} cannot update history to a URL which differs in components other than in ` +
           `path, query, or fragment.`,

--- a/lib/jsdom/living/window/Location-impl.js
+++ b/lib/jsdom/living/window/Location-impl.js
@@ -84,7 +84,7 @@ exports.implementation = class LocationImpl {
   set host(v) {
     const copyURL = { ...this._url };
 
-    if (copyURL.cannotBeABaseURL) {
+    if (whatwgURL.hasAnOpaquePath(copyURL)) {
       return;
     }
 
@@ -103,7 +103,7 @@ exports.implementation = class LocationImpl {
   set hostname(v) {
     const copyURL = { ...this._url };
 
-    if (copyURL.cannotBeABaseURL) {
+    if (whatwgURL.hasAnOpaquePath(copyURL)) {
       return;
     }
 
@@ -122,7 +122,7 @@ exports.implementation = class LocationImpl {
   set port(v) {
     const copyURL = { ...this._url };
 
-    if (copyURL.host === null || copyURL.cannotBeABaseURL || copyURL.scheme === "file") {
+    if (whatwgURL.cannotHaveAUsernamePasswordPort(copyURL)) {
       return;
     }
 
@@ -132,18 +132,12 @@ exports.implementation = class LocationImpl {
   }
 
   get pathname() {
-    const url = this._url;
-
-    if (url.cannotBeABaseURL) {
-      return url.path[0];
-    }
-
-    return "/" + url.path.join("/");
+    return whatwgURL.serializePath(this._url);
   }
   set pathname(v) {
     const copyURL = { ...this._url };
 
-    if (copyURL.cannotBeABaseURL) {
+    if (whatwgURL.hasAnOpaquePath(copyURL)) {
       return;
     }
 

--- a/test/web-platform-tests/to-upstream/html/browsers/history/the-location-interface/location-getters-about-blank.html
+++ b/test/web-platform-tests/to-upstream/html/browsers/history/the-location-interface/location-getters-about-blank.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Location properties on an about:blank page</title>
+<!-- Context: https://github.com/jsdom/jsdom/issues/3431 -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe></iframe>
+
+<script>
+"use strict";
+
+test(() => {
+  const l = frames[0].location;
+
+  assert_equals(l.href, "about:blank", "href");
+  assert_equals(l.origin, "null", "origin");
+  assert_equals(l.protocol, "about:", "protocol");
+  assert_equals(l.host, "", "host");
+  assert_equals(l.hostname, "", "hostname");
+  assert_equals(l.port, "", "port");
+  assert_equals(l.pathname, "blank", "pathname");
+  assert_equals(l.search, "", "search");
+  assert_equals(l.hash, "", "hash");
+});
+</script>


### PR DESCRIPTION
This broke in 6c1f0585e33afceff2e802867f2abaee1c08f48f when we upgraded whatwg-url without adapting Location for its breaking changes.

Some fixes here (e.g. to the setters) are not really testable, since we never navigate after changing the host or port of an opaque-path URL anyway. But we include them for completeness.

Closes #3431.