### PR TITLE
Fix the RegExp flag used for input pattern validation

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -1025,10 +1025,16 @@ class HTMLInputElementImpl extends HTMLElementImpl {
             // The pattern attribute should be matched against the entire value, not just any
             // subset, so add ^ and $ anchors. But also check the validity of the regex itself
             // first.
-            new RegExp(pattern, "u"); // eslint-disable-line no-new
-            regExp = new RegExp("^(?:" + pattern + ")$", "u");
-          } catch (e) {
-            return false;
+            regExp = new RegExp("^(?:" + pattern + ")$", "v");
+          } catch (_) {
+            // Exception may have been thrown because "v" was unsupported
+            // Fallback to "u" flag
+            try {
+              const pattern = this.getAttributeNS(null, "pattern");
+              regExp = new RegExp("^(?:" + pattern + ")$", "u");
+            } catch (e) {
+              return false;
+            }
           }
           if (this._hasAttributeAndApplies("multiple")) {
             return !splitOnCommas(this._value).every(value => regExp.test(value));

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1107,7 +1107,6 @@ formaction.html: [fail, Unknown]
 
 DIR: html/semantics/forms/constraints
 
-form-validation-validity-patternMismatch.html: [fail, Unknown]
 form-validation-validity-valueMissing.html: [fail, 'Spec unclear (see https://github.com/whatwg/html/issues/5202)']
 form-validation-willValidate.html:
   "[INPUT in COLOR status] Must be barred from the constraint validation if it is readonly": [fail, Not implemented]
@@ -1190,7 +1189,6 @@ input-type-button.html: [fail, Depends on offsetWidth]
 input-type-change-value.html: [fail, Unknown]
 input-type-checkbox-switch.tentative.window.html: [fail, Unknown]
 input-untrusted-key-event.html: [fail-slow, Not implemented]
-pattern_attribute_v_flag.html: [fail, Unknown]
 radio-disconnected-group-owner.html: [fail, Unknown]
 range-2.html: [fail, step attribute not yet implemented]
 range-restore-oninput-onchange-event.https.html: [fail-slow, Not implemented]

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1107,6 +1107,7 @@ formaction.html: [fail, Unknown]
 
 DIR: html/semantics/forms/constraints
 
+form-validation-validity-patternMismatch.html: [fail-node18, v is in invalid flag for RegExp in Node 18]
 form-validation-validity-valueMissing.html: [fail, 'Spec unclear (see https://github.com/whatwg/html/issues/5202)']
 form-validation-willValidate.html:
   "[INPUT in COLOR status] Must be barred from the constraint validation if it is readonly": [fail, Not implemented]
@@ -1189,6 +1190,7 @@ input-type-button.html: [fail, Depends on offsetWidth]
 input-type-change-value.html: [fail, Unknown]
 input-type-checkbox-switch.tentative.window.html: [fail, Unknown]
 input-untrusted-key-event.html: [fail-slow, Not implemented]
+pattern_attribute_v_flag.html: [fail-node18, v is in invalid flag for RegExp in Node 18]
 radio-disconnected-group-owner.html: [fail, Unknown]
 range-2.html: [fail, step attribute not yet implemented]
 range-restore-oninput-onchange-event.https.html: [fail-slow, Not implemented]


### PR DESCRIPTION
According to MDN (https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#overview), the RegExp flag was changed from 'u' to 'v' around mid-2023, so jsdom should update to match that.

Fixes: https://github.com/jsdom/jsdom/issues/3680