### PR TITLE
Add AbortSignal.any() static method

### DIFF
--- a/lib/jsdom/living/aborting/AbortSignal-impl.js
+++ b/lib/jsdom/living/aborting/AbortSignal-impl.js
@@ -37,6 +37,35 @@ class AbortSignalImpl extends EventTargetImpl {
     return abortSignal;
   }
 
+  static any(globalObject, signals) {
+    for (const signal of signals) {
+      if (signal.aborted) {
+        return AbortSignalImpl.abort(globalObject, signal.reason);
+      }
+    }
+
+    const anySignal = AbortSignal.createImpl(globalObject, []);
+    const handlers = new Map();
+
+    function stopListening() {
+      for (const signal of signals) {
+        signal.removeEventListener("abort", handlers.get(signal));
+      }
+    }
+
+    for (const signal of signals) {
+      function handler() {
+        stopListening();
+        anySignal._signalAbort(signal.reason);
+      }
+
+      handlers.set(signal, handler);
+      signal.addEventListener("abort", handler);
+    }
+
+    return anySignal;
+  }
+
   static timeout(globalObject, milliseconds) {
     const signal = AbortSignal.createImpl(globalObject, []);
     globalObject.setTimeout(() => {

--- a/lib/jsdom/living/aborting/AbortSignal.webidl
+++ b/lib/jsdom/living/aborting/AbortSignal.webidl
@@ -2,6 +2,7 @@
 interface AbortSignal : EventTarget {
   [WebIDL2JSCallWithGlobal, NewObject] static AbortSignal abort(optional any reason);
   [WebIDL2JSCallWithGlobal, NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+  [WebIDL2JSCallWithGlobal, NewObject] static AbortSignal _any(sequence<AbortSignal> signals);
 
   readonly attribute boolean aborted;
   readonly attribute any reason;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -395,7 +395,9 @@ throw-on-dynamic-markup-insertion-counter-reactions.html: [timeout, document.ope
 
 DIR: dom/abort
 
-abort-signal-any.any.html: [fail, Not implemented]
+
+abort-signal-any.any.html:
+  "Abort events for AbortSignal.any() signals fire in the right order (using AbortController)": [fail, Dependent abort signals not implemented]
 
 ---
 


### PR DESCRIPTION
This PR adds the [`AbortSignal.any()` static method](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static).

All but one WPT test is passing:

```
  web-platform-tests
    dom/abort
      ✔ AbortSignal.any.html
      ✔ [expected 1 failure] abort-signal-any.any.html
      ✔ abort-signal-timeout.html
      ✔ event.any.html
      ✔ reason-constructor.html
```

The one test that I couldn't pass has to do with event firing order with "dependant" abort signals. See steps 5 and 6 in ["signal abort"](https://dom.spec.whatwg.org/#abortsignal-signal-abort).

As far as I understand, passing this final test would require you to somehow be able to:

- Ensure that the "source" signal's `abort` event handlers have finished firing before dispatching the `abort` event of the "dependent" abort signal, AND
- Do so without resorting to dispatching the dependent signal's `abort` event asynchronously.

I don't know if that's even possible without a larger rewrite of abort signals.