### PR TITLE
Add CSSOM View extensions to MouseEvent

### DIFF
--- a/lib/jsdom/living/events/MouseEvent-impl.js
+++ b/lib/jsdom/living/events/MouseEvent-impl.js
@@ -7,6 +7,13 @@ const UIEventImpl = require("./UIEvent-impl").implementation;
 const MouseEventInit = require("../generated/MouseEventInit");
 
 class MouseEventImpl extends UIEventImpl {
+  get x() {
+    return this.clientX;
+  }
+  get y() {
+    return this.clientY;
+  }
+
   initMouseEvent(
     type,
     bubbles,
@@ -33,8 +40,6 @@ class MouseEventImpl extends UIEventImpl {
     this.screenY = screenY;
     this.clientX = clientX;
     this.clientY = clientY;
-    this.x = clientX;
-    this.y = clientY;
     this.ctrlKey = ctrlKey;
     this.altKey = altKey;
     this.shiftKey = shiftKey;

--- a/lib/jsdom/living/events/MouseEvent-impl.js
+++ b/lib/jsdom/living/events/MouseEvent-impl.js
@@ -33,6 +33,8 @@ class MouseEventImpl extends UIEventImpl {
     this.screenY = screenY;
     this.clientX = clientX;
     this.clientY = clientY;
+    this.x = clientX;
+    this.y = clientY;
     this.ctrlKey = ctrlKey;
     this.altKey = altKey;
     this.shiftKey = shiftKey;

--- a/lib/jsdom/living/events/MouseEvent-impl.js
+++ b/lib/jsdom/living/events/MouseEvent-impl.js
@@ -5,6 +5,7 @@ const EventModifierMixinImpl = require("./EventModifierMixin-impl").implementati
 const UIEventImpl = require("./UIEvent-impl").implementation;
 
 const MouseEventInit = require("../generated/MouseEventInit");
+const { wrapperForImpl } = require("../generated/utils");
 
 class MouseEventImpl extends UIEventImpl {
   get x() {
@@ -13,11 +14,31 @@ class MouseEventImpl extends UIEventImpl {
   get y() {
     return this.clientY;
   }
+  get pageX() {
+    if (this._dispatchFlag) {
+      return 0;
+    }
+    const offset = wrapperForImpl(this.view)?.scrollX || 0;
+    return offset + this.clientX;
+  }
+  get pageY() {
+    if (this._dispatchFlag) {
+      return 0;
+    }
+    const offset = wrapperForImpl(this.view)?.scrollY || 0;
+    return offset + this.clientY;
+  }
   get offsetX() {
-    return 0;
+    if (this._dispatchFlag) {
+      return 0;
+    }
+    return this.pageX;
   }
   get offsetY() {
-    return 0;
+    if (this._dispatchFlag) {
+      return 0;
+    }
+    return this.pageY;
   }
 
   initMouseEvent(

--- a/lib/jsdom/living/events/MouseEvent-impl.js
+++ b/lib/jsdom/living/events/MouseEvent-impl.js
@@ -13,6 +13,12 @@ class MouseEventImpl extends UIEventImpl {
   get y() {
     return this.clientY;
   }
+  get offsetX() {
+    return 0;
+  }
+  get offsetY() {
+    return 0;
+  }
 
   initMouseEvent(
     type,

--- a/lib/jsdom/living/events/MouseEvent.webidl
+++ b/lib/jsdom/living/events/MouseEvent.webidl
@@ -7,9 +7,6 @@ interface MouseEvent : UIEvent {
   readonly attribute long screenY;
   readonly attribute long clientX;
   readonly attribute long clientY;
-  readonly attribute long x;
-  readonly attribute long y;
-
   readonly attribute boolean ctrlKey;
   readonly attribute boolean shiftKey;
   readonly attribute boolean altKey;
@@ -53,4 +50,28 @@ partial interface MouseEvent {
                         optional boolean metaKeyArg = 0,
                         optional short buttonArg = 0,
                         optional EventTarget? relatedTargetArg = null);
+};
+
+// https://www.w3.org/TR/cssom-view/#extensions-to-the-mouseevent-interface
+// Adds attributes and changes existing ones to doubles
+partial interface MouseEvent {
+  readonly attribute double screenX;
+  readonly attribute double screenY;
+  readonly attribute double pageX;
+  readonly attribute double pageY;
+  readonly attribute double clientX;
+  readonly attribute double clientY;
+  readonly attribute double x;
+  readonly attribute double y;
+  readonly attribute double offsetX;
+  readonly attribute double offsetY;
+};
+
+// https://www.w3.org/TR/cssom-view/#extensions-to-the-mouseevent-interface
+// Changes existing coordinate entries to doubles
+partial dictionary MouseEventInit {
+  double screenX = 0.0;
+  double screenY = 0.0;
+  double clientX = 0.0;
+  double clientY = 0.0;
 };

--- a/lib/jsdom/living/events/MouseEvent.webidl
+++ b/lib/jsdom/living/events/MouseEvent.webidl
@@ -7,6 +7,8 @@ interface MouseEvent : UIEvent {
   readonly attribute long screenY;
   readonly attribute long clientX;
   readonly attribute long clientY;
+  readonly attribute long x;
+  readonly attribute long y;
 
   readonly attribute boolean ctrlKey;
   readonly attribute boolean shiftKey;

--- a/lib/jsdom/living/events/MouseEvent.webidl
+++ b/lib/jsdom/living/events/MouseEvent.webidl
@@ -52,7 +52,7 @@ partial interface MouseEvent {
                         optional EventTarget? relatedTargetArg = null);
 };
 
-// https://www.w3.org/TR/cssom-view/#extensions-to-the-mouseevent-interface
+// https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
 // Adds attributes and changes existing ones to doubles
 partial interface MouseEvent {
   readonly attribute double screenX;
@@ -67,7 +67,7 @@ partial interface MouseEvent {
   readonly attribute double offsetY;
 };
 
-// https://www.w3.org/TR/cssom-view/#extensions-to-the-mouseevent-interface
+// https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
 // Changes existing coordinate entries to doubles
 partial dictionary MouseEventInit {
   double screenX = 0.0;

--- a/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
+++ b/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
@@ -76,6 +76,8 @@ async_test(t => {
     assert_equals(e.clientY, 0);
     assert_equals(e.x, 0);
     assert_equals(e.y, 0);
+    assert_equals(e.pageX, 0);
+    assert_equals(e.pageY, 0);
     assert_equals(e.offsetX, 0);
     assert_equals(e.offsetY, 0);
 
@@ -88,4 +90,37 @@ async_test(t => {
 
 }, "clicking using click() should produce an event object with the correct MouseEventInit values");
 
+test(() => {
+  window.scrollX = 10;
+  window.scrollY = 20;
+  const e = new MouseEvent("click", {
+    clientX: 1, clientY: 2, view: window
+  });
+  assert_equals(e.x, 1);
+  assert_equals(e.y, 2);
+  assert_equals(e.pageX, 11);
+  assert_equals(e.pageY, 22);
+  assert_equals(e.offsetX, 11);
+  assert_equals(e.offsetY, 22);
+}, "MouseEvent should provide the correct computed values when the dispatch flag is not set");
+
+test(() => {
+  const e = new MouseEvent("click", {
+    screenX: 1.5, screenY: 2.5, clientX: 3.5, clientY: 4.5
+  });
+  assert_equals(e.screenX, 1.5);
+  assert_equals(e.screenY, 2.5);
+  assert_equals(e.clientX, 3.5);
+  assert_equals(e.clientY, 4.5);
+}, "MouseEvent.constructor should preserve doubles");
+
+test(() => {
+  const e = new MouseEvent("click");
+  e.initMouseEvent("click", true, true, null, null, 1.5, 2.5, 3.5, 4.5);
+  assert_equals(e.screenX, 1);
+  assert_equals(e.screenY, 2);
+  assert_equals(e.clientX, 3);
+  assert_equals(e.clientY, 4);
+
+}, "MouseEvent.initMouseEvent should convert doubles to longs");
 </script>

--- a/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
+++ b/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
@@ -76,6 +76,8 @@ async_test(t => {
     assert_equals(e.clientY, 0);
     assert_equals(e.x, 0);
     assert_equals(e.y, 0);
+    assert_equals(e.offsetX, 0);
+    assert_equals(e.offsetY, 0);
 
     assert_equals(e.button, 0);
     assert_equals(e.buttons, 0);

--- a/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
+++ b/test/web-platform-tests/to-upstream/html/editing/activation/click-event-properties.html
@@ -74,6 +74,8 @@ async_test(t => {
     assert_equals(e.screenY, 0);
     assert_equals(e.clientX, 0);
     assert_equals(e.clientY, 0);
+    assert_equals(e.x, 0);
+    assert_equals(e.y, 0);
 
     assert_equals(e.button, 0);
     assert_equals(e.buttons, 0);


### PR DESCRIPTION
Ensure that the [CSSOM View MouseEvent attributes](https://www.w3.org/TR/cssom-view/#extensions-to-the-mouseevent-interface) are set. Specifically this ensures that `x`/`y` mirror `clientX`/`clientY` and that `offsetX`/`offsetY` are set (always `0` since there is no layout).

Fixes #3483, #3470
Builds on and supersedes #3472 (reworks it to fix the default case and the tests)