### PR TITLE
fix(getModifierState): query the correct property for alt, ctrl, meta, and shift keys

### DIFF
--- a/lib/jsdom/living/events/EventModifierMixin-impl.js
+++ b/lib/jsdom/living/events/EventModifierMixin-impl.js
@@ -11,6 +11,12 @@ class EventModifierMixinImpl {
   // these invalid modifiers will be undefined on `this` (thus `false` after casting it to boolean), we don't need to do
   // extra checking for validity.
   getModifierState(keyArg) {
+    if (keyArg === "Control") {
+      return Boolean(this.ctrlKey);
+    }
+    if (["Alt", "Meta", "Shift"].includes(keyArg)) {
+      return Boolean(this[`${keyArg.toLowerCase()}Key`]);
+    }
     return Boolean(this[`modifier${keyArg}`]);
   }
 }

--- a/test/web-platform-tests/to-upstream/uievents/getModifierState.html
+++ b/test/web-platform-tests/to-upstream/uievents/getModifierState.html
@@ -26,6 +26,34 @@ test(() => {
 }, "getModifierState false");
 
 test(() => {
+  const kbEvent = new KeyboardEvent("eventName", { ctrlKey: true });
+  const mouseEvent = new MouseEvent("eventName", { ctrlKey: true });
+  assert_equals(kbEvent.getModifierState("Control"), true);
+  assert_equals(mouseEvent.getModifierState("Control"), true);
+}, "getModifierState Control true");
+
+test(() => {
+  const kbEvent = new KeyboardEvent("eventName", { ctrlKey: false });
+  const mouseEvent = new MouseEvent("eventName", { ctrlKey: false });
+  assert_equals(kbEvent.getModifierState("Control"), false);
+  assert_equals(mouseEvent.getModifierState("Control"), false);
+}, "getModifierState Control false");
+
+test(() => {
+  const kbEvent = new KeyboardEvent("eventName", { altKey: true });
+  const mouseEvent = new MouseEvent("eventName", { altKey: true });
+  assert_equals(kbEvent.getModifierState("Alt"), true);
+  assert_equals(mouseEvent.getModifierState("Alt"), true);
+}, "getModifierState Alt true");
+
+test(() => {
+  const kbEvent = new KeyboardEvent("eventName", { altKey: false });
+  const mouseEvent = new MouseEvent("eventName", { altKey: false });
+  assert_equals(kbEvent.getModifierState("Alt"), false);
+  assert_equals(mouseEvent.getModifierState("Alt"), false);
+}, "getModifierState Alt false");
+
+test(() => {
   const kbEvent = new KeyboardEvent("eventName");
   const mouseEvent = new MouseEvent("eventName");
   assert_equals(kbEvent.getModifierState("Invalid"), false);


### PR DESCRIPTION
This fixes #3126 

Chrome, Firefox, and Edge all return true for `getModifierState('Control')` when the `ctrlKey` property is true. Same for alt, meta, and shift modifiers as well. The spec doesn't seem to mention how the method should determine if a modifier is activated (https://www.w3.org/TR/uievents/#dom-keyboardevent-getmodifierstate) and since the `xKey` properties are the only ones on the instance that carry information about the state of these 4 modifiers, makes sense to look at those props for these 4 modifiers.