### PR TITLE
Beign able to check location changes

### DIFF
--- a/lib/jsdom/living/window/Location-impl.js
+++ b/lib/jsdom/living/window/Location-impl.js
@@ -32,9 +32,9 @@ exports.implementation = class LocationImpl {
   _locationObjectNavigate(url, { replacement = false } = {}) {
     // Not implemented: the setup for calling navigate, which doesn't apply to our stub navigate anyway.
 
-    const warn = "\x1b[33m Navigation is not implemented on jsdom as unit tests doesn't require it. " + 
+    const warn = "\x1b[33m Navigation is not implemented on jsdom as unit tests doesn't require it. " +
       "But you can test window.location changes.";
-      this._relevantDocument._defaultView._virtualConsole.emit("jsdomWarn", warn);
+    this._relevantDocument._defaultView._virtualConsole.emit("jsdomWarn", warn);
 
     navigate(this._relevantDocument._defaultView, url, { replacement, exceptionsEnabled: true });
   }


### PR DESCRIPTION
Unit tests check inputs and outputs. It is not necessary to have navigation implemented, but you should be able to check the changes in the url, since it is an output.
With this change, it is now allowed to set the url to be able to check the changes in location.
Merge it if you think it's convenient.
Thank you.