### PR TITLE
Mark `Element.scrollIntoView` as not implemented

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -26,6 +26,7 @@ const ShadowRoot = require("../generated/ShadowRoot");
 const Text = require("../generated/Text");
 const { isValidHostElementName } = require("../helpers/shadow-dom");
 const { isValidCustomElementName, lookupCEDefinition } = require("../helpers/custom-elements");
+const notImplemented = require("../../browser/not-implemented");
 
 function attachId(id, elm, doc) {
   if (id && elm && doc) {
@@ -380,6 +381,10 @@ class ElementImpl extends NodeImpl {
 
   get clientHeight() {
     return 0;
+  }
+
+  scrollIntoView() {
+    notImplemented("Element.prototype.scrollIntoView", this._ownerDocument._defaultView);
   }
 
   // https://dom.spec.whatwg.org/#dom-element-attachshadow


### PR DESCRIPTION
Resolves #1695 

Because JSDom can't handle layout, `Element.scrollIntoView` can't really be implemented. However, it hasn't been marked as not implemented like several other scrolling methods have, for example `window.scrollTo`.

This PR marks `Element.scrollIntoView` as not implemented, with the purpose of improved error reporting when users write tests than invoke `Element.scrollIntoView`.