### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/jsdom-ci.yml
+++ b/.github/workflows/jsdom-ci.yml
@@ -12,15 +12,18 @@ on:
     branches:
      - master
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: Run linter
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
       - name: Install dependencies
@@ -32,11 +35,11 @@ jobs:
       TEST_SUITE: 'node-canvas'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: Run Canvas tests with Node 18
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
       - name: Install required image manipulation packages with APT
@@ -52,11 +55,11 @@ jobs:
       TEST_SUITE: 'browser'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: Run web browser tests
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
       - name: Setup HOSTS file for Web Platform Test server
@@ -77,11 +80,11 @@ jobs:
         architecture:
           - x64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Run tests with Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         architecture: ${{ matrix.architecture }}


### PR DESCRIPTION
This PR:

-   Declares the minimum permissions for CI workflows to run at the workflow level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
-   Bumps GitHub Actions to their latest major versions, which now use Node 16 internally instead of Node 12 (EOL as of end of April 2022, no longer receives security updates):
    - Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    - Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)