### PR TITLE
Use css-color module

### DIFF
--- a/benchmark/dom/get-computed-style.js
+++ b/benchmark/dom/get-computed-style.js
@@ -1,0 +1,48 @@
+"use strict";
+const suite = require("../document-suite");
+
+exports["getComputedStyle() on document.body"] = () => {
+  let window, document;
+
+  return suite({
+    setup(doc) {
+      window = doc.defaultView;
+      document = doc;
+    },
+    fn() {
+      window.getComputedStyle(document.body);
+    }
+  });
+};
+
+exports["getComputedStyle() on element with rgb color"] = () => {
+  let window, node;
+
+  return suite({
+    setup(doc) {
+      window = doc.defaultView;
+      node = doc.createElement("div");
+      node.style.color = "rgb(128, 0, 128)";
+      doc.body.appendChild(node);
+    },
+    fn() {
+      window.getComputedStyle(node);
+    }
+  });
+};
+
+exports["getComputedStyle() on element with non-rgb color"] = () => {
+  let window, node;
+
+  return suite({
+    setup(doc) {
+      window = doc.defaultView;
+      node = doc.createElement("div");
+      node.style.color = "color-mix(in srgb, red, blue)";
+      doc.body.appendChild(node);
+    },
+    fn() {
+      window.getComputedStyle(node);
+    }
+  });
+};

--- a/benchmark/dom/index.js
+++ b/benchmark/dom/index.js
@@ -5,5 +5,6 @@ module.exports = {
   "tree-modification": require("./tree-modification"),
   "compare-document-position": require("./compare-document-position"),
   "named-properties": require("./named-properties"),
-  "inner-html": require("./inner-html")
+  "inner-html": require("./inner-html"),
+  "get-computed-style": require("./get-computed-style")
 };

--- a/lib/jsdom/living/helpers/colors.js
+++ b/lib/jsdom/living/helpers/colors.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { resolve: getResolvedValueForColor } = require("@asamuzakjp/css-color");
+
 // https://drafts.csswg.org/css-color-4/#named-color
 const namedColors = {
   __proto__: null,
@@ -193,11 +195,11 @@ function sharedSpecifiedAndComputedAndUsed(color) {
     return hexToRGBA(color.slice(1));
   }
 
-  if (/^rgba?\(/.test(color)) {
+  if (/^rgba?\(/.test(color) && color.includes(",")) {
     return color.split(",").map(s => s.trim()).join(", ");
   }
 
-  return color;
+  return getResolvedValueForColor(color);
 }
 
 function hexToRGB(color) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "24.0.0",
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/css-color": "^1.0.1",
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
         "decimal.js": "^10.4.3",
@@ -66,6 +67,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-1.0.1.tgz",
+      "integrity": "sha512-HRE89jJMyiCdYbgOrozBz81oYVG8WSegy7jLrCAQ8JWQdH5lyz4Ax6t1Q7ja5hjdxcWSHs/HEYvzC1qwEfTmKw=="
     },
     "node_modules/@domenic/eslint-config": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "repository": "jsdom/jsdom",
   "dependencies": {
+    "@asamuzakjp/css-color": "^1.0.1",
     "cssstyle": "^4.0.1",
     "data-urls": "^5.0.0",
     "decimal.js": "^10.4.3",


### PR DESCRIPTION
Fix #3657 

# Benchmark result

|Benchmark|main|patch|
|:--------|:--------|:--------|
|# dom/get-computed-style/getComputedStyle() on document.body #|jsdom  x 24,411 ops/sec ±2.90% (88 runs sampled)|jsdom  x 28,467 ops/sec ±1.05% (89 runs sampled)|
|# dom/get-computed-style/getComputedStyle() on element with non-rgb color #|jsdom  x 24,564 ops/sec ±1.24% (89 runs sampled)|jsdom  x 29,178 ops/sec ±0.91% (91 runs sampled)|
|# dom/get-computed-style/getComputedStyle() on element with rgb color #|jsdom  x 14,097 ops/sec ±4.15% (85 runs sampled)|jsdom  x 13,822 ops/sec ±2.08% (84 runs sampled)|

Ignore the 2nd `getComputedStyle() on element with non-rgb color` as it simply failed.
It looks like jsdom does not pass unsupported colors, e.g. `color-mix()`, correctly to `getSpecifiedColor()`.
We need to fix https://github.com/jsdom/jsdom/blob/main/lib/jsdom/living/helpers/style-rules.js#L175 to support them?
