### PR TITLE
Remove redundant style setter

### DIFF
--- a/lib/jsdom/living/nodes/ElementCSSInlineStyle-impl.js
+++ b/lib/jsdom/living/nodes/ElementCSSInlineStyle-impl.js
@@ -15,9 +15,6 @@ class ElementCSSInlineStyle {
   get style() {
     return this._style;
   }
-  set style(value) {
-    this._style.cssText = value;
-  }
 }
 
 module.exports = {


### PR DESCRIPTION
This is generated by webidl2js from the [PutForwards] annotation in the IDL file.

Closes #3045. Closes #3044.