### PR TITLE
Implement the getSetCookie method of Headers

### DIFF
--- a/lib/jsdom/living/fetch/Headers-impl.js
+++ b/lib/jsdom/living/fetch/Headers-impl.js
@@ -56,9 +56,17 @@ class HeadersImpl {
     return this.headersList.contains(name);
   }
 
+  getSetCookie() {
+    return this.headersList.get("Set-Cookie") || [];
+  }
+
   get(name) {
     assertName(name);
-    return this.headersList.get(name);
+    const r = this.headersList.get(name);
+    if (!r) {
+      return null;
+    }
+    return r.join(", ");
   }
 
   _removePrivilegedNoCORSHeaders() {
@@ -79,12 +87,6 @@ class HeadersImpl {
         }
         break;
       case "request-no-cors": {
-        let temporaryValue = this.get(name);
-        if (temporaryValue === null) {
-          temporaryValue = value;
-        } else {
-          temporaryValue += `, ${value}`;
-        }
         if (!isCORSWhitelisted(name, value)) {
           return;
         }

--- a/lib/jsdom/living/fetch/Headers.webidl
+++ b/lib/jsdom/living/fetch/Headers.webidl
@@ -8,6 +8,7 @@ interface Headers {
   undefined append(ByteString name, ByteString value);
   undefined delete(ByteString name);
   ByteString? get(ByteString name);
+  sequence<ByteString> getSetCookie();
   boolean has(ByteString name);
   undefined set(ByteString name, ByteString value);
   iterable<ByteString, ByteString>;

--- a/lib/jsdom/living/fetch/header-list.js
+++ b/lib/jsdom/living/fetch/header-list.js
@@ -46,16 +46,19 @@ class HeaderList {
 
   sortAndCombine() {
     const names = [...this.headers.keys()].sort();
-    return names.reduce((ret, n) => {
-      if (n === "set-cookie") {
-        this.get(n).forEach(v => {
-          ret.push([n, v]);
-        });
+
+    const headers = [];
+    for (const name of names) {
+      if (name === "set-cookie") {
+        for (const value of this.get(name)) {
+          headers.push([name, value]);
+        }
       } else {
-        ret.push([n, this.get(n).join(", ")]);
+        headers.push([name, this.get(name).join(", ")]);
       }
-      return ret;
-    }, []);
+    }
+
+    return headers;
   }
 }
 

--- a/lib/jsdom/living/fetch/header-list.js
+++ b/lib/jsdom/living/fetch/header-list.js
@@ -15,10 +15,9 @@ class HeaderList {
   append(name, value) {
     const existing = this.headers.get(name.toLowerCase());
     if (existing) {
-      name = existing[0].name;
-      existing.push({ name, value });
+      existing.push(value);
     } else {
-      this.headers.set(name.toLowerCase(), [{ name, value }]);
+      this.headers.set(name.toLowerCase(), [value]);
     }
   }
 
@@ -32,7 +31,7 @@ class HeaderList {
     if (!values) {
       return null;
     }
-    return values.map(h => h.value).join(", ");
+    return values;
   }
 
   delete(name) {
@@ -42,12 +41,21 @@ class HeaderList {
   set(name, value) {
     const lowerName = name.toLowerCase();
     this.headers.delete(lowerName);
-    this.headers.set(lowerName, [{ name, value }]);
+    this.headers.set(lowerName, [value]);
   }
 
   sortAndCombine() {
     const names = [...this.headers.keys()].sort();
-    return names.map(n => [n, this.get(n)]);
+    return names.reduce((ret, n) => {
+      if (n === "set-cookie") {
+        this.get(n).forEach(v => {
+          ret.push([n, v]);
+        });
+      } else {
+        ret.push([n, this.get(n).join(", ")]);
+      }
+      return ret;
+    }, []);
   }
 }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -500,7 +500,7 @@ innerhtml-05.xhtml: [fail, Unknown]
 
 DIR: fetch/api/headers
 
-header-setcookie.any.html: [fail, Unknown]
+header-setcookie.any.html: [fail, Response is not defined]
 header-values-normalize.any.html: [fail, fetch is not defined]
 header-values.any.html: [fail, fetch is not defined]
 headers-no-cors.any.html: [fail, Request is not defined]

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -500,7 +500,8 @@ innerhtml-05.xhtml: [fail, Unknown]
 
 DIR: fetch/api/headers
 
-header-setcookie.any.html: [fail, Response is not defined]
+header-setcookie.any.html:
+  "Set-Cookie is a forbidden response header": [fail, Response is not defined]
 header-values-normalize.any.html: [fail, fetch is not defined]
 header-values.any.html: [fail, fetch is not defined]
 headers-no-cors.any.html: [fail, Request is not defined]


### PR DESCRIPTION
I've implemented the `getSetCookie` method of `Headers`. The `HeaderList` data structure has been changed accordingly.

See here for the specification of the `getSetCookie` method.
https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie

With this fix, the `header-setcookie.any.html` test is resolved except for a failure due to `Response` not being implemented.

before
```
  1) web-platform-tests
       fetch/api/headers
         header-setcookie.any.html:
     18/24 errors in test:

Failed in "Headers iterator does not combine set-cookie headers":
assert_equals: Array length is not equal expected 2 but got 1
...
```

after
```
  1) web-platform-tests
       fetch/api/headers
         header-setcookie.any.html:
     1/24 errors in test:

Failed in "Set-Cookie is a forbidden response header"
Response is not defined
```