### PR TITLE
feat: HTML Search Element

### DIFF
--- a/lib/jsdom/living/helpers/create-element.js
+++ b/lib/jsdom/living/helpers/create-element.js
@@ -21,7 +21,7 @@ const INTERFACE_TAG_MAPPING = {
     HTMLElement: [
       "abbr", "address", "article", "aside", "b", "bdi", "bdo", "cite", "code", "dd", "dfn", "dt", "em", "figcaption",
       "figure", "footer", "header", "hgroup", "i", "kbd", "main", "mark", "nav", "noscript", "rp", "rt", "ruby", "s",
-      "samp", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr"
+      "samp", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr", "search"
     ],
     HTMLAnchorElement: ["a"],
     HTMLAreaElement: ["area"],

--- a/test/to-port-to-wpts/htmlelement.js
+++ b/test/to-port-to-wpts/htmlelement.js
@@ -8,7 +8,7 @@ const { JSDOM } = require("../..");
 const nonInheritedTags = [
   "article", "section", "nav", "aside", "hgroup", "header", "footer", "address", "dt",
   "dd", "figure", "figcaption", "main", "em", "strong", "small", "s", "cite", "abbr",
-  "code", "i", "b", "u"
+  "code", "i", "b", "u", "search"
 ];
 
 describe("htmlelement", () => {


### PR DESCRIPTION
Recently introduced in Chrome 118, a new semantic element containing search bar and filters. It has no styles or behaviour.

https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search