### PR TITLE
Add support for `blob` url scheme

### DIFF
--- a/lib/jsdom/browser/resources/resource-loader.js
+++ b/lib/jsdom/browser/resources/resource-loader.js
@@ -14,7 +14,7 @@ module.exports = class ResourceLoader {
     strictSSL = true,
     proxy = undefined,
     userAgent = `Mozilla/5.0 (${process.platform || "unknown OS"}) AppleWebKit/537.36 ` +
-                `(KHTML, like Gecko) jsdom/${packageVersion}`
+    `(KHTML, like Gecko) jsdom/${packageVersion}`
   } = {}) {
     this._strictSSL = strictSSL;
     this._proxy = proxy;
@@ -131,6 +131,24 @@ module.exports = class ResourceLoader {
           return this._readFile(fileURLToPath(urlString));
         } catch (e) {
           return Promise.reject(e);
+        }
+      }
+
+      case "blob": {
+        if ((typeof process !== 'undefined') && (typeof process.versions.node !== 'undefined')) {
+          try {
+            const { resolveObjectURL } = require('node:buffer');
+            if (resolveObjectURL) {
+              const blob = resolveObjectURL(urlString);
+              return blob.arrayBuffer();
+            } else {
+              return Promise.reject(new Error('cannot handle blob url scheme (resolveObjectURL missing)'));
+            }
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        } else {
+          return Promise.reject(new Error('cannot handle blob url scheme (wrong platform)'));
         }
       }
 

--- a/lib/jsdom/browser/resources/resource-loader.js
+++ b/lib/jsdom/browser/resources/resource-loader.js
@@ -135,20 +135,19 @@ module.exports = class ResourceLoader {
       }
 
       case "blob": {
-        if ((typeof process !== 'undefined') && (typeof process.versions.node !== 'undefined')) {
+        if ((typeof process !== "undefined") && (typeof process.versions.node !== "undefined")) {
           try {
-            const { resolveObjectURL } = require('node:buffer');
+            const { resolveObjectURL } = require("node:buffer");
             if (resolveObjectURL) {
               const blob = resolveObjectURL(urlString);
               return blob.arrayBuffer();
-            } else {
-              return Promise.reject(new Error('cannot handle blob url scheme (resolveObjectURL missing)'));
             }
+            return Promise.reject(new Error("cannot handle blob url scheme (resolveObjectURL missing)"));
           } catch (e) {
             return Promise.reject(e);
           }
         } else {
-          return Promise.reject(new Error('cannot handle blob url scheme (wrong platform)'));
+          return Promise.reject(new Error("cannot handle blob url scheme (wrong platform)"));
         }
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsdom",
-  "version": "24.1.0",
+  "version": "24.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsdom",
-      "version": "24.1.0",
+      "version": "24.2.1",
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsdom",
-  "version": "24.1.0",
+  "version": "24.2.1",
   "description": "A JavaScript implementation of many web standards",
   "keywords": [
     "dom",


### PR DESCRIPTION
Hi there

A small change that supports the use (in my case) of three.js's GLTFLoader class, which makes extensive use of blob-caching via `URL.createObjectURL` which generates a URL of the form `blob:nodedata:<uuid>`, which can then be decoded via the node.js api `resolveObjectURL`. [https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static](MDN)

I introduced a new case in `resource-loader.js` to handle the `blob` scheme. It requires `const { resolveObjectURL } = require("node:buffer");` which I placed inside a `try` block. You may want to do this differently, if so let me know.

All the best
Jim