### PR TITLE
Implement full long reflection

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -748,35 +748,6 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     return null;
   }
 
-  // Reflected IDL attribute does not care about whether the content attribute applies.
-  get maxLength() {
-    if (!this.hasAttributeNS(null, "maxlength")) {
-      return 524288; // stole this from chrome
-    }
-    return parseInt(this.getAttributeNS(null, "maxlength"));
-  }
-
-  set maxLength(value) {
-    if (value < 0) {
-      throw DOMException.create(this._globalObject, ["The index is not in the allowed range.", "IndexSizeError"]);
-    }
-    this.setAttributeNS(null, "maxlength", String(value));
-  }
-
-  get minLength() {
-    if (!this.hasAttributeNS(null, "minlength")) {
-      return 0;
-    }
-    return parseInt(this.getAttributeNS(null, "minlength"));
-  }
-
-  set minLength(value) {
-    if (value < 0) {
-      throw DOMException.create(this._globalObject, ["The index is not in the allowed range.", "IndexSizeError"]);
-    }
-    this.setAttributeNS(null, "minlength", String(value));
-  }
-
   get size() {
     if (!this.hasAttributeNS(null, "size")) {
       return 20;

--- a/lib/jsdom/living/nodes/HTMLInputElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLInputElement.webidl
@@ -22,9 +22,9 @@ interface HTMLInputElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString inputMode;
   readonly attribute HTMLElement? list;
   [CEReactions, Reflect] attribute DOMString max;
-  [CEReactions] attribute long maxLength;
+  [CEReactions, ReflectNonNegative] attribute long maxLength;
   [CEReactions, Reflect] attribute DOMString min;
-  [CEReactions] attribute long minLength;
+  [CEReactions, ReflectNonNegative] attribute long minLength;
   [CEReactions, Reflect] attribute boolean multiple;
   [CEReactions, Reflect] attribute DOMString name;
   [CEReactions, Reflect] attribute DOMString pattern;

--- a/lib/jsdom/living/nodes/HTMLTextAreaElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLTextAreaElement.webidl
@@ -9,8 +9,8 @@ interface HTMLTextAreaElement : HTMLElement {
   [CEReactions, Reflect] attribute boolean disabled;
   readonly attribute HTMLFormElement? form;
   [CEReactions, Reflect] attribute DOMString inputMode;
-  [CEReactions, Reflect] attribute long maxLength; // TODO limited to only non-negative numbers
-  [CEReactions, Reflect] attribute long minLength; // TODO limited to only non-negative numbers
+  [CEReactions, ReflectNonNegative] attribute long maxLength;
+  [CEReactions, ReflectNonNegative] attribute long minLength;
   [CEReactions, Reflect] attribute DOMString name;
   [CEReactions, Reflect] attribute DOMString placeholder;
   [CEReactions, Reflect] attribute boolean readOnly;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1190,8 +1190,6 @@ input-type-button.html: [fail, Depends on offsetWidth]
 input-type-change-value.html: [fail, Unknown]
 input-type-checkbox-switch.tentative.window.html: [fail, Unknown]
 input-untrusted-key-event.html: [fail-slow, Not implemented]
-maxlength.html: [fail, Reflection not implemented correctly]
-minlength.html: [fail, Reflection not implemented correctly]
 pattern_attribute_v_flag.html: [fail, Unknown]
 radio-disconnected-group-owner.html: [fail, Unknown]
 range-2.html: [fail, step attribute not yet implemented]
@@ -1242,8 +1240,6 @@ show-picker-cross-origin-iframe.tentative.html: [timeout, Unknown]
 
 DIR: html/semantics/forms/the-textarea-element
 
-textarea-maxlength.html: [fail, Unknown]
-textarea-minlength.html: [fail, Unknown]
 textarea-placeholder-lineheight.html: [fail, getBoundingClientRect() is not implemented]
 wrap-enumerated-ascii-case-insensitive.html: [timeout, Unknown]
 


### PR DESCRIPTION
This makes maxLength and minLength have the precisely correct semantics for HTMLInputElement and HTMLTextAreaElement. And the code is now fully generated, instead of hand-coded.