### PR TITLE
fix CVE-2023-26136 Security fix for Prototype Pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rrweb-cssom": "^0.6.0",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",
-    "tough-cookie": "^4.1.2",
+    "tough-cookie": "^4.1.3",
     "w3c-xmlserializer": "^4.0.0",
     "webidl-conversions": "^7.0.0",
     "whatwg-encoding": "^2.0.0",


### PR DESCRIPTION
https://github.com/salesforce/tough-cookie/releases/tag/v4.1.3 
Security fix for Prototype Pollution discovery in https://github.com/salesforce/tough-cookie/issues/282. This is a minor release, although output from the inspect utility is affected by this change, we felt this change was important enough to be pushed into the next patch.