### PR TITLE
Implement ARIAMixin string reflection

### DIFF
--- a/lib/jsdom/living/nodes/ARIAMixin-impl.js
+++ b/lib/jsdom/living/nodes/ARIAMixin-impl.js
@@ -1,0 +1,75 @@
+"use strict";
+
+// ARIA Element properties that reflect to strings (not Element or FrozenArray<Element>)
+const ARIA_STRING_PROPS = [
+  "role",
+  "ariaAtomic",
+  "ariaAutoComplete",
+  "ariaBusy",
+  "ariaChecked",
+  "ariaColCount",
+  "ariaColIndex",
+  "ariaColIndexText",
+  "ariaColSpan",
+  "ariaCurrent",
+  "ariaDescription",
+  "ariaDisabled",
+  "ariaExpanded",
+  "ariaHasPopup",
+  "ariaHidden",
+  "ariaInvalid",
+  "ariaKeyShortcuts",
+  "ariaLabel",
+  "ariaLevel",
+  "ariaLive",
+  "ariaModal",
+  "ariaMultiLine",
+  "ariaMultiSelectable",
+  "ariaOrientation",
+  "ariaPlaceholder",
+  "ariaPosInSet",
+  "ariaPressed",
+  "ariaReadOnly",
+  "ariaRelevant", // Removed in https://github.com/w3c/aria/issues/1267, but WPT tests require it
+  "ariaRequired",
+  "ariaRoleDescription",
+  "ariaRowCount",
+  "ariaRowIndex",
+  "ariaRowIndexText",
+  "ariaRowSpan",
+  "ariaSelected",
+  "ariaSetSize",
+  "ariaSort",
+  "ariaValueMax",
+  "ariaValueMin",
+  "ariaValueNow",
+  "ariaValueText"
+];
+
+class ARIAMixinImpl {
+}
+
+// TODO: handle element reflection as well
+for (const prop of ARIA_STRING_PROPS) {
+  // e.g. `ariaPosInSet` -> `aria-posinset`
+  const attribute = prop.replace(/[A-Z]/, letter => `-${letter}`).toLowerCase();
+  Object.defineProperty(ARIAMixinImpl.prototype, prop, {
+    get() {
+      return this.getAttributeNS(null, attribute);
+    },
+    set(value) {
+      // Per the spec, only null is treated as removing the attribute. However, Chromium/WebKit currently
+      // differ from the spec and allow undefined as well. Here, we follow the standard.
+      // See: https://github.com/w3c/aria/issues/1858
+      if (value === null) {
+        this.removeAttributeNS(null, attribute);
+      } else {
+        this.setAttributeNS(null, attribute, value);
+      }
+    }
+  });
+}
+
+module.exports = {
+  implementation: ARIAMixinImpl
+};

--- a/lib/jsdom/living/nodes/ARIAMixin-impl.js
+++ b/lib/jsdom/living/nodes/ARIAMixin-impl.js
@@ -52,7 +52,7 @@ class ARIAMixinImpl {
 // TODO: handle element reflection as well
 for (const prop of ARIA_STRING_PROPS) {
   // e.g. `ariaPosInSet` -> `aria-posinset`
-  const attribute = prop.replace(/^aria/, 'aria-').toLowerCase();
+  const attribute = prop.replace(/^aria/, "aria-").toLowerCase();
   Object.defineProperty(ARIAMixinImpl.prototype, prop, {
     get() {
       return this.getAttributeNS(null, attribute);

--- a/lib/jsdom/living/nodes/ARIAMixin-impl.js
+++ b/lib/jsdom/living/nodes/ARIAMixin-impl.js
@@ -52,7 +52,7 @@ class ARIAMixinImpl {
 // TODO: handle element reflection as well
 for (const prop of ARIA_STRING_PROPS) {
   // e.g. `ariaPosInSet` -> `aria-posinset`
-  const attribute = prop.replace(/[A-Z]/, letter => `-${letter}`).toLowerCase();
+  const attribute = prop.replace(/^aria/, 'aria-').toLowerCase();
   Object.defineProperty(ARIAMixinImpl.prototype, prop, {
     get() {
       return this.getAttributeNS(null, attribute);

--- a/lib/jsdom/living/nodes/ARIAMixin-impl.js
+++ b/lib/jsdom/living/nodes/ARIAMixin-impl.js
@@ -66,7 +66,9 @@ for (const prop of ARIA_STRING_PROPS) {
       } else {
         this.setAttributeNS(null, attribute, value);
       }
-    }
+    },
+    configurable: true,
+    enumerable: true
   });
 }
 

--- a/lib/jsdom/living/nodes/ARIAMixin.webidl
+++ b/lib/jsdom/living/nodes/ARIAMixin.webidl
@@ -1,0 +1,63 @@
+// https://w3c.github.io/aria/#ARIAMixin
+interface mixin ARIAMixin {
+	[CEReactions] attribute DOMString? role;
+	// TODO: not implemented
+	// [CEReactions] attribute Element? ariaActiveDescendantElement;
+	[CEReactions] attribute DOMString? ariaAtomic;
+	[CEReactions] attribute DOMString? ariaAutoComplete;
+	[CEReactions] attribute DOMString? ariaBusy;
+	[CEReactions] attribute DOMString? ariaChecked;
+	[CEReactions] attribute DOMString? ariaColCount;
+	[CEReactions] attribute DOMString? ariaColIndex;
+	[CEReactions] attribute DOMString? ariaColIndexText;
+	[CEReactions] attribute DOMString? ariaColSpan;
+	// TODO: not implemented
+	// [CEReactions] attribute FrozenArray<Element>? ariaControlsElements;
+	[CEReactions] attribute DOMString? ariaCurrent;
+	// TODO: not implemented
+	// [CEReactions] attribute FrozenArray<Element>? ariaDescribedByElements;
+	[CEReactions] attribute DOMString? ariaDescription;
+	// TODO: not implemented
+	// [CEReactions] attribute FrozenArray<Element>? ariaDetailsElements;
+	[CEReactions] attribute DOMString? ariaDisabled;
+	// TODO: not implemented
+	// [CEReactions] attribute FrozenArray<Element>? ariaErrorMessageElements;
+	[CEReactions] attribute DOMString? ariaExpanded;
+	// TODO: not implemented
+	// [CEReactions] attribute FrozenArray<Element>? ariaFlowToElements;
+	[CEReactions] attribute DOMString? ariaHasPopup;
+	[CEReactions] attribute DOMString? ariaHidden;
+	[CEReactions] attribute DOMString? ariaInvalid;
+	[CEReactions] attribute DOMString? ariaKeyShortcuts;
+	[CEReactions] attribute DOMString? ariaLabel;
+	// TODO: not implemented
+	// [CEReactions] attribute FrozenArray<Element>? ariaLabelledByElements;
+	[CEReactions] attribute DOMString? ariaLevel;
+	[CEReactions] attribute DOMString? ariaLive;
+	[CEReactions] attribute DOMString? ariaModal;
+	[CEReactions] attribute DOMString? ariaMultiLine;
+	[CEReactions] attribute DOMString? ariaMultiSelectable;
+	[CEReactions] attribute DOMString? ariaOrientation;
+	// TODO: not implemented
+	// [CEReactions] attribute FrozenArray<Element>? ariaOwnsElements;
+	[CEReactions] attribute DOMString? ariaPlaceholder;
+	[CEReactions] attribute DOMString? ariaPosInSet;
+	[CEReactions] attribute DOMString? ariaPressed;
+	[CEReactions] attribute DOMString? ariaReadOnly;
+	// Removed in https://github.com/w3c/aria/issues/1267, but WPT tests require it
+  [CEReactions] attribute DOMString? ariaRelevant;
+	[CEReactions] attribute DOMString? ariaRequired;
+	[CEReactions] attribute DOMString? ariaRoleDescription;
+	[CEReactions] attribute DOMString? ariaRowCount;
+	[CEReactions] attribute DOMString? ariaRowIndex;
+	[CEReactions] attribute DOMString? ariaRowIndexText;
+	[CEReactions] attribute DOMString? ariaRowSpan;
+	[CEReactions] attribute DOMString? ariaSelected;
+	[CEReactions] attribute DOMString? ariaSetSize;
+	[CEReactions] attribute DOMString? ariaSort;
+	[CEReactions] attribute DOMString? ariaValueMax;
+	[CEReactions] attribute DOMString? ariaValueMin;
+	[CEReactions] attribute DOMString? ariaValueNow;
+	[CEReactions] attribute DOMString? ariaValueText;
+};
+Element includes ARIAMixin;

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -26,6 +26,7 @@ const ShadowRoot = require("../generated/ShadowRoot");
 const Text = require("../generated/Text");
 const { isValidHostElementName } = require("../helpers/shadow-dom");
 const { isValidCustomElementName, lookupCEDefinition } = require("../helpers/custom-elements");
+const ARIAMixinImpl = require("./ARIAMixin-impl.js").implementation;
 
 function attachId(id, elm, doc) {
   if (id && elm && doc) {
@@ -552,6 +553,7 @@ mixin(ElementImpl.prototype, ParentNodeImpl.prototype);
 mixin(ElementImpl.prototype, ChildNodeImpl.prototype);
 mixin(ElementImpl.prototype, SlotableMixinImpl.prototype);
 mixin(ElementImpl.prototype, InnerHTMLImpl.prototype);
+mixin(ElementImpl.prototype, ARIAMixinImpl.prototype);
 
 ElementImpl.prototype.getElementsByTagName = memoizeQuery(function (qualifiedName) {
   return listOfElementsWithQualifiedName(qualifiedName, this);

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -652,7 +652,6 @@ DIR: html/canvas/element/drawing-images-to-the-canvas
 
 DIR: html/dom
 
-aria-attribute-reflection.html: [fail, Unknown]
 aria-element-reflection.html: [fail, WAI-ARIA not implemented]
 documents/dom-tree-accessors/Document.currentScript.html: [fail-slow, Unknown]
 documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-xhtml.xhtml: [fail, Needs MathML support]

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -192,8 +192,7 @@ perform-microtask-checkpoint-before-construction.html: [fail, impossible to impl
 pseudo-class-defined-customized-builtins.html: [fail-slow, :defined is not defined and throws]
 pseudo-class-defined.html: [timeout, :defined is not defined and throws]
 reactions/Animation.html: [fail, Animation not implemented]
-reactions/AriaMixin-element-attributes.html: [fail, AriaMixin not implemented]
-reactions/AriaMixin-string-attributes.html: [fail, AriaMixin not implemented]
+reactions/AriaMixin-element-attributes.html: [fail, ARIAMixin element reflection not implemented]
 reactions/CSSStyleDeclaration.html: [fail, CSSStyleDeclaration is not implemented using webidl2js, https://github.com/jsdom/cssstyle/issues/113]
 reactions/Document.html:
   "execCommand on Document must enqueue a disconnected reaction when deleting a custom element from a contenteditable element": [fail, document.execCommand() is not implemented, https://github.com/jsdom/jsdom/issues/1539]
@@ -652,7 +651,7 @@ DIR: html/canvas/element/drawing-images-to-the-canvas
 
 DIR: html/dom
 
-aria-element-reflection.html: [fail, WAI-ARIA not implemented]
+aria-element-reflection.html: [fail, ARIAMixin element reflection not implemented]
 documents/dom-tree-accessors/Document.currentScript.html: [fail-slow, Unknown]
 documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-xhtml.xhtml: [fail, Needs MathML support]
 documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace.html: [fail, Needs MathML support]

--- a/test/web-platform-tests/wpt-server.js
+++ b/test/web-platform-tests/wpt-server.js
@@ -33,7 +33,7 @@ exports.start = async ({ toUpstream = false } = {}) => {
 
   const configArg = path.relative(path.resolve(wptDir), configPath);
   const args = ["./wpt.py", "serve", "--config", configArg];
-  const subprocess = childProcess.spawn("python", args, {
+  const subprocess = childProcess.spawn("python3", args, {
     cwd: wptDir,
     stdio: ["inherit", "pipe", "pipe"]
   });


### PR DESCRIPTION
Partially addresses #3323. Implements string-based ARIA reflection (e.g. `ariaLabel`, `role`), but not element-based reflection (e.g. `ariaLabelledByElements`, `ariaActiveDescendantElement`).

This has some overlap with #3561, but looks like it should be largely complementary.

With this PR, the following works:

```js
element.setAttribute('aria-label', 'foo')
element.setAttribute('role', 'button')
console.log(element.ariaLabel) // 'foo'
console.log(element.role) // 'button'
```

I confirmed that the [`aria-element-reflection.html` WPT test](https://github.com/web-platform-tests/wpt/blob/master/html/dom/aria-attribute-reflection.html) is now passing.