### PR TITLE
Fix: Add support to alias x and y to MouseEvent

### DIFF
--- a/lib/jsdom/living/events/MouseEvent-impl.js
+++ b/lib/jsdom/living/events/MouseEvent-impl.js
@@ -33,6 +33,8 @@ class MouseEventImpl extends UIEventImpl {
     this.screenY = screenY;
     this.clientX = clientX;
     this.clientY = clientY;
+    this.x = clientX;
+    this.y = clientY;
     this.ctrlKey = ctrlKey;
     this.altKey = altKey;
     this.shiftKey = shiftKey;

--- a/lib/jsdom/living/events/MouseEvent.webidl
+++ b/lib/jsdom/living/events/MouseEvent.webidl
@@ -7,6 +7,8 @@ interface MouseEvent : UIEvent {
   readonly attribute long screenY;
   readonly attribute long clientX;
   readonly attribute long clientY;
+  readonly attribute long x;
+  readonly attribute long y;
 
   readonly attribute boolean ctrlKey;
   readonly attribute boolean shiftKey;

--- a/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
+++ b/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
@@ -74,6 +74,8 @@ async_test(t => {
     assert_equals(e.screenY, 0);
     assert_equals(e.clientX, 0);
     assert_equals(e.clientY, 0);
+    assert_equals(e.x, 0);
+    assert_equals(e.y, 0);
 
     assert_equals(e.button, 0);
     assert_equals(e.buttons, 0);


### PR DESCRIPTION
# Add support to alias x and y to MouseEvent

Fix created to solve the problem where it does not return the x and y attributes of the MouseEvent interface.

When the following script runs, we get the attributes as a result.
```js
const event = new MouseEvent("click", {
  clientX: 10,
  clientY: 20,
});
const { x, y, clientX, clientY } = event;
console.log(`x: ${x}`);
console.log(`y: ${y}`);
console.log(`clientX: ${clientX}`);
console.log(`clientY: ${clientY}`);
```
![image](https://user-images.githubusercontent.com/40774281/208225949-adbb2a49-d56f-4d72-9e22-81ab325356b1.png)

![image](https://user-images.githubusercontent.com/40774281/208225591-9678e5dc-f835-4fef-a8d1-a806d698d26b.png)
Interface of reference: https://www.w3.org/TR/cssom-view-1/#extensions-to-the-mouseevent-interface

![image](https://user-images.githubusercontent.com/40774281/208226075-8b26db31-f4a2-4665-849a-38a0cffe3903.png)
Reference: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent

This fixes #3470