### PR TITLE
Fix location.hash setter with the empty string input

### DIFF
--- a/lib/jsdom/living/window/Location-impl.js
+++ b/lib/jsdom/living/window/Location-impl.js
@@ -182,16 +182,12 @@ exports.implementation = class LocationImpl {
   set hash(v) {
     const copyURL = { ...this._url };
 
-    if (copyURL.scheme === "javascript") {
-      return;
-    }
+    const input = v[0] === "#" ? v.substring(1) : v;
+    copyURL.fragment = "";
+    whatwgURL.basicURLParse(input, { url: copyURL, stateOverride: "fragment" });
 
-    if (v === "") {
-      copyURL.fragment = null;
-    } else {
-      const input = v[0] === "#" ? v.substring(1) : v;
-      copyURL.fragment = "";
-      whatwgURL.basicURLParse(input, { url: copyURL, stateOverride: "fragment" });
+    if (copyURL.fragment === this._url.fragment) {
+      return;
     }
 
     this._locationObjectSetterNavigate(copyURL);

--- a/test/web-platform-tests/to-upstream/html/browsers/history/the-location-interface/location-hash-setter-empty-string.html
+++ b/test/web-platform-tests/to-upstream/html/browsers/history/the-location-interface/location-hash-setter-empty-string.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Location hash setter with the empty string</title>
+<!-- Context: https://github.com/jsdom/jsdom/issues/3494 -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  assert_equals(location.hash, "", "Initially no hash");
+  assert_false(location.href.includes("#"), "Initially no # in href");
+
+  location.hash = "test";
+  assert_equals(location.hash, "#test", "hash after setting to a non-empty value");
+  assert_true(location.href.includes("#"), "Setting a hash to a non-empty value causes # in href");
+
+  location.hash = "";
+  assert_equals(location.hash, "", "hash after setting to empty string");
+  assert_true(location.href.endsWith("#"), "Setting hash to an empty value leaves # in the href");
+});
+</script>


### PR DESCRIPTION
Closes #3494. Closes #3495 by superseding it.