### PR TITLE
add missing abort method for sad path

### DIFF
--- a/lib/jsdom/living/xhr/xhr-utils.js
+++ b/lib/jsdom/living/xhr/xhr-utils.js
@@ -327,6 +327,9 @@ function createClient(xhr) {
       const eventEmitterclient = new EventEmitter();
       process.nextTick(() => eventEmitterclient.emit("error", e));
       eventEmitterclient.end = () => {};
+      eventEmitterclient.abort = () => {
+        // do nothing
+      };
       return eventEmitterclient;
     }
   }

--- a/test/web-platform-tests/to-upstream/xhr/abort-with-error.any.js
+++ b/test/web-platform-tests/to-upstream/xhr/abort-with-error.any.js
@@ -1,0 +1,15 @@
+// META: title=XMLHttpRequest: abort() still works when error thrown internally
+
+      var test = async_test();
+
+      test.step(function() {
+        var client = new XMLHttpRequest();
+
+        client.open("GET", "invalid-protocol://example.com", true);
+        client.onabort = test.step_func(function() {
+          test.done();
+        });
+        
+        client.send(null);
+        client.abort();
+      });

--- a/test/web-platform-tests/to-upstream/xhr/abort-with-error.any.js
+++ b/test/web-platform-tests/to-upstream/xhr/abort-with-error.any.js
@@ -1,15 +1,16 @@
+"use strict";
 // META: title=XMLHttpRequest: abort() still works when error thrown internally
 
-      var test = async_test();
+const test_runner = async_test();
 
-      test.step(function() {
-        var client = new XMLHttpRequest();
+test_runner.step(() => {
+  const client = new XMLHttpRequest();
 
-        client.open("GET", "invalid-protocol://example.com", true);
-        client.onabort = test.step_func(function() {
-          test.done();
-        });
-        
-        client.send(null);
-        client.abort();
-      });
+  client.open("GET", "invalid-protocol://example.com", true);
+  client.onabort = test_runner.step_func(() => {
+    test_runner.done();
+  });
+
+  client.send(null);
+  client.abort();
+});


### PR DESCRIPTION
Thanks @domenic and team for the great project,

Your XMLHttpRequest implementation wraps an internal client called `client`.  When we abort the request it aborts the internal client [here](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/living/xhr/XMLHttpRequest-impl.js#L364).  Now this internal client is created in `xhr-utils.createClient` which has a number of paths for data url, file url etc.  At the catch statement [here](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/living/xhr/xhr-utils.js#L326) we still assign client, but it is an `EventEmitter` which lacks an abort method.  If we then try to abort the wrapping XMLHttpRequest it throws a strange exception which doesn't tell the user about the true root cause.  I suggest adding an empty abort method to prevent confusion.

I want to add a unit test as well, but I'm not sure how to trigger the catch block.  If you agree with this change I can do so using e.g. Sinon or any other way that you suggest.