### PR TITLE
downgrade nwsapi to 2.2.4 to solve open issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.7",
+        "nwsapi": "2.2.4",
         "parse5": "^7.1.2",
         "rrweb-cssom": "^0.6.0",
         "saxes": "^6.0.0",
@@ -1618,9 +1618,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
+      "integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g=="
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
     "is-potential-custom-element-name": "^1.0.1",
-    "nwsapi": "^2.2.7",
+    "nwsapi": "2.2.4",
     "parse5": "^7.1.2",
     "rrweb-cssom": "^0.6.0",
     "saxes": "^6.0.0",


### PR DESCRIPTION
currently having to pin nwsapi to 2.2.4 due to open issues

https://github.com/dperini/nwsapi/issues/95

getting these same symtoms `SyntaxError: missing ) after argument list` when using https://github.com/adobe/react-spectrum/blob/main/packages/react-aria-components/src/Popover.tsx

Seems stalled on nwsapi side... consider downgrading?
