### PR TITLE
Simplified Array.from in convertToSequenceDOMString

### DIFF
--- a/lib/jsdom/living/custom-elements/CustomElementRegistry-impl.js
+++ b/lib/jsdom/living/custom-elements/CustomElementRegistry-impl.js
@@ -26,7 +26,7 @@ function convertToSequenceDOMString(obj) {
     throw new TypeError("Invalid Sequence");
   }
 
-  return Array.from(obj).map(webIDLConversions.DOMString);
+  return Array.from(obj, webIDLConversions.DOMString);
 }
 
 // Returns true is the passed value is a valid constructor.


### PR DESCRIPTION
`Array.from` has optional second argument. Calling `map` is not required for this case.