### PR TITLE
Add the global structuredClone() method

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -745,6 +745,10 @@ function Window(options) {
     return result;
   };
 
+  this.structuredClone = function (...args) {
+    return structuredClone(...args);
+  };
+
   this.stop = function () {
     const manager = idlUtils.implForWrapper(this._document)._requestManager;
     if (manager) {


### PR DESCRIPTION
Adds the global [structuredClone()](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) method to the Window scope. The method was  introduced in Node.js version 17.0.0 ([release notes](https://nodejs.org/es/blog/release/v17.0.0/)). The available polyfills of the  structuredClone() method for Node.js are considered to be incomplete in comparison to the web browser JavaScript runtime implementations.

Example - Error message when the structuredClone() method is not defined in the global scope of Node.js (Node.js < 17)

```
ReferenceError: structuredClone is not defined
```

Users can provide their own polyfill of the structuredClone() method  (Node.js < 17)

```js
global.structuredClone = (value, options) => ...
```

References

- Specification: [HTML Standard](https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone)
- MDN: [structuredClone()](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)
- Node.js Documentation: [structuredClone()](https://nodejs.org/docs/latest/api/globals.html#structuredclonevalue-options)

Resolves https://github.com/jsdom/jsdom/issues/3363