### PR TITLE
Don't look up the global custom elements registry through its sandbox-writable property.

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -342,7 +342,7 @@ function Window(options) {
   });
   const screen = Screen.create(window);
   const crypto = Crypto.create(window);
-  const customElementRegistry = CustomElementRegistry.create(window);
+  this._customElementRegistry = CustomElementRegistry.create(window);
 
   define(this, {
     get length() {
@@ -441,7 +441,7 @@ function Window(options) {
       return this._sessionStorage;
     },
     get customElements() {
-      return customElementRegistry;
+      return this._customElementRegistry;
     },
     get event() {
       return window._currentEvent ? idlUtils.wrapperForImpl(window._currentEvent) : undefined;

--- a/lib/jsdom/living/helpers/custom-elements.js
+++ b/lib/jsdom/living/helpers/custom-elements.js
@@ -149,7 +149,7 @@ function lookupCEDefinition(document, namespace, localName, isValue) {
     return definition;
   }
 
-  const registry = implForWrapper(document._globalObject.customElements);
+  const registry = implForWrapper(document._globalObject._customElementRegistry);
 
   const definitionByName = registry._customElementDefinitions.find(def => {
     return def.name === def.localName && def.localName === localName;

--- a/lib/jsdom/living/helpers/html-constructor.js
+++ b/lib/jsdom/living/helpers/html-constructor.js
@@ -10,7 +10,7 @@ const ALREADY_CONSTRUCTED_MARKER = Symbol("already-constructed-marker");
 
 // https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor
 function HTMLConstructor(globalObject, constructorName, newTarget) {
-  const registry = implForWrapper(globalObject.customElements);
+  const registry = implForWrapper(globalObject._customElementRegistry);
   if (newTarget === HTMLConstructor) {
     throw new TypeError("Invalid constructor");
   }

--- a/test/web-platform-tests/to-upstream/custom-elements/overwritten-customElements-global.html
+++ b/test/web-platform-tests/to-upstream/custom-elements/overwritten-customElements-global.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+test(() => {
+  class SomeElement1 extends HTMLElement {}
+  customElements.define("some-element-1", SomeElement1);
+
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  window.customElements = {};
+
+  const element = document.createElement("some-element-1");
+  assert_true(element instanceof SomeElement1);
+
+  Object.defineProperty(window, 'customElements', savedCustomElements);
+}, "Custom elements can still be created after `window.customElements` is overwritten.");
+
+test(() => {
+  class SomeElement2 extends HTMLElement {}
+  customElements.define("some-element-2", SomeElement2);
+
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  window.customElements = {};
+
+  const element = new SomeElement2();
+  assert_true(element instanceof SomeElement2);
+
+  Object.defineProperty(window, 'customElements', savedCustomElements);
+}, "Custom elements can still be constructed after `window.customElements` is overwritten.");
+
+test(() => {
+  class SomeElement3 extends HTMLElement {}
+  customElements.define("some-element-3", SomeElement3);
+
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  delete window.customElements;
+
+  const element = document.createElement("some-element-3");
+  assert_true(element instanceof SomeElement3);
+
+  Object.defineProperty(window, 'customElements', savedCustomElements);
+}, "Custom elements can still be created after `window.customElements` is deleted.");
+
+test(() => {
+  class SomeElement4 extends HTMLElement {}
+  customElements.define("some-element-4", SomeElement4);
+
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  delete window.customElements;
+
+  const element = new SomeElement4();
+  assert_true(element instanceof SomeElement4);
+
+  Object.defineProperty(window, 'customElements', savedCustomElements);
+}, "Custom elements can still be constructed after `window.customElements` is deleted.");
+</script>

--- a/test/web-platform-tests/to-upstream/custom-elements/overwritten-customElements-global.html
+++ b/test/web-platform-tests/to-upstream/custom-elements/overwritten-customElements-global.html
@@ -11,51 +11,51 @@ test(() => {
   class SomeElement1 extends HTMLElement {}
   customElements.define("some-element-1", SomeElement1);
 
-  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, "customElements");
   window.customElements = {};
 
   const element = document.createElement("some-element-1");
   assert_true(element instanceof SomeElement1);
 
-  Object.defineProperty(window, 'customElements', savedCustomElements);
+  Object.defineProperty(window, "customElements", savedCustomElements);
 }, "Custom elements can still be created after `window.customElements` is overwritten.");
 
 test(() => {
   class SomeElement2 extends HTMLElement {}
   customElements.define("some-element-2", SomeElement2);
 
-  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, "customElements");
   window.customElements = {};
 
   const element = new SomeElement2();
   assert_true(element instanceof SomeElement2);
 
-  Object.defineProperty(window, 'customElements', savedCustomElements);
+  Object.defineProperty(window, "customElements", savedCustomElements);
 }, "Custom elements can still be constructed after `window.customElements` is overwritten.");
 
 test(() => {
   class SomeElement3 extends HTMLElement {}
   customElements.define("some-element-3", SomeElement3);
 
-  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, "customElements");
   delete window.customElements;
 
   const element = document.createElement("some-element-3");
   assert_true(element instanceof SomeElement3);
 
-  Object.defineProperty(window, 'customElements', savedCustomElements);
+  Object.defineProperty(window, "customElements", savedCustomElements);
 }, "Custom elements can still be created after `window.customElements` is deleted.");
 
 test(() => {
   class SomeElement4 extends HTMLElement {}
   customElements.define("some-element-4", SomeElement4);
 
-  const savedCustomElements = Object.getOwnPropertyDescriptor(window, 'customElements');
+  const savedCustomElements = Object.getOwnPropertyDescriptor(window, "customElements");
   delete window.customElements;
 
   const element = new SomeElement4();
   assert_true(element instanceof SomeElement4);
 
-  Object.defineProperty(window, 'customElements', savedCustomElements);
+  Object.defineProperty(window, "customElements", savedCustomElements);
 }, "Custom elements can still be constructed after `window.customElements` is deleted.");
 </script>


### PR DESCRIPTION
jsdom currently finds the global custom elements registry by reading the sandbox-writable `.customElements` property of the global object. This means that code running in the sandbox can break jsdom by overwriting or deleting that property. This PR updates jsdom to store and look up a global object's custom element registry through a `_`-prefixed property instead (similar to `._document`).