### PR TITLE
Add option to display invalid constraints on form validation in console

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -214,6 +214,8 @@ function transformOptions(options, encoding, mimeType) {
       pretendToBeVisual: false,
       storageQuota: 5000000,
 
+      _reportInvalidConstraintsToConsole: false,
+
       // Defaults filled in later
       resourceLoader: undefined,
       virtualConsole: undefined,
@@ -281,6 +283,10 @@ function transformOptions(options, encoding, mimeType) {
 
   if (options.storageQuota !== undefined) {
     transformed.windowOptions.storageQuota = Number(options.storageQuota);
+  }
+
+  if (options._reportInvalidConstraintsToConsole !== undefined) {
+    transformed.windowOptions._reportInvalidConstraintsToConsole = Boolean(options._reportInvalidConstraintsToConsole);
   }
 
   return transformed;

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -282,6 +282,8 @@ function Window(options) {
 
   this._runScripts = options.runScripts;
 
+  this._reportInvalidConstraintsToConsole = options._reportInvalidConstraintsToConsole;
+
   // Set up the window as if it's a top level window.
   // If it's not, then references will be corrected by frame/iframe code.
   this._parent = this._top = this._globalProxy;

--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -225,6 +225,12 @@ class HTMLFormElementImpl extends HTMLElementImpl {
 
     const unhandledInvalidControls = [];
     for (const invalidControl of invalidControls) {
+
+      // Report form validation errors to the console for developers debugging why their forms are not submited in tests
+      if(window._reportInvalidConstraintsToConsole){ 
+        console.error("Form validation failed for "+invalidControl.outerHTML+" with the value: "+ JSON.stringify(invalidControl.value));
+      }
+
       const notCancelled = fireAnEvent("invalid", invalidControl, undefined, { cancelable: true });
       if (notCancelled) {
         unhandledInvalidControls.push(invalidControl);


### PR DESCRIPTION
Since #3249 a form must be valid to be submitted.

This PR intends to add a new config option `reportInvalidConstraintsToConsole` to help developers find error in their tests.
In a regular web browser the browser informs the user on the failed form fields.
This option should bring this feature to jsdom to help developers indentify which fields are causing their form to not be submitted during testing.

---

This PR stills needs some work by someone who is familar with the dev. of jsdom. The config option is not correctly passed down to the HTMLFormElement-impl.js file yet. Softwaretests are still missing.

Feel free to edit and modify everything!
