### PR TITLE
Revert "Improve performance of appending <option> to <select>"

### DIFF
--- a/benchmark/html/index.js
+++ b/benchmark/html/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
 module.exports = {
-  parsing: require("./parsing"),
-  select: require("./select")
+  parsing: require("./parsing")
 };

--- a/benchmark/html/select.js
+++ b/benchmark/html/select.js
@@ -1,9 +1,0 @@
-"use strict";
-const suite = require("../document-suite");
-
-exports.text = suite(document => {
-  document.body.innerHTML = `
-  <select>
-    ${"<option value=\"volvo\">Volvo</option>".repeat(5000)}
-  </select>`;
-});

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -42,10 +42,6 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     this._customValidityErrorMessage = "";
 
     this._labels = null;
-
-    // Essentially a cache for the current selected element for use while building a select by appending options.
-    // See _selectednessSettingAlgorithmWithKnownNewAddition().
-    this._lastSelectedOptionForFastPath = null;
   }
 
   _formReset() {
@@ -57,10 +53,6 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
   }
 
   _askedForAReset() {
-    this._selectednessSettingAlgorithm();
-  }
-
-  _selectednessSettingAlgorithm() {
     if (this.hasAttributeNS(null, "multiple")) {
       return;
     }
@@ -82,7 +74,6 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
         if (!disabled) {
           // (do not set dirty)
           option._selectedness = true;
-          this._lastSelectedOptionForFastPath = option;
           break;
         }
       }
@@ -91,46 +82,12 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
       selected.forEach((option, index) => {
         option._selectedness = index === selected.length - 1;
       });
-      this._lastSelectedOptionForFastPath = selected[selected.length - 1];
-    }
-  }
-
-  _selectednessSettingAlgorithmWithKnownNewAddition(child) {
-    if (this.hasAttributeNS(null, "multiple")) {
-      return;
-    }
-    if (child.hasAttributeNS(null, "disabled")) {
-      return;
-    }
-    const optArr = toOptionArray(child);
-    if (optArr.length === 0) {
-      return;
-    }
-    const selectedOptions = optArr.filter(opt => opt._selectedness);
-    // If any selected is last selected
-    if (selectedOptions.length > 0) {
-      // pushed at least one element with selected=true, reset
-      this._askedForAReset();
-      return;
-    }
-
-    // No selection so first option is selected
-    if ((!this._lastSelectedOptionForFastPath || !this._lastSelectedOptionForFastPath._selectedness) &&
-        this._displaySize === 1) {
-      this._lastSelectedOptionForFastPath = optArr[0];
-      this._lastSelectedOptionForFastPath._selectedness = true;
     }
   }
 
   _descendantAdded(parent, child) {
     if (child.nodeType === NODE_TYPE.ELEMENT_NODE) {
-      if (parent === this) {
-        this._selectednessSettingAlgorithmWithKnownNewAddition(child);
-      } else if (parent._localName === "optgroup") {
-        this._selectednessSettingAlgorithmWithKnownNewAddition(parent);
-      } else {
-        this._askedForAReset();
-      }
+      this._askedForAReset();
     }
 
     super._descendantAdded(parent, child);
@@ -138,9 +95,6 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 
   _descendantRemoved(parent, child) {
     if (child.nodeType === NODE_TYPE.ELEMENT_NODE) {
-      if (this._lastSelectedOptionForFastPath === child) {
-        this._lastSelectedOptionForFastPath = null;
-      }
       this._askedForAReset();
     }
 
@@ -323,20 +277,6 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 }
 
 mixin(HTMLSelectElementImpl.prototype, DefaultConstraintValidationImpl.prototype);
-
-function toOptionArray(child) {
-  const array = [];
-  if (child._localName === "option" && !child.hasAttributeNS(null, "disabled")) {
-    array.push(child);
-  } else if (child._localName === "optgroup") {
-    for (const childOfGroup of domSymbolTree.childrenIterator(child)) {
-      if (childOfGroup._localName === "option" && !childOfGroup.hasAttributeNS(null, "disabled")) {
-        array.push(childOfGroup);
-      }
-    }
-  }
-  return array;
-}
 
 module.exports = {
   implementation: HTMLSelectElementImpl

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-selected.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-selected.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTMLSelectElement's selectedOptions and HTMLOptionElement's selected</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#dom-select-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<select id="sel">
+  <option id="opt1" value="x" data-foo="a" selected="selected">1st opt</option>
+  <option id="opt2" value="y" data-foo="b">2nd opt</option>
+</select>
+
+<script>
+"use strict";
+test(() => {
+  const select = document.getElementById("sel");
+  const opt1 = document.getElementById("opt1");
+
+  assert_equals(select.selectedOptions.length, 1);
+  assert_equals(select.selectedOptions[0], opt1);
+});
+</script>


### PR DESCRIPTION
Closes https://github.com/jsdom/jsdom/issues/3476

Reverts https://github.com/jsdom/jsdom/pull/3404 which broke `HTMLSelectElement.selectedOptions` when `HTMLOptionElement.selected` is set (revealed by broken `accname/name_file-label-embedded-select-manual.html` in https://github.com/eps1lon/dom-accessibility-api/pull/874

Browser:  HTMLOptionElement.selected
Pre 20.0.1: https://runkit.com/eps1lon/63ad844e952ef10008dda4f7
20.0.1: https://runkit.com/eps1lon/63ad82c22f199e000881c52e

## Test plan

- [x] test for expected behavior fails with https://github.com/jsdom/jsdom/pull/3404: https://github.com/jsdom/jsdom/actions/runs/3800475811/jobs/6463992433
- [x] test for expected behavior passes with https://github.com/jsdom/jsdom/pull/3404 reverted 