### PR TITLE
Cache element styles for getComputedStyle

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -31,7 +31,7 @@ const reportException = require("../living/helpers/runtime-script-errors");
 const { getCurrentEventHandlerValue } = require("../living/helpers/create-event-accessor.js");
 const { fireAnEvent } = require("../living/helpers/events");
 const SessionHistory = require("../living/window/SessionHistory");
-const { forEachMatchingSheetRuleOfElement, getResolvedValue, propertiesWithResolvedValueImplemented,
+const { getDeclarationForElement, getResolvedValue, propertiesWithResolvedValueImplemented,
   SHADOW_DOM_PSEUDO_REGEXP } = require("../living/helpers/style-rules.js");
 const CustomElementRegistry = require("../living/generated/CustomElementRegistry");
 const jsGlobals = require("./js-globals.json");
@@ -835,28 +835,13 @@ function Window(options) {
     const declaration = new CSSStyleDeclaration();
     const { forEach } = Array.prototype;
 
-    function handleProperty(style, property) {
-      const value = style.getPropertyValue(property);
-      // https://drafts.csswg.org/css-cascade-4/#valdef-all-unset
-      if (value === "unset") {
-        declaration.removeProperty(property);
-      } else {
-        declaration.setProperty(
-          property,
-          value,
-          style.getPropertyPriority(property)
-        );
-      }
-    }
-
-    forEachMatchingSheetRuleOfElement(elt, rule => {
-      forEach.call(rule.style, property => {
-        handleProperty(rule.style, property);
-      });
-    });
-
-    forEach.call(elt.style, property => {
-      handleProperty(elt.style, property);
+    const elementDeclaration = getDeclarationForElement(elt);
+    forEach.call(elementDeclaration, property => {
+      declaration.setProperty(
+        property,
+        elementDeclaration.getPropertyValue(property),
+        elementDeclaration.getPropertyPriority(property)
+      );
     });
 
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -1,5 +1,6 @@
 "use strict";
 const cssom = require("cssom");
+const { CSSStyleDeclaration } = require("cssstyle");
 const defaultStyleSheet = require("../../browser/default-stylesheet");
 const { matchesDontThrow } = require("./selectors");
 
@@ -21,7 +22,7 @@ exports.propertiesWithResolvedValueImplemented = {
   }
 };
 
-exports.forEachMatchingSheetRuleOfElement = (elementImpl, handleRule) => {
+function forEachMatchingSheetRuleOfElement(elementImpl, handleRule) {
   function handleSheet(sheet) {
     forEach.call(sheet.cssRules, rule => {
       if (rule.media) {
@@ -44,6 +45,54 @@ exports.forEachMatchingSheetRuleOfElement = (elementImpl, handleRule) => {
 
   handleSheet(parsedDefaultStyleSheet);
   forEach.call(elementImpl._ownerDocument.styleSheets._list, handleSheet);
+}
+
+exports.invalidateStyleCache = elementImpl => {
+  if (elementImpl._attached) {
+    elementImpl._ownerDocument._styleCache = null;
+  }
+};
+
+exports.getDeclarationForElement = elementImpl => {
+  let styleCache = elementImpl._ownerDocument._styleCache;
+  if (!styleCache) {
+    styleCache = elementImpl._ownerDocument._styleCache = new WeakMap();
+  }
+
+  const cachedDeclaration = styleCache.get(elementImpl);
+  if (cachedDeclaration) {
+    return cachedDeclaration;
+  }
+
+  const declaration = new CSSStyleDeclaration();
+
+  function handleProperty(style, property) {
+    const value = style.getPropertyValue(property);
+    // https://drafts.csswg.org/css-cascade-4/#valdef-all-unset
+    if (value === "unset") {
+      declaration.removeProperty(property);
+    } else {
+      declaration.setProperty(
+        property,
+        value,
+        style.getPropertyPriority(property)
+      );
+    }
+  }
+
+  forEachMatchingSheetRuleOfElement(elementImpl, rule => {
+    forEach.call(rule.style, property => {
+      handleProperty(rule.style, property);
+    });
+  });
+
+  forEach.call(elementImpl.style, property => {
+    handleProperty(elementImpl.style, property);
+  });
+
+  styleCache.set(elementImpl, declaration);
+
+  return declaration;
 };
 
 function matches(rule, element) {
@@ -57,27 +106,7 @@ function matches(rule, element) {
 // rules appear. The last rule is the most specific while the first rule is
 // the least specific.
 function getCascadedPropertyValue(element, property) {
-  let value = "";
-
-  exports.forEachMatchingSheetRuleOfElement(element, rule => {
-    const propertyValue = rule.style.getPropertyValue(property);
-    // https://drafts.csswg.org/css-cascade-4/#valdef-all-unset
-    if (propertyValue === "unset") {
-      value = "";
-    } else if (propertyValue !== "") { // getPropertyValue returns "" if the property is not found
-      value = propertyValue;
-    }
-  });
-
-  const inlineValue = element.style.getPropertyValue(property);
-  // https://drafts.csswg.org/css-cascade-4/#valdef-all-unset
-  if (inlineValue === "unset") {
-    value = "";
-  } else if (inlineValue !== "" && inlineValue !== null) {
-    value = inlineValue;
-  }
-
-  return value;
+  return exports.getDeclarationForElement(element).getPropertyValue(property);
 }
 
 // https://drafts.csswg.org/css-cascade-4/#specified-value

--- a/lib/jsdom/living/helpers/stylesheets.js
+++ b/lib/jsdom/living/helpers/stylesheets.js
@@ -2,6 +2,7 @@
 const cssom = require("cssom");
 const whatwgEncoding = require("whatwg-encoding");
 const whatwgURL = require("whatwg-url");
+const { invalidateStyleCache } = require("./style-rules");
 
 // TODO: this should really implement https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet
 // It (and the things it calls) is nowhere close right now.
@@ -17,6 +18,8 @@ exports.removeStylesheet = (sheet, elementImpl) => {
 
   // Remove the association explicitly; in the spec it's implicit so this step doesn't exist.
   elementImpl.sheet = null;
+
+  invalidateStyleCache(elementImpl);
 
   // TODO: "Set the CSS style sheet’s parent CSS style sheet, owner node and owner CSS rule to null."
   // Probably when we have a real CSSOM implementation.
@@ -51,6 +54,8 @@ function addStylesheet(sheet, elementImpl) {
 
   // Set the association explicitly; in the spec it's implicit.
   elementImpl.sheet = sheet;
+
+  invalidateStyleCache(elementImpl);
 
   // TODO: title and disabled stuff
 }

--- a/lib/jsdom/living/helpers/stylesheets.js
+++ b/lib/jsdom/living/helpers/stylesheets.js
@@ -65,6 +65,11 @@ function fetchStylesheetInternal(elementImpl, urlString, parsedURL) {
   }
 
   function onStylesheetLoad(data) {
+    // if the element was detached before the load could finish, don't process the data
+    if (!elementImpl._attached) {
+      return;
+    }
+
     const css = whatwgEncoding.decode(data, defaultEncoding);
 
     // TODO: MIME type checking?

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -195,6 +195,9 @@ class DocumentImpl extends NodeImpl {
 
     // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#throw-on-dynamic-markup-insertion-counter
     this._throwOnDynamicMarkupInsertionCounter = 0;
+
+    // Cache of computed element styles
+    this._styleCache = null;
   }
 
   _getTheParent(event) {

--- a/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
@@ -2,7 +2,7 @@
 const DOMTokenList = require("../generated/DOMTokenList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const idlUtils = require("../generated/utils");
-const { fetchStylesheet } = require("../helpers/stylesheets");
+const { fetchStylesheet, removeStylesheet } = require("../helpers/stylesheets");
 const { parseURLToResultingURLRecord } = require("../helpers/document-base-url");
 const whatwgURL = require("whatwg-url");
 
@@ -30,6 +30,13 @@ class HTMLLinkElementImpl extends HTMLElementImpl {
   _attach() {
     super._attach();
     maybeFetchAndProcess(this);
+  }
+
+  _detach() {
+    super._detach();
+    if (this.sheet) {
+      removeStylesheet(this.sheet, this);
+    }
   }
 
   _attrModified(name, value, oldValue) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -20,6 +20,7 @@ const {
   isShadowRoot, shadowIncludingRoot, assignSlot, assignSlotableForTree, assignSlotable, signalSlotChange, isSlot,
   shadowIncludingInclusiveDescendantsIterator, shadowIncludingDescendantsIterator
 } = require("../helpers/shadow-dom");
+const { invalidateStyleCache } = require("../helpers/style-rules");
 
 function nodeEquals(a, b) {
   if (a.nodeType !== b.nodeType) {
@@ -225,10 +226,11 @@ class NodeImpl extends EventTargetImpl {
       this._childNodesList._update();
     }
     this._clearMemoizedQueries();
+    invalidateStyleCache(this);
   }
 
   _childTextContentChangeSteps() {
-    // Default: do nothing
+    invalidateStyleCache(this);
   }
 
   _clearMemoizedQueries() {

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-mutations.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-mutations.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Updating the document must invalidate the style cache and change the results of getComputedStyle</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .my-link {
+    font-size: 1.0em;
+  }
+
+  .my-link[href] {
+    font-size: 1.1em;
+  }
+
+  .my-link[href="#a"] {
+    font-size: 1.2em;
+  }
+
+  .my-link[href="#b"] {
+    font-size: 1.3em;
+  }
+
+  .my-box ~ .my-link {
+    font-size: 1.4em;
+  }
+
+  .my-box.bigger ~ .my-link {
+    font-size: 1.5em;
+  }
+
+  .my-link:empty {
+    font-size: 1.6em;
+  }
+</style>
+
+<a class="my-link">Hello world</a>
+<script>
+"use strict";
+const link = document.querySelector(".my-link");
+
+test(() => {
+  assert_equals(getComputedStyle(link).fontSize, "1.0em");
+}, "Initial style value");
+
+test(() => {
+  link.href = "#x"; // appendAttribute
+
+  assert_equals(getComputedStyle(link).fontSize, "1.1em");
+}, "Assigning to attribute updates the computed style");
+
+test(() => {
+  link.setAttribute("href", "#a"); // changeAttribute
+
+  assert_equals(getComputedStyle(link).fontSize, "1.2em");
+}, "Setting an attribute updates the computed style");
+
+test(() => {
+  const attr = document.createAttribute("href");
+  attr.value = "#b";
+  link.attributes.setNamedItem(attr); // replaceAttribute
+
+  assert_equals(getComputedStyle(link).fontSize, "1.3em");
+}, "Replacing an attribute updates the computed style");
+
+test(() => {
+  link.removeAttribute("href"); // removeAttribute
+
+  assert_equals(getComputedStyle(link).fontSize, "1.0em");
+}, "Removing an attribute updates the computed style");
+
+test(() => {
+  const box = document.createElement("div");
+  box.className = "my-box";
+  link.before(box);
+
+  assert_equals(getComputedStyle(link).fontSize, "1.4em");
+}, "Inserting an element updates the computed style");
+
+test(() => {
+  const biggerBox = document.createElement("div");
+  biggerBox.className = "my-box bigger";
+  document.querySelector(".my-box").replaceWith(biggerBox);
+
+  assert_equals(getComputedStyle(link).fontSize, "1.5em");
+}, "Replacing an element updates the computed style");
+
+test(() => {
+  const box = document.querySelector(".my-box");
+  document.body.removeChild(box);
+
+  assert_equals(getComputedStyle(link).fontSize, "1.0em");
+}, "Removing an element updates the computed style");
+
+test(() => {
+  link.textContent = "";
+  // setting character data of a text node should also make the element :empty, but
+  // nwsapi doesn't implement this correctly yet. To update the computed styles,
+  // style cache needs to be invalidated also after `CharacterDataImpl.replaceData`.
+  // link.childNodes[0].data = "";
+
+  assert_equals(getComputedStyle(link).fontSize, "1.6em");
+}, "Emptying an element updates the computed style");
+</script>

--- a/test/web-platform-tests/to-upstream/cssom/getComputedStyle-style-element-updates.html
+++ b/test/web-platform-tests/to-upstream/cssom/getComputedStyle-style-element-updates.html
@@ -36,4 +36,10 @@ test(() => {
 
   assert_equals(getComputedStyle(el).fontSize, "3em");
 }, "Updating the inserted CSS element changes the computed style");
+
+test(() => {
+  document.head.removeChild(insertedStyle);
+
+  assert_equals(getComputedStyle(el).fontSize, "1.5em");
+}, "Removing the inserted CSS element updates the computed style back to original value");
 </script>

--- a/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-link-element/stylesheet-appropriate-time-to-obtain.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-link-element/stylesheet-appropriate-time-to-obtain.html
@@ -14,7 +14,7 @@
 <script>
 "use strict";
 
-promise_test(() => {
+promise_test(t => {
 
   let resolve;
   const promise = new Promise(r => {
@@ -32,13 +32,15 @@ promise_test(() => {
   link.href = "stylesheet-appropriate-time-to-obtain-1.css";
 
   document.body.appendChild(link);
+  t.add_cleanup(() => link.remove());
 
+  assert_equals(window.getComputedStyle(document.body).color, "");
 
   return promise;
 
 }, "adding a href attribute before inserting the link into the document causes the stylesheet to load and apply");
 
-promise_test(() => {
+promise_test(t => {
 
   let resolve;
   const promise = new Promise(r => {
@@ -48,6 +50,7 @@ promise_test(() => {
   const link = document.createElement("link");
   link.rel = "stylesheet";
   document.body.appendChild(link);
+  t.add_cleanup(() => link.remove());
 
   link.onload = () => {
     assert_equals(window.getComputedStyle(document.body).color, "rgb(0, 0, 2)");
@@ -56,11 +59,13 @@ promise_test(() => {
 
   link.href = "stylesheet-appropriate-time-to-obtain-2.css";
 
+  assert_equals(window.getComputedStyle(document.body).color, "");
+
   return promise;
 
 }, "adding a href attribute after inserting the link into the document causes the stylesheet to load and apply");
 
-promise_test(() => {
+promise_test(t => {
 
   let resolve;
   const promise = new Promise(r => {
@@ -70,6 +75,7 @@ promise_test(() => {
   const link = document.createElement("link");
   link.rel = "stylesheet";
   document.body.appendChild(link);
+  t.add_cleanup(() => link.remove());
 
   link.onload = () => {
     assert_equals(window.getComputedStyle(document.body).color, "rgb(0, 0, 2)");
@@ -83,6 +89,8 @@ promise_test(() => {
   };
 
   link.href = "stylesheet-appropriate-time-to-obtain-2.css";
+
+  assert_equals(window.getComputedStyle(document.body).color, "");
 
   return promise;
 


### PR DESCRIPTION
Fixes #3234. Caches the computed styles for each element, avoiding expensive re-calculations. Also, modifies the implementation of `getResolvedValue` to not match all the style rules for itself, but reuse the cached results.

Each document has its own cache, and the cache is completely invalidated on every DOM change. I looked up all `queueMutationRecord` calls and added an `invalidateStyleCache` call to every place that also triggers a mutation observer.

What are the actual performance improvements? I tested it on one of our React Testing Library unit test suites in the [Gutenberg](https://github.com/wordpress/gutenberg) project. Before the patch, the suite takes 11.0 s to run:
```
 PASS  packages/components/src/border-box-control/test/index.js (10.066 s)
  BorderBoxControl
    Linked view rendering
      ✓ should render correctly when no value provided (311 ms)
      ✓ should hide label (26 ms)
      ✓ should show correct width value when flat border value provided (70 ms)
      ✓ should show correct width value when consistent split borders provided (55 ms)
      ✓ should render placeholder and omit unit select when border values are mixed (184 ms)
      ✓ should render shared border width and unit select when switching to linked view (202 ms)
      ✓ should omit style options when requested (491 ms)
    Split view rendering
      ✓ should render split view by default when mixed values provided (376 ms)
      ✓ should render correct width values in appropriate inputs (191 ms)
      ✓ should render split view correctly when starting with flat border (250 ms)
      ✓ should omit style options when requested (2902 ms)
    onChange handling
      Linked value change handling
        ✓ should set undefined when new border is empty (65 ms)
        ✓ should update with complete flat border (100 ms)
        ✓ should maintain mixed values if not explicitly set via linked control (178 ms)
        ✓ should update with consistent split borders (91 ms)
        ✓ should set undefined borders when change results in empty borders (63 ms)
        ✓ should set flat border when change results in consistent split borders (182 ms)
      Split value change handling
        ✓ should set split borders when the updated borders are mixed (222 ms)
        ✓ should set flat border when updated borders are consistent (227 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        10.989 s
```

After the patch, it takes only 7.6 s to run, a 30% improvement:
```
 PASS  packages/components/src/border-box-control/test/index.js (6.845 s)
  BorderBoxControl
    Linked view rendering
      ✓ should render correctly when no value provided (257 ms)
      ✓ should hide label (44 ms)
      ✓ should show correct width value when flat border value provided (60 ms)
      ✓ should show correct width value when consistent split borders provided (55 ms)
      ✓ should render placeholder and omit unit select when border values are mixed (184 ms)
      ✓ should render shared border width and unit select when switching to linked view (149 ms)
      ✓ should omit style options when requested (180 ms)
    Split view rendering
      ✓ should render split view by default when mixed values provided (151 ms)
      ✓ should render correct width values in appropriate inputs (93 ms)
      ✓ should render split view correctly when starting with flat border (138 ms)
      ✓ should omit style options when requested (727 ms)
    onChange handling
      Linked value change handling
        ✓ should set undefined when new border is empty (46 ms)
        ✓ should update with complete flat border (68 ms)
        ✓ should maintain mixed values if not explicitly set via linked control (147 ms)
        ✓ should update with consistent split borders (55 ms)
        ✓ should set undefined borders when change results in empty borders (39 ms)
        ✓ should set flat border when change results in consistent split borders (125 ms)
      Split value change handling
        ✓ should set split borders when the updated borders are mixed (108 ms)
        ✓ should set flat border when updated borders are consistent (105 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        7.625 s
```

There's one test that's particularly heavy on `getComputedStyle` calls:
```
Split view rendering > should omit style options when requested
```
This one improves from 2.90s to 0.73s, an 75% improvement, or 4x faster.

The `pointer-events` patch in #3478 adds more perf improvements on top of that. The test run looks like:
```
 PASS  packages/components/src/border-box-control/test/index.js
  BorderBoxControl
    Linked view rendering
      ✓ should render correctly when no value provided (201 ms)
      ✓ should hide label (25 ms)
      ✓ should show correct width value when flat border value provided (43 ms)
      ✓ should show correct width value when consistent split borders provided (43 ms)
      ✓ should render placeholder and omit unit select when border values are mixed (159 ms)
      ✓ should render shared border width and unit select when switching to linked view (127 ms)
      ✓ should omit style options when requested (154 ms)
    Split view rendering
      ✓ should render split view by default when mixed values provided (120 ms)
      ✓ should render correct width values in appropriate inputs (78 ms)
      ✓ should render split view correctly when starting with flat border (125 ms)
      ✓ should omit style options when requested (596 ms)
    onChange handling
      Linked value change handling
        ✓ should set undefined when new border is empty (39 ms)
        ✓ should update with complete flat border (54 ms)
        ✓ should maintain mixed values if not explicitly set via linked control (118 ms)
        ✓ should update with consistent split borders (50 ms)
        ✓ should set undefined borders when change results in empty borders (35 ms)
        ✓ should set flat border when change results in consistent split borders (122 ms)
      Split value change handling
        ✓ should set split borders when the updated borders are mixed (97 ms)
        ✓ should set flat border when updated borders are consistent (94 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        5.223 s, estimated 11 s
```
The 5.2 s time, compared to 7.6 s without the `pointer-events` patch, means another 30% improvement. Due to faster style lookup during `userEvent.click`.