### PR TITLE
Update ws to 8.17.1 to mitigate CVE-2024-37890

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
         "whatwg-url": "^14.0.0",
-        "ws": "^8.17.0",
+        "ws": "^8.17.1",
         "xml-name-validator": "^5.0.0"
       },
       "devDependencies": {
@@ -2278,9 +2278,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2392,6 +2392,7 @@
       }
     },
     "scripts/eslint-plugin": {
+      "name": "eslint-plugin-jsdom-internal",
       "version": "0.0.0",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "whatwg-encoding": "^3.1.1",
     "whatwg-mimetype": "^4.0.0",
     "whatwg-url": "^14.0.0",
-    "ws": "^8.17.0",
+    "ws": "^8.17.1",
     "xml-name-validator": "^5.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This pull request for ws dependency package that mitigates [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)