### PR TITLE
Make JSDOM.reconfigure() adjust the History API with the updated URL

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -95,8 +95,7 @@ class JSDOM {
 
       document._URL = url;
       document._origin = whatwgURL.serializeURLOrigin(document._URL);
-      const { currentEntry } = this[window]._sessionHistory;
-      currentEntry.url = url;
+      this[window]._sessionHistory.currentEntry.url = url;
     }
   }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -95,6 +95,8 @@ class JSDOM {
 
       document._URL = url;
       document._origin = whatwgURL.serializeURLOrigin(document._URL);
+      const { currentEntry } = this[window]._sessionHistory;
+      currentEntry.url = url;
     }
   }
 

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -321,6 +321,21 @@ describe("API: JSDOM class's methods", () => {
         assert.strictEqual(window.document.URL, "http://example.com/");
         assert.strictEqual(window.document.documentURI, "http://example.com/");
       });
+
+      it("should allow History.replaceState with the changed URL", () => {
+        const dom = new JSDOM(``, { url: "http://example.com/" });
+        const { window } = dom;
+
+        assert.strictEqual(window.document.URL, "http://example.com/");
+
+        dom.reconfigure({ url: "http://localhost/" });
+
+        assert.strictEqual(window.document.URL, "http://localhost/");
+
+        window.history.replaceState(null, "");
+
+        assert.strictEqual(window.document.URL, "http://localhost/");
+      });
     });
   });
 });

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -322,7 +322,7 @@ describe("API: JSDOM class's methods", () => {
         assert.strictEqual(window.document.documentURI, "http://example.com/");
       });
 
-      it("should allow History.replaceState with the changed URL", () => {
+      it("should update the URL used by history.replaceState()", () => {
         const dom = new JSDOM(``, { url: "http://example.com/" });
         const { window } = dom;
 


### PR DESCRIPTION
Previously, after using JSDOM.reconfigure() to change the URL, the History API held onto a cached version of the previous URL. This means if one used the History API like:

    window.history.replaceState(null, "");

The cached URL would be used to replace the value of window.location.href back to the original. This is unexpected. Not supplying a third argument should not change the URL.

To fix, update the current history entry when calling reconfigure().

Fixes #3504