### PR TITLE
Issue #3635 : Fix Operator Syntax Error

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -580,7 +580,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
 
   get files() {
     if (this.type === "file") {
-      this[filesSymbol] ||= FileList.createImpl(this._globalObject);
+      this[filesSymbol] = this[filesSymbol] || FileList.createImpl(this._globalObject);
     } else {
       this[filesSymbol] = null;
     }

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -579,9 +579,9 @@ class HTMLInputElementImpl extends HTMLElementImpl {
   }
 
   get files() {
-    if (this.type === "file") {
-      this[filesSymbol] = this[filesSymbol] || FileList.createImpl(this._globalObject);
-    } else {
+    if (this.type === "file" && !this[filesSymbol]) {
+      this[filesSymbol] = FileList.createImpl(this._globalObject);
+    } else if (this.type !== "file") {
       this[filesSymbol] = null;
     }
     return this[filesSymbol];


### PR DESCRIPTION
#3635 
The code provided includes the usage of the ||= operator, which was introduced in ECMAScript 2021. The error encountered on render.com indicates that the platform might be running an environment that does not support this particular JavaScript feature.

When running similar code in browsers, the behavior depends on the browser's JavaScript engine and its support for ECMAScript features. Most modern browsers support ECMAScript 2021 features, including the ||= operator. However, some older browsers or specific environments may not fully support the latest ECMAScript specifications.

If you encounter a similar issue in a browser, it could be due to using an outdated or less feature-rich browser that does not support ECMAScript 2021. In such cases, you might need to consider alternative approaches or transpile your code to an earlier ECMAScript version to ensure compatibility with a broader range of browsers.