### PR TITLE
Update `whatwg-url` to the v23

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,12 @@
     "webidl-conversions": "^7.0.0",
     "whatwg-encoding": "^2.0.0",
     "whatwg-mimetype": "^3.0.0",
-    "whatwg-url": "^12.0.1",
+    "whatwg-url": "^13.0.0",
     "ws": "^8.13.0",
     "xml-name-validator": "^4.0.0"
+  },
+  "resolutions": {
+    "whatwg-url": "^13.0.0"
   },
   "peerDependencies": {
     "canvas": "^2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,10 +1311,10 @@ whatwg-mimetype@^3.0.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
   integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
-whatwg-url@^12.0.0, whatwg-url@^12.0.1:
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-12.0.1.tgz#fd7bcc71192e7c3a2a97b9a8d6b094853ed8773c"
-  integrity sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==
+whatwg-url@^12.0.0, whatwg-url@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-13.0.0.tgz#b7b536aca48306394a34e44bda8e99f332410f8f"
+  integrity sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==
   dependencies:
     tr46 "^4.1.1"
     webidl-conversions "^7.0.0"


### PR DESCRIPTION
Updated `whatwg-url` to the v23 for https://github.com/jsdom/jsdom/issues/3604

As per https://github.com/jsdom/whatwg-url/releases/tag/v13.0.0:
 
> Breaking change: removed Node.js v14 support.
> 
> Added URL.canParse(), per https://github.com/whatwg/url/commit/ae3c28b84e3e7122c2807401c26b8a63cb2ab445.
> 
> Added URLSearchParams's size getter, per https://github.com/whatwg/url/commit/12b6f0c456c6df049e2704c92bb3a6d4d1364ec8.
> 
> Added optional second value argument to URLSearchParams's has() and delete() methods, per https://github.com/whatwg/url/commit/bfb9157186c237078cb1ac4998607d88242abe35.
>
> Changed the serialization of the origin of blob: URLs whose inner URLs were not http: or https: to be "null", per https://github.com/whatwg/url/commit/eee49fdf4f99d59f717cbeb0bce29fda930196d4.

JSDOM already only offers support for Node v16+

I also used yarn resolutions to force `whatwg-url` to only be present in the v23 because `data-urls` uses the v22. This can be removed if `data-urls` was also update to be able to use the v23

