### PR TITLE
Trigger selectionchange event on document when selection changes (small change - 2 files)

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -67,6 +67,7 @@ class HTMLOrSVGElementImpl {
     ownerDocument._lastFocusedElement = this;
     focusing.fireFocusEventWithTargetAdjustment("focus", this, previous);
     focusing.fireFocusEventWithTargetAdjustment("focusin", this, previous, { bubbles: true });
+    ownerDocument.getSelection().collapse(this, 0);
   }
 
   blur() {
@@ -79,6 +80,7 @@ class HTMLOrSVGElementImpl {
     focusing.fireFocusEventWithTargetAdjustment("focusout", this, this._ownerDocument, { bubbles: true });
     focusing.fireFocusEventWithTargetAdjustment("focus", this._ownerDocument, this);
     focusing.fireFocusEventWithTargetAdjustment("focusin", this._ownerDocument, this, { bubbles: true });
+    this._ownerDocument.getSelection().empty();
   }
 }
 

--- a/lib/jsdom/living/selection/Selection-impl.js
+++ b/lib/jsdom/living/selection/Selection-impl.js
@@ -344,7 +344,11 @@ class SelectionImpl {
 
     // https://w3c.github.io/selection-api/#selectionchange-event
     if (didSelectionChange) {
-      fireAnEvent("selectionchange", implForWrapper(this._globalObject._document));
+      // Fire the event asynchronously, as it's done in the browser
+      const document = this._globalObject._document;
+      setTimeout(() => {
+        fireAnEvent("selectionchange", implForWrapper(document));
+      }, 0);
     }
   }
 }

--- a/lib/jsdom/living/selection/Selection-impl.js
+++ b/lib/jsdom/living/selection/Selection-impl.js
@@ -11,6 +11,7 @@ const { setBoundaryPointStart, setBoundaryPointEnd } = require("../range/Range-i
 
 const Range = require("../generated/Range");
 const { implForWrapper } = require("../generated/utils");
+const { fireAnEvent } = require("../helpers/events");
 
 // https://w3c.github.io/selection-api/#dfn-direction
 const SELECTION_DIRECTION = {
@@ -329,11 +330,22 @@ class SelectionImpl {
   }
 
   _associateRange(newRange) {
+    const didSelectionChange = this._range !== newRange &&
+      (
+        // Change from/to null selection
+        newRange === null ||
+        this._range === null ||
+        // Change of selection range
+        compareBoundaryPointsPosition(newRange._start, this._range._start) !== 0 ||
+        compareBoundaryPointsPosition(newRange._end, this._range._end) !== 0
+      );
     this._range = newRange;
     this._direction = newRange === null ? SELECTION_DIRECTION.DIRECTIONLESS : SELECTION_DIRECTION.FORWARDS;
 
-    // TODO: Emit "selectionchange" event. At this time, there is currently no test in WPT covering this.
     // https://w3c.github.io/selection-api/#selectionchange-event
+    if (didSelectionChange) {
+      fireAnEvent("selectionchange", implForWrapper(this._globalObject._document));
+    }
   }
 }
 

--- a/test/web-platform-tests/to-upstream/selection/document-selectionchange.html
+++ b/test/web-platform-tests/to-upstream/selection/document-selectionchange.html
@@ -8,116 +8,110 @@
 
 <div id="example">test <span>nested</span></div>
 
-<input id="input" width="200" value="foo"><br>
-<textarea id="textarea" width="200">foo</textarea>
-<div id="contenteditable" contenteditable>test <span>nested</span></div><br>
-
 <script>
   "use strict";
 
-  test(t => {
-    let events = 0;
-    document.addEventListener("selectionchange", () => {
-      events++;
+  function tick() {
+    return new Promise(resolve => {
+      setTimeout(resolve, 0);
     });
-    const target = document.getElementById("example");
-    const selection = document.getSelection();
-    selection.setBaseAndExtent(target, 0, target, 1);
-    assert_equals(events, 1, "Should be 1 event");
-    selection.setBaseAndExtent(target, 0, target, 1);
-    assert_equals(events, 1, "Should be 1 event because we called setBaseAndExtent with the same arguments");
-    selection.setBaseAndExtent(target, 0, target, 2);
-    assert_equals(events, 2, "Should be 2 events");
-    t.add_cleanup(() => selection.removeAllRanges());
-  }, `triggers selectionchange event on setBaseAndExtent`);
-
-  test(t => {
-    let events = 0;
-    document.addEventListener("selectionchange", () => {
-      events++;
-    });
-    const target = document.getElementById("example");
-    const selection = document.getSelection();
-    selection.selectAllChildren(target);
-    assert_equals(events, 1, "Should be 1 event");
-    selection.selectAllChildren(target);
-    assert_equals(events, 1, "Should be 1 event because we called selectAllChildren with the same arguments");
-    t.add_cleanup(() => selection.removeAllRanges());
-  }, `triggers selectionchange event on selectAllChildren`);
-
-  test(t => {
-    let events = 0;
-    document.addEventListener("selectionchange", () => {
-      events++;
-    });
-    const target = document.getElementById("example");
-    const selection = document.getSelection();
-    selection.selectAllChildren(target);
-    assert_equals(events, 1, "Should be 1 event");
-    selection.removeAllRanges();
-    assert_equals(events, 2, "Should be 2 events");
-    selection.removeAllRanges();
-    assert_equals(events, 2, "Should be 2 events because we called removeAllRanges with the same arguments");
-    t.add_cleanup(() => selection.removeAllRanges());
-  }, `triggers selectionchange event on removeAllRanges`);
-
-  test(t => {
-    let events = 0;
-    document.addEventListener("selectionchange", () => {
-      events++;
-    });
-    const target = document.getElementById("example");
-    const selection = document.getSelection();
-    selection.setBaseAndExtent(target, 0, target, 1);
-    assert_equals(events, 1, "Should be 1 event");
-    selection.collapseToStart();
-    assert_equals(events, 2, "Should be 2 events");
-    selection.collapseToStart();
-    assert_equals(events, 2, "Should be 2 events because we called collapseToStart with the same arguments");
-    t.add_cleanup(() => selection.removeAllRanges());
-  }, `triggers selectionchange event on collapseToStart`);
-
-  test(t => {
-    let events = 0;
-    document.addEventListener("selectionchange", () => {
-      events++;
-    });
-    const target = document.getElementById("example");
-    const selection = document.getSelection();
-    selection.setBaseAndExtent(target, 0, target, 1);
-    assert_equals(events, 1, "Should be 1 event");
-    selection.collapseToEnd();
-    assert_equals(events, 2, "Should be 2 events");
-    selection.collapseToEnd();
-    assert_equals(events, 2, "Should be 2 events because we called collapseToEnd with the same arguments");
-    t.add_cleanup(() => selection.removeAllRanges());
-  }, `triggers selectionchange event on collapseToEnd`);
-
-  for (const id of ["input", "textarea", "contenteditable"]) {
-    test(t => {
-      const element = document.getElementById(id);
-      let events = 0;
-      document.addEventListener("selectionchange", () => {
-        events++;
-      });
-      element.focus();
-      assert_equals(events, 1, "Should be 1 event");
-      element.blur();
-      assert_equals(events, 2, "Should be 2 event");
-      t.add_cleanup(() => document.getSelection().removeAllRanges());
-    }, `triggers selectionchange event on focus/blur for ${id}`);
   }
 
-  test(t => {
-    const element = document.getElementById("example");
+  async function setupTest() {
+    const target = document.getElementById("example");
+    const selection = document.getSelection();
+
+    // Clean-up the state
+    selection.removeAllRanges();
+    await tick();
+
+    // Add event listeners and increment count on each event
     let events = 0;
     document.addEventListener("selectionchange", () => {
       events++;
     });
-    element.focus();
-    assert_equals(events, 0, "Should be 0 events");
-    element.blur();
-    assert_equals(events, 0, "Should be 0 events");
-    t.add_cleanup(() => document.getSelection().removeAllRanges());
-  }, "does not trigger selectionchange event when focusing on unfocusable element");
+
+    function getEventsCount() {
+      return events;
+    }
+
+    return { target, selection, getEventsCount };
+  }
+
+  promise_test(async () => {
+    const { target, selection, getEventsCount } = await setupTest();
+
+    selection.setBaseAndExtent(target, 0, target, 1);
+    assert_equals(getEventsCount(), 0, "Should be 0 events as they're scheduled");
+    await tick();
+    assert_equals(getEventsCount(), 1, "Should be 1 event");
+
+    selection.setBaseAndExtent(target, 0, target, 1);
+    await tick();
+    assert_equals(getEventsCount(), 1, "Should be 1 event because we called setBaseAndExtent with the same arguments");
+
+    selection.setBaseAndExtent(target, 0, target, 2);
+    await tick();
+    assert_equals(getEventsCount(), 2, "Should be 2 events");
+  }, `triggers selectionchange event on setBaseAndExtent`);
+
+  promise_test(async () => {
+    const { target, selection, getEventsCount } = await setupTest();
+
+    selection.selectAllChildren(target);
+    await tick();
+    assert_equals(getEventsCount(), 1, "Should be 1 event");
+
+    selection.selectAllChildren(target);
+    await tick();
+    assert_equals(getEventsCount(), 1, "Should be 1 event because we called selectAllChildren with the same arguments");
+  }, `triggers selectionchange event on selectAllChildren`);
+
+  promise_test(async () => {
+    const { target, selection, getEventsCount } = await setupTest();
+
+    selection.selectAllChildren(target);
+    await tick();
+    assert_equals(getEventsCount(), 1, "Should be 1 event");
+
+    selection.removeAllRanges();
+    await tick();
+    assert_equals(getEventsCount(), 2, "Should be 2 events");
+
+    selection.removeAllRanges();
+    await tick();
+    assert_equals(getEventsCount(), 2, "Should be 2 events because we called removeAllRanges with the same arguments");
+  }, `triggers selectionchange event on removeAllRanges`);
+
+  promise_test(async () => {
+    const { target, selection, getEventsCount } = await setupTest();
+
+    selection.setBaseAndExtent(target, 0, target, 1);
+    await tick();
+    assert_equals(getEventsCount(), 1, "Should be 1 event");
+
+    selection.collapseToStart();
+    await tick();
+    assert_equals(getEventsCount(), 2, "Should be 2 events");
+
+    selection.collapseToStart();
+    await tick();
+    assert_equals(getEventsCount(), 2, "Should be 2 events because we called collapseToStart with the same arguments");
+  }, `triggers selectionchange event on collapseToStart`);
+
+  promise_test(async () => {
+    const { target, selection, getEventsCount } = await setupTest();
+
+    selection.setBaseAndExtent(target, 0, target, 1);
+    await tick();
+    assert_equals(getEventsCount(), 1, "Should be 1 event");
+
+    selection.collapseToEnd();
+    await tick();
+    assert_equals(getEventsCount(), 2, "Should be 2 events");
+
+    selection.collapseToEnd();
+    await tick();
+    assert_equals(getEventsCount(), 2, "Should be 2 events because we called collapseToEnd with the same arguments");
+  }, `triggers selectionchange event on collapseToEnd`);
 </script>

--- a/test/web-platform-tests/to-upstream/selection/document-selectionchange.html
+++ b/test/web-platform-tests/to-upstream/selection/document-selectionchange.html
@@ -8,6 +8,10 @@
 
 <div id="example">test <span>nested</span></div>
 
+<input id="input" width="200" value="foo"><br>
+<textarea id="textarea" width="200">foo</textarea>
+<div id="contenteditable" contenteditable>test <span>nested</span></div><br>
+
 <script>
   "use strict";
 
@@ -88,4 +92,32 @@
     assert_equals(events, 2, "Should be 2 events because we called collapseToEnd with the same arguments");
     t.add_cleanup(() => selection.removeAllRanges());
   }, `triggers selectionchange event on collapseToEnd`);
+
+  for (const id of ["input", "textarea", "contenteditable"]) {
+    test(t => {
+      const element = document.getElementById(id);
+      let events = 0;
+      document.addEventListener("selectionchange", () => {
+        events++;
+      });
+      element.focus();
+      assert_equals(events, 1, "Should be 1 event");
+      element.blur();
+      assert_equals(events, 2, "Should be 2 event");
+      t.add_cleanup(() => document.getSelection().removeAllRanges());
+    }, `triggers selectionchange event on focus/blur for ${id}`);
+  }
+
+  test(t => {
+    const element = document.getElementById("example");
+    let events = 0;
+    document.addEventListener("selectionchange", () => {
+      events++;
+    });
+    element.focus();
+    assert_equals(events, 0, "Should be 0 events");
+    element.blur();
+    assert_equals(events, 0, "Should be 0 events");
+    t.add_cleanup(() => document.getSelection().removeAllRanges());
+  }, "does not trigger selectionchange event when focusing on unfocusable element");
 </script>

--- a/test/web-platform-tests/to-upstream/selection/document-selectionchange.html
+++ b/test/web-platform-tests/to-upstream/selection/document-selectionchange.html
@@ -1,0 +1,91 @@
+<!DOCTYPE HTML>
+<title>selectionchange event on document</title>
+<link rel="author" title="Piotr Oleś" href="mailto:piotrek.oles@gmail.com">
+<link rel="help" href="https://w3c.github.io/selection-api/#selectionchange-event">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="example">test <span>nested</span></div>
+
+<script>
+  "use strict";
+
+  test(t => {
+    let events = 0;
+    document.addEventListener("selectionchange", () => {
+      events++;
+    });
+    const target = document.getElementById("example");
+    const selection = document.getSelection();
+    selection.setBaseAndExtent(target, 0, target, 1);
+    assert_equals(events, 1, "Should be 1 event");
+    selection.setBaseAndExtent(target, 0, target, 1);
+    assert_equals(events, 1, "Should be 1 event because we called setBaseAndExtent with the same arguments");
+    selection.setBaseAndExtent(target, 0, target, 2);
+    assert_equals(events, 2, "Should be 2 events");
+    t.add_cleanup(() => selection.removeAllRanges());
+  }, `triggers selectionchange event on setBaseAndExtent`);
+
+  test(t => {
+    let events = 0;
+    document.addEventListener("selectionchange", () => {
+      events++;
+    });
+    const target = document.getElementById("example");
+    const selection = document.getSelection();
+    selection.selectAllChildren(target);
+    assert_equals(events, 1, "Should be 1 event");
+    selection.selectAllChildren(target);
+    assert_equals(events, 1, "Should be 1 event because we called selectAllChildren with the same arguments");
+    t.add_cleanup(() => selection.removeAllRanges());
+  }, `triggers selectionchange event on selectAllChildren`);
+
+  test(t => {
+    let events = 0;
+    document.addEventListener("selectionchange", () => {
+      events++;
+    });
+    const target = document.getElementById("example");
+    const selection = document.getSelection();
+    selection.selectAllChildren(target);
+    assert_equals(events, 1, "Should be 1 event");
+    selection.removeAllRanges();
+    assert_equals(events, 2, "Should be 2 events");
+    selection.removeAllRanges();
+    assert_equals(events, 2, "Should be 2 events because we called removeAllRanges with the same arguments");
+    t.add_cleanup(() => selection.removeAllRanges());
+  }, `triggers selectionchange event on removeAllRanges`);
+
+  test(t => {
+    let events = 0;
+    document.addEventListener("selectionchange", () => {
+      events++;
+    });
+    const target = document.getElementById("example");
+    const selection = document.getSelection();
+    selection.setBaseAndExtent(target, 0, target, 1);
+    assert_equals(events, 1, "Should be 1 event");
+    selection.collapseToStart();
+    assert_equals(events, 2, "Should be 2 events");
+    selection.collapseToStart();
+    assert_equals(events, 2, "Should be 2 events because we called collapseToStart with the same arguments");
+    t.add_cleanup(() => selection.removeAllRanges());
+  }, `triggers selectionchange event on collapseToStart`);
+
+  test(t => {
+    let events = 0;
+    document.addEventListener("selectionchange", () => {
+      events++;
+    });
+    const target = document.getElementById("example");
+    const selection = document.getSelection();
+    selection.setBaseAndExtent(target, 0, target, 1);
+    assert_equals(events, 1, "Should be 1 event");
+    selection.collapseToEnd();
+    assert_equals(events, 2, "Should be 2 events");
+    selection.collapseToEnd();
+    assert_equals(events, 2, "Should be 2 events because we called collapseToEnd with the same arguments");
+    t.add_cleanup(() => selection.removeAllRanges());
+  }, `triggers selectionchange event on collapseToEnd`);
+</script>


### PR DESCRIPTION
I want to test my contenteditable component that relies on `selectionchange` events. When debugging why my tests doesn't reflect browser behaviour, I found this TODO:
https://github.com/jsdom/jsdom/blob/main/lib/jsdom/living/selection/Selection-impl.js#L335

This PR addresses that TODO by triggering `selectionchange` event on `document` as stated in the spec. I added missing tests as well.