### PR TITLE
Feat add promiserejection event class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .svn
 .*.swp

--- a/lib/jsdom/living/events/PromiseRejectionEvent-impl.js
+++ b/lib/jsdom/living/events/PromiseRejectionEvent-impl.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const EventImpl = require("./Event-impl").implementation;
+
+const PromiseRejectionEventInit = require("../generated/PromiseRejectionEventInit");
+
+class PromiseRejectionEventImpl extends EventImpl {
+
+}
+PromiseRejectionEventImpl.defaultInit = PromiseRejectionEventInit.convert(undefined, undefined);
+
+module.exports = {
+  implementation: PromiseRejectionEventImpl
+};

--- a/lib/jsdom/living/events/PromiseRejectionEvent.webidl
+++ b/lib/jsdom/living/events/PromiseRejectionEvent.webidl
@@ -1,0 +1,13 @@
+// https://html.spec.whatwg.org/multipage/webappapis.html#the-promiserejectionevent-interface
+[Exposed=(Window,Worker)]
+interface PromiseRejectionEvent : Event {
+  constructor(DOMString type, PromiseRejectionEventInit eventInitDict);
+
+  readonly attribute Promise<any> promise;
+  readonly attribute any reason;
+};
+
+dictionary PromiseRejectionEventInit : EventInit {
+  required Promise<any> promise;
+  any reason;
+};


### PR DESCRIPTION
In our repo we are missing this event constructor for testing some of the error capturing mechanisms we build in jest.

I am not sure actually about how to test this if it is needed?
Also not sure if this is all I have to do?