### PR TITLE
Fix `window.getComputedStyle` error message

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -830,7 +830,7 @@ function Window(options) {
         throw new TypeError("Tried to get the computed style of a Shadow DOM pseudo-element.");
       }
 
-      notImplemented("window.computedStyle(elt, pseudoElt)", this);
+      notImplemented("window.getComputedStyle(elt, pseudoElt)", this);
     }
 
     const declaration = new CSSStyleDeclaration();


### PR DESCRIPTION
The error message previously mentioned `window.computedStyle` which does not exist. Instead it should say `window.getComputedStyle`.