### PR TITLE
Added rudimentary innerText function.

### DIFF
--- a/lib/jsdom/living/domparsing/InnerText-impl.js
+++ b/lib/jsdom/living/domparsing/InnerText-impl.js
@@ -1,9 +1,5 @@
 "use strict";
 
-const { parseFragment } = require("../../browser/parser");
-const { HTML_NS } = require("../helpers/namespaces.js");
-const { isShadowRoot } = require("../helpers/shadow-dom.js");
-const NODE_TYPE = require("../node-type.js");
 const { getDeclarationForElement } = require("../helpers/style-rules.js");
 const { ELEMENT_NODE, TEXT_NODE } = require("../node-type");
 const { getChildNodes } = require("./parse5-adapter-serialization");
@@ -16,7 +12,9 @@ function isRendered(element) {
   return (
     !element.getAttributeNS(null, "hidden") &&
     getComputedStyle(element, "display") !== "none" &&
-    getComputedStyle(element, "visibility") !== "hidden"
+    getComputedStyle(element, "visibility") !== "hidden" &&
+    element.tagName !== "IMG" &&
+    element.tagName !== "NOSCRIPT"
   );
 }
 
@@ -46,13 +44,15 @@ function renderedTextCollect(node) {
       case "capitalize": {
         text = text
           .split(" ")
-          .map(word => word[0].toUpperCase() + word.slice(1))
+          .map(word => word.length >= 1 ? word[0].toUpperCase() + word.slice(1) : word)
           .join(" ");
         break;
       }
     }
     text = text.trim();
-    items.push(text);
+    if (text) {
+      items.push(text);
+    }
   } else if (node.nodeType === ELEMENT_NODE) {
     if (node._localName === "br") {
       items.push("\n");
@@ -98,22 +98,28 @@ exports.implementation = class InnerTextImpl {
     while (typeof results.at(-1) === "number") {
       results.pop();
     }
-    results = results.map(result => typeof result === "number" ? "\n".repeat(result) : result);
-    return results.join("");
-  }
-  set innerText(text) {
-    const contextElement = isShadowRoot(this) ? this.host : this;
-    const fragment = parseFragment(text, contextElement);
 
-    let contextObject = this;
-    if (
-      this.nodeType === NODE_TYPE.ELEMENT_NODE &&
-      this.localName === "template" &&
-      this.namespaceURI === HTML_NS
-    ) {
-      contextObject = this._templateContents;
+    let currentRun = [];
+    const reducedResults = [];
+
+    for (const result of results) {
+      if (typeof result === "number") {
+        currentRun.push(result);
+      } else {
+        if (currentRun.length > 0) {
+          reducedResults.push(Math.max(currentRun));
+        }
+        currentRun = [];
+        reducedResults.push(result);
+      }
     }
 
-    contextObject._replaceAll(fragment);
+    results = reducedResults.map(result => typeof result === "number" ? "\n".repeat(result) : result);
+    return results.join("\n");
+  }
+  set innerText(text) {
+    text = text.replace(/[&<>'"]/g, r => "&#" + r.charCodeAt(0) + ";");
+    text = text.replace("\n", "<br />");
+    this.innerHTML = text;
   }
 };

--- a/lib/jsdom/living/domparsing/InnerText-impl.js
+++ b/lib/jsdom/living/domparsing/InnerText-impl.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const { parseFragment } = require("../../browser/parser");
+const { HTML_NS } = require("../helpers/namespaces.js");
+const { isShadowRoot } = require("../helpers/shadow-dom.js");
+const NODE_TYPE = require("../node-type.js");
+const { getDeclarationForElement } = require("../helpers/style-rules.js");
+const { ELEMENT_NODE, TEXT_NODE } = require("../node-type");
+const { getChildNodes } = require("./parse5-adapter-serialization");
+
+function getComputedStyle(element, property) {
+  return getDeclarationForElement(element).getPropertyValue(property);
+}
+
+function isRendered(element) {
+  return (
+    !element.getAttributeNS(null, "hidden") &&
+    getComputedStyle(element, "display") !== "none" &&
+    getComputedStyle(element, "visibility") !== "hidden"
+  );
+}
+
+function renderedTextCollect(node) {
+  let items = [];
+
+  if (node.nodeType === ELEMENT_NODE && !isRendered(node)) {
+    return items;
+  }
+  for (const childNode of getChildNodes(node)) {
+    items.push(...renderedTextCollect(childNode));
+  }
+  if (node.nodeType === TEXT_NODE) {
+    let text = node.textContent || "";
+    if (!node.parentElement) {
+      return items;
+    }
+    switch (getComputedStyle(node.parentElement, "text-transform")) {
+      case "uppercase": {
+        text = text.toUpperCase();
+        break;
+      }
+      case "lowercase": {
+        text = text.toLowerCase();
+        break;
+      }
+      case "capitalize": {
+        text = text
+          .split(" ")
+          .map(word => word[0].toUpperCase() + word.slice(1))
+          .join(" ");
+        break;
+      }
+    }
+    text = text.trim();
+    items.push(text);
+  } else if (node.nodeType === ELEMENT_NODE) {
+    if (node._localName === "br") {
+      items.push("\n");
+    }
+    if (
+      getComputedStyle(node, "display") === "table-cell" &&
+      node.parentElement?.lastChild !== node
+    ) {
+      items.push("\u0009");
+    }
+    if (
+      getComputedStyle(node, "display") === "table-row" &&
+      node.parentElement?.lastChild !== node
+    ) {
+      items.push("\n");
+    }
+    if (node._localName === "p") {
+      items = [2, ...items, 2];
+    }
+
+    if (["block", "flex", "table", "grid"].includes(node.style.display)) {
+      items = [1, ...items, 1];
+    }
+  }
+  return items;
+}
+
+// https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute
+exports.implementation = class InnerTextImpl {
+  get innerText() {
+    if (!isRendered(this)) {
+      return this.textContent;
+    }
+    let results = [];
+    for (const node of getChildNodes(this)) {
+      const current = renderedTextCollect(node);
+      results.push(...current);
+    }
+    results = results.filter(Boolean);
+    while (typeof results[0] === "number") {
+      results.shift();
+    }
+    while (typeof results.at(-1) === "number") {
+      results.pop();
+    }
+    results = results.map(result => typeof result === "number" ? "\n".repeat(result) : result);
+    return results.join("");
+  }
+  set innerText(text) {
+    const contextElement = isShadowRoot(this) ? this.host : this;
+    const fragment = parseFragment(text, contextElement);
+
+    let contextObject = this;
+    if (
+      this.nodeType === NODE_TYPE.ELEMENT_NODE &&
+      this.localName === "template" &&
+      this.namespaceURI === HTML_NS
+    ) {
+      contextObject = this._templateContents;
+    }
+
+    contextObject._replaceAll(fragment);
+  }
+};

--- a/lib/jsdom/living/domparsing/InnerText.webidl
+++ b/lib/jsdom/living/domparsing/InnerText.webidl
@@ -1,0 +1,5 @@
+interface mixin InnerText {
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerText;
+};
+
+HTMLElement includes InnerText;

--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -5,6 +5,7 @@ const MouseEvent = require("../generated/MouseEvent");
 const ElementCSSInlineStyleImpl = require("./ElementCSSInlineStyle-impl").implementation;
 const GlobalEventHandlersImpl = require("./GlobalEventHandlers-impl").implementation;
 const HTMLOrSVGElementImpl = require("./HTMLOrSVGElement-impl").implementation;
+const InnerTextImpl = require("../domparsing/InnerText-impl").implementation;
 const { firstChildWithLocalName } = require("../helpers/traversal");
 const { isDisabled } = require("../helpers/form-controls");
 const { fireAnEvent } = require("../helpers/events");
@@ -154,6 +155,7 @@ class HTMLElementImpl extends ElementImpl {
 mixin(HTMLElementImpl.prototype, ElementCSSInlineStyleImpl.prototype);
 mixin(HTMLElementImpl.prototype, GlobalEventHandlersImpl.prototype);
 mixin(HTMLElementImpl.prototype, HTMLOrSVGElementImpl.prototype);
+mixin(HTMLElementImpl.prototype, InnerTextImpl.prototype);
 
 module.exports = {
   implementation: HTMLElementImpl

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -166,6 +166,30 @@ describe("API: JSDOM class's methods", () => {
 
       assert.deepEqual(dom.nodeLocation(node), undefined);
     });
+    it("should return the correct text from innerText", () => {
+      const source = `<p id="source">
+      <style>
+        #source {
+          color: red;
+        }
+        #text {
+          text-transform: uppercase;
+        }
+      </style>
+      <span id="text">
+        Take a look at<br />
+        how this text<br />
+        is interpreted below.
+      </span>
+      <span style="display:none">HIDDEN TEXT</span>
+    </p>`;
+      const expectedResult = `TAKE A LOOK AT
+HOW THIS TEXT
+IS INTERPRETED BELOW.`;
+      const dom = new JSDOM(source);
+      const result = dom.window.document.getElementById("source").innerText;
+      assert.strictEqual(result, expectedResult);
+    });
   });
 
   describe("getInternalVMContext", () => {


### PR DESCRIPTION
After needing the innerText feature for a project of mine, I decided to quickly draft up a mock version of one that could be used. This implementation follows the [HTML Standard](https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute) as best as I could without implementing any complicated layout management tools.

Known missing features:
- The CSS `white-space` processing.
- Hypenation.

Aside from this, my implementation passes the test case shown in [MDN's example](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText#examples), as well as a few other personal tests. I know there are improvements needed, but hopefully this can get people started on an implementation.

This mostly fixes #1245.