### PR TITLE
Update rrweb-cssom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.10",
         "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.0",
+        "rrweb-cssom": "^0.7.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.1.4",
@@ -1904,9 +1904,10 @@
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.0.tgz",
-      "integrity": "sha512-KlSv0pm9kgQSRxXEMgtivPJ4h826YHsuob8pSHcfSZsSXGtvpEAie8S0AnXuObEJ7nhikOb4ahwxDm0H2yW17g=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -2392,6 +2393,7 @@
       }
     },
     "scripts/eslint-plugin": {
+      "name": "eslint-plugin-jsdom-internal",
       "version": "0.0.0",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "is-potential-custom-element-name": "^1.0.1",
     "nwsapi": "^2.2.10",
     "parse5": "^7.1.2",
-    "rrweb-cssom": "^0.7.0",
+    "rrweb-cssom": "^0.7.1",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",
     "tough-cookie": "^4.1.4",


### PR DESCRIPTION
Bump rrweb-cssom to fix nested CSS selectors parser bug.

Found after dependabot tried bumping jsdom to `24.1.0`, which in turn bumped rrweb-cssom to `0.7.0`, which introduced a [bug](https://github.com/rrweb-io/CSSOM/pull/4). It was fixed in jsdom [`0.7.1`](https://github.com/rrweb-io/CSSOM/releases/tag/v0.7.1).

The message in our logs is:

```
SyntaxError: '>textarea[readonly]' is not a valid selector
 ❯ emit node_modules/nwsapi/src/nwsapi.js:576:17
 ❯ _querySelectorAll node_modules/nwsapi/src/nwsapi.js:1528:9
 ❯ Object._querySelector [as first] node_modules/nwsapi/src/nwsapi.js:1437:14
 ❯ HTMLDivElementImpl.querySelector node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:69:44
 ❯ HTMLDivElement.querySelector node_modules/jsdom/lib/jsdom/living/generated/Element.js:1094:58
 ❯ Array.Resolver node_modules/nwsapi/src/nwsapi.js:781:17
 ❯ match_assert node_modules/nwsapi/src/nwsapi.js:1364:13
 ❯ Object._matches [as match] node_modules/nwsapi/src/nwsapi.js:1382:16
 ❯ exports.matchesDontThrow node_modules/jsdom/lib/jsdom/living/helpers/selectors.js:29:36
 ❯ matches node_modules/jsdom/lib/jsdom/living/helpers/style-rules.js:172:10

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { code: 12, INDEX_SIZE_ERR: 1, DOMSTRING_SIZE_ERR: 2, HIERARCHY_REQUEST_ERR: 3, WRONG_DOCUMENT_ERR: 4, INVALID_CHARACTER_ERR: 5, NO_DATA_ALLOWED_ERR: 6, NO_MODIFICATION_ALLOWED_ERR: 7, NOT_FOUND_ERR: 8, NOT_SUPPORTED_ERR: 9, INUSE_ATTRIBUTE_ERR: 10, INVALID_STATE_ERR: 11, SYNTAX_ERR: 12, INVALID_MODIFICATION_ERR: 13, NAMESPACE_ERR: 14, INVALID_ACCESS_ERR: 15, VALIDATION_ERR: 16, TYPE_MISMATCH_ERR: 17, SECURITY_ERR: 18, NETWORK_ERR: 19, ABORT_ERR: 20, URL_MISMATCH_ERR: 21, QUOTA_EXCEEDED_ERR: 22, TIMEOUT_ERR: 23, INVALID_NODE_TYPE_ERR: 24, DATA_CLONE_ERR: 25 }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/12]⎯
```