### PR TITLE
updated tough-cookie package to stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rrweb-cssom": "^0.6.0",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",
-    "tough-cookie": "^4.1.2",
+    "tough-cookie": "^4.1.3",
     "w3c-xmlserializer": "^4.0.0",
     "webidl-conversions": "^7.0.0",
     "whatwg-encoding": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,10 +1219,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
-  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+tough-cookie@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
     psl "^1.1.33"
     punycode "^2.1.1"


### PR DESCRIPTION
The "tough cookie" package was found to have a vulnerability related to Prototype Pollution in version 4.1.2. To address this issue, I updated the package to version 4.1.3, which contains the necessary fixes to mitigate the vulnerability.