### PR TITLE
add support for CSSFontFaceRule

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -28,6 +28,7 @@ exports.addToCore = core => {
   core.CSSMediaRule = cssom.CSSMediaRule;
   core.CSSImportRule = cssom.CSSImportRule;
   core.CSSStyleDeclaration = cssstyle.CSSStyleDeclaration;
+  core.CSSFontFaceRule = cssom.CSSFontFaceRule;
 
   // Relevant specs
   // http://www.w3.org/TR/DOM-Level-2-Style (2000)
@@ -38,7 +39,6 @@ exports.addToCore = core => {
 
   // Objects that aren't in cssom library but should be:
   //   CSSRuleList  (cssom just uses array)
-  //   CSSFontFaceRule
   //   CSSPageRule
 
   // These rules don't really make sense to implement, so CSSOM draft makes them


### PR DESCRIPTION
This code is 9 years old but it looks like CSSFontFaceRule existed already 11 years ago.

I am not sure why it was explicitly disabled.