### PR TITLE
Add inheritance for pointer-events to getComputedStyle()

### DIFF
--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -18,6 +18,12 @@ exports.propertiesWithResolvedValueImplemented = {
     inherited: true,
     initial: "visible",
     computedValue: "as-specified"
+  },
+  // https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty
+  "pointer-events": {
+    inherited: true,
+    initial: "auto",
+    computedValue: "as-specified"
   }
 };
 
@@ -104,7 +110,7 @@ function getComputedValue(element, property) {
 }
 
 // https://drafts.csswg.org/cssom/#resolved-value
-// Only implements `visibility`
+// Only implements `visibility` and `pointer-events`
 exports.getResolvedValue = (element, property) => {
   // Determined for special case properties, none of which are implemented here.
   // So we skip to "any other property: The resolved value is the computed value."

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -11,10 +11,10 @@ let parsedDefaultStyleSheet;
 // every supported property.
 // https://drafts.csswg.org/indexes/#properties
 exports.propertiesWithResolvedValueImplemented = {
-  __proto__: null,
+  "__proto__": null,
 
   // https://drafts.csswg.org/css2/visufx.html#visibility
-  visibility: {
+  "visibility": {
     inherited: true,
     initial: "visible",
     computedValue: "as-specified"

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-pointerEvents.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-pointerEvents.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Computed pointerEvents is inherited</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #parent {
+    pointer-events: none;
+  }
+</style>
+
+<body>
+  <div id="parent">
+      <div id="child">Hello, Jarda!</div>
+  </div>
+</body>
+
+<script>
+"use strict";
+
+test(() => {
+  const element = document.querySelector("body");
+  assert_equals(getComputedStyle(element).pointerEvents, "auto");
+}, "Body element has the initial value for pointerEvents");
+
+test(() => {
+  const element = document.querySelector("#parent");
+  assert_equals(getComputedStyle(element).pointerEvents, "none");
+}, "Parent element returns the directly specified value for pointerEvents");
+
+test(() => {
+  const element = document.querySelector("#child");
+  assert_equals(getComputedStyle(element).pointerEvents, "none");
+}, "Child element inherits the pointerEvents value from its parent");
+</script>


### PR DESCRIPTION
This PR is adding support for inheritance of the `pointer-events` CSS property to `getComputedStyle()`. If a parent element specifies `pointer-events: none`, then for a child element `getComputedStyle(childEl).pointerEvents` should be `none`, too.

This has been implemented for `visibility` for some time, and `pointer-events` is also an "Inherited: yes" ([#](https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty)) property, with the same inheritance behavior, and deserves to be supported.

A real-world impact of this should be improved performance of Testing Library, namely the [`closestPointerEventsDeclaration` helper](https://github.com/testing-library/user-event/blob/1aa2027e5ec445ab413808556efa7763b65053d3/src/utils/pointer/cssPointerEvents.ts#L22-L32) in `@testing-library/user-event`. Every `userEvent.click(el)` call runs this to find out if `pointer-event`s are allowed. Its complexity should be reduced from _O(n^2)_ to just _O(n)_ (more [here](https://github.com/jsdom/jsdom/issues/3234#issuecomment-1359965734)).