### PR TITLE
Fix defer="" scripts inserted after DOMContentLoaded

### DIFF
--- a/lib/jsdom/browser/resources/per-document-resource-loader.js
+++ b/lib/jsdom/browser/resources/per-document-resource-loader.js
@@ -68,7 +68,10 @@ module.exports = class PerDocumentResourceLoader {
 
     if (element.localName === "script" && element.hasAttributeNS(null, "async")) {
       this._asyncQueue.push(request, onLoadWrapped, onErrorWrapped, this._queue.getLastScript());
-    } else if (element.localName === "script" && element.hasAttributeNS(null, "defer")) {
+    } else if (
+      element.localName === "script" &&
+        element.hasAttributeNS(null, "defer") &&
+        this._document.readyState !== "interactive") {
       this._deferQueue.push(request, onLoadWrapped, onErrorWrapped, false, element);
     } else {
       this._queue.push(request, onLoadWrapped, onErrorWrapped, false, element);

--- a/test/web-platform-tests/to-upstream/html/semantics/scripting-1/the-script-element/dynamically-created-defer-script.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/scripting-1/the-script-element/dynamically-created-defer-script.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Dynamically created defer scripts inserted after DOMContentLoaded</title>
+<!-- Regression test for https://github.com/jsdom/jsdom/issues/3451. -->
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+window.scriptRan = false;
+
+async_test(t => {
+  window.addEventListener("DOMContentLoaded", t.step_func(() => {
+    const s = document.createElement("script");
+    s.defer = true;
+    s.src = "resources/dynamically-created-defer-script.js";
+    document.head.append(s);
+
+    s.onload = t.step_func_done(() => {
+      assert_true(window.scriptRan);
+    });
+  }));
+});
+</script>

--- a/test/web-platform-tests/to-upstream/html/semantics/scripting-1/the-script-element/resources/dynamically-created-defer-script.js
+++ b/test/web-platform-tests/to-upstream/html/semantics/scripting-1/the-script-element/resources/dynamically-created-defer-script.js
@@ -1,0 +1,2 @@
+"use strict";
+window.scriptRan = true;


### PR DESCRIPTION
Closes #3451. Closes #3453 by superseding it with tests.