### PR TITLE
Refactor Window object setup code

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -91,60 +91,73 @@ const events = new Set([
   // "error" and "beforeunload" are added separately
 ]);
 
-exports.createWindow = function (options) {
-  return new Window(options);
-};
-
 const jsGlobalEntriesToInstall = Object.entries(jsGlobals).filter(([name]) => name in global);
 
-// https://html.spec.whatwg.org/#the-window-object
-function setupWindow(windowInstance, { runScripts }) {
-  if (runScripts === "outside-only" || runScripts === "dangerously") {
-    contextifyWindow(windowInstance);
+exports.createWindow = options => {
+  const makeVMContext = options.runScripts === "outside-only" || options.runScripts === "dangerously";
+
+  // Bootstrap with an empty object from the Node.js realm. We'll muck with its prototype chain shortly.
+  const window = {};
+
+  // Make window into a global object: either via vm, or just aliasing the Node.js globals.
+  // Also set _globalObject and _globalProxy.
+  //
+  // TODO: don't expose _globalObject and _globalProxy as public properties. While you're there, audit usage sites to
+  // see how necessary they really are.
+  if (makeVMContext) {
+    vm.createContext(window);
+
+    window._globalObject = window;
+    window._globalProxy = vm.runInContext("this", window);
 
     // Without this, these globals will only appear to scripts running inside the context using vm.runScript; they will
     // not appear to scripts running from the outside, including to JSDOM implementation code.
     for (const [globalName, globalPropDesc] of jsGlobalEntriesToInstall) {
-      const propDesc = { ...globalPropDesc, value: vm.runInContext(globalName, windowInstance) };
-      Object.defineProperty(windowInstance, globalName, propDesc);
+      const propDesc = { ...globalPropDesc, value: vm.runInContext(globalName, window) };
+      Object.defineProperty(window, globalName, propDesc);
     }
   } else {
+    window._globalObject = window._globalProxy = window;
+
     // Without contextifying the window, none of the globals will exist. So, let's at least alias them from the Node.js
     // context. See https://github.com/jsdom/jsdom/issues/2727 for more background and discussion.
     for (const [globalName, globalPropDesc] of jsGlobalEntriesToInstall) {
       const propDesc = { ...globalPropDesc, value: global[globalName] };
-      Object.defineProperty(windowInstance, globalName, propDesc);
+      Object.defineProperty(window, globalName, propDesc);
     }
   }
 
-  installInterfaces(windowInstance, ["Window"]);
+  // Create instances of all the web platform interfaces and install them on the window.
+  installInterfaces(window, ["Window"]);
 
-  const EventTargetConstructor = windowInstance.EventTarget;
+  // Now we have an EventTarget contructor so we can work on the prototype chain.
 
-  // eslint-disable-next-line func-name-matching, func-style, no-shadow
-  const windowConstructor = function Window() {
+  // eslint-disable-next-line func-name-matching, func-style
+  const WindowConstructor = function Window() {
     throw new TypeError("Illegal constructor");
   };
-  Object.setPrototypeOf(windowConstructor, EventTargetConstructor);
+  Object.setPrototypeOf(WindowConstructor, window.EventTarget);
 
-  Object.defineProperty(windowInstance, "Window", {
+  Object.defineProperty(window, "Window", {
     configurable: true,
     writable: true,
-    value: windowConstructor
+    value: WindowConstructor
   });
 
-  const windowProperties = Object.create(EventTargetConstructor.prototype);
-  Object.defineProperties(windowProperties, {
+  // TODO: do an actual WindowProperties object. See https://github.com/jsdom/jsdom/pull/3765 for an attempt.
+  const windowPropertiesObject = Object.create(window.EventTarget.prototype);
+  Object.defineProperties(windowPropertiesObject, {
     [Symbol.toStringTag]: {
       value: "WindowProperties",
       configurable: true
     }
   });
+  namedPropertiesWindow.initializeWindow(window, window._globalProxy);
 
-  const windowPrototype = Object.create(windowProperties);
+  const windowPrototype = Object.create(windowPropertiesObject);
   Object.defineProperties(windowPrototype, {
     constructor: {
-      value: windowConstructor,
+      value: WindowConstructor,
       writable: true,
       configurable: true
     },
@@ -154,113 +167,123 @@ function setupWindow(windowInstance, { runScripts }) {
     }
   });
 
-  windowConstructor.prototype = windowPrototype;
-  Object.setPrototypeOf(windowInstance, windowPrototype);
-  if (runScripts === "outside-only" || runScripts === "dangerously") {
-    const global = vm.runInContext("this", windowInstance);
-    Object.setPrototypeOf(global, windowPrototype);
+  WindowConstructor.prototype = windowPrototype;
+  Object.setPrototypeOf(window, windowPrototype);
+  if (makeVMContext) {
+    Object.setPrototypeOf(window._globalProxy, windowPrototype);
+
+    // TODO next major version: include this.
+    // Object.setPrototypeOf(window.EventTarget.prototype, window.Object.prototype);
   }
 
-  EventTarget.setup(windowInstance, windowInstance);
-  mixin(windowInstance, WindowEventHandlersImpl.prototype);
-  mixin(windowInstance, GlobalEventHandlersImpl.prototype);
-  windowInstance._initGlobalEvents();
+  // Now that the prototype chain is fully set up, call the superclass setup.
+  EventTarget.setup(window, window);
 
-  Object.defineProperty(windowInstance, "onbeforeunload", {
-    configurable: true,
-    enumerable: true,
-    get() {
-      return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(this, "beforeunload"));
-    },
-    set(V) {
-      if (!idlUtils.isObject(V)) {
-        V = null;
-      } else {
-        V = OnBeforeUnloadEventHandlerNonNull.convert(windowInstance, V, {
-          context: "Failed to set the 'onbeforeunload' property on 'Window': The provided value"
-        });
-      }
-      this._setEventHandlerFor("beforeunload", V);
+  installEventHandlers(window);
+
+  installOwnProperties(window, options);
+
+  // Not sure why this is necessary... TODO figure it out.
+  Object.defineProperty(idlUtils.implForWrapper(window), idlUtils.wrapperSymbol, { get: () => window._globalProxy });
+
+  // Fire or prepare to fire load and pageshow events.
+  process.nextTick(() => {
+    if (!window.document) {
+      return; // window might've been closed already
+    }
+
+    if (window.document.readyState === "complete") {
+      fireAnEvent("load", window, undefined, {}, true);
+    } else {
+      window.document.addEventListener("load", () => {
+        fireAnEvent("load", window, undefined, {}, true);
+        if (!window._document) {
+          return; // window might've been closed already
+        }
+
+        const documentImpl = idlUtils.implForWrapper(window._document);
+        if (!documentImpl._pageShowingFlag) {
+          documentImpl._pageShowingFlag = true;
+          fireAPageTransitionEvent("pageshow", window, false);
+        }
+      });
     }
   });
 
-  Object.defineProperty(windowInstance, "onerror", {
+  return window;
+};
+
+function installEventHandlers(window) {
+  mixin(window, WindowEventHandlersImpl.prototype);
+  mixin(window, GlobalEventHandlersImpl.prototype);
+  window._initGlobalEvents();
+
+  Object.defineProperty(window, "onbeforeunload", {
     configurable: true,
     enumerable: true,
     get() {
-      return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(this, "error"));
+      return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(window, "beforeunload"));
     },
     set(V) {
       if (!idlUtils.isObject(V)) {
         V = null;
       } else {
-        V = OnErrorEventHandlerNonNull.convert(windowInstance, V, {
+        V = OnBeforeUnloadEventHandlerNonNull.convert(window, V, {
+          context: "Failed to set the 'onbeforeunload' property on 'Window': The provided value"
+        });
+      }
+      window._setEventHandlerFor("beforeunload", V);
+    }
+  });
+
+  Object.defineProperty(window, "onerror", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(window, "error"));
+    },
+    set(V) {
+      if (!idlUtils.isObject(V)) {
+        V = null;
+      } else {
+        V = OnErrorEventHandlerNonNull.convert(window, V, {
           context: "Failed to set the 'onerror' property on 'Window': The provided value"
         });
       }
-      this._setEventHandlerFor("error", V);
+      window._setEventHandlerFor("error", V);
     }
   });
 
   for (const event of events) {
-    Object.defineProperty(windowInstance, `on${event}`, {
+    Object.defineProperty(window, `on${event}`, {
       configurable: true,
       enumerable: true,
       get() {
-        return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(this, event));
+        return idlUtils.tryWrapperForImpl(getCurrentEventHandlerValue(window, event));
       },
       set(V) {
         if (!idlUtils.isObject(V)) {
           V = null;
         } else {
-          V = EventHandlerNonNull.convert(windowInstance, V, {
+          V = EventHandlerNonNull.convert(window, V, {
             context: `Failed to set the 'on${event}' property on 'Window': The provided value`
           });
         }
-        this._setEventHandlerFor(event, V);
+        window._setEventHandlerFor(event, V);
       }
     });
   }
-
-  windowInstance._globalObject = windowInstance;
 }
 
-function makeReplaceablePropertyDescriptor(property, window) {
-  const desc = {
-    set(value) {
-      Object.defineProperty(window, property, {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value
-      });
-    }
-  };
-
-  Object.defineProperty(desc.set, "name", { value: `set ${property}` });
-  return desc;
-}
-
-// NOTE: per https://heycam.github.io/webidl/#Global, all properties on the Window object must be own-properties.
-// That is why we assign everything inside of the constructor, instead of using a shared prototype.
-// You can verify this in e.g. Firefox or Internet Explorer, which do a good job with Web IDL compliance.
-function Window(options) {
-  setupWindow(this, { runScripts: options.runScripts });
-
+function installOwnProperties(window, options) {
   const windowInitialized = performance.now();
-
-  const window = this;
 
   // ### PRIVATE DATA PROPERTIES
 
-  this._resourceLoader = options.resourceLoader;
-
-  // vm initialization is deferred until script processing is activated
-  this._globalProxy = this;
-  Object.defineProperty(idlUtils.implForWrapper(this), idlUtils.wrapperSymbol, { get: () => this._globalProxy });
+  window._resourceLoader = options.resourceLoader;
 
   // List options explicitly to be clear which are passed through
-  this._document = documents.createWrapper(window, {
+  window._document = documents.createWrapper(window, {
     parsingMode: options.parsingMode,
     contentType: options.contentType,
     encoding: options.encoding,
@@ -269,87 +292,82 @@ function Window(options) {
     lastModified: options.lastModified,
     referrer: options.referrer,
     parseOptions: options.parseOptions,
-    defaultView: this._globalProxy,
-    global: this,
+    defaultView: window._globalProxy,
+    global: window,
     parentOrigin: options.parentOrigin
   }, { alwaysUseDocumentClass: true });
 
-  if (vm.isContext(window)) {
-    const documentImpl = idlUtils.implForWrapper(window._document);
-    documentImpl._defaultView = window._globalProxy = vm.runInContext("this", window);
-  }
-
-  const documentOrigin = idlUtils.implForWrapper(this._document)._origin;
-  this._origin = documentOrigin;
+  const documentOrigin = idlUtils.implForWrapper(window._document)._origin;
+  window._origin = documentOrigin;
 
   // https://html.spec.whatwg.org/#session-history
-  this._sessionHistory = new SessionHistory({
-    document: idlUtils.implForWrapper(this._document),
-    url: idlUtils.implForWrapper(this._document)._URL,
+  window._sessionHistory = new SessionHistory({
+    document: idlUtils.implForWrapper(window._document),
+    url: idlUtils.implForWrapper(window._document)._URL,
     stateObject: null
-  }, this);
+  }, window);
 
-  this._virtualConsole = options.virtualConsole;
+  window._virtualConsole = options.virtualConsole;
 
-  this._runScripts = options.runScripts;
+  window._runScripts = options.runScripts;
 
   // Set up the window as if it's a top level window.
   // If it's not, then references will be corrected by frame/iframe code.
-  this._parent = this._top = this._globalProxy;
-  this._frameElement = null;
+  window._parent = window._top = window._globalProxy;
+  window._frameElement = null;
 
   // This implements window.frames.length, since window.frames returns a
   // self reference to the window object.  This value is incremented in the
   // HTMLFrameElement implementation.
-  this._length = 0;
+  window._length = 0;
 
   // https://dom.spec.whatwg.org/#window-current-event
-  this._currentEvent = undefined;
+  window._currentEvent = undefined;
 
-  this._pretendToBeVisual = options.pretendToBeVisual;
-  this._storageQuota = options.storageQuota;
+  window._pretendToBeVisual = options.pretendToBeVisual;
+  window._storageQuota = options.storageQuota;
 
   // Some properties (such as localStorage and sessionStorage) share data
   // between windows in the same origin. This object is intended
   // to contain such data.
   if (options.commonForOrigin && options.commonForOrigin[documentOrigin]) {
-    this._commonForOrigin = options.commonForOrigin;
+    window._commonForOrigin = options.commonForOrigin;
   } else {
-    this._commonForOrigin = {
+    window._commonForOrigin = {
       [documentOrigin]: {
         localStorageArea: new Map(),
         sessionStorageArea: new Map(),
-        windowsInSameOrigin: [this]
+        windowsInSameOrigin: [window]
       }
     };
   }
 
-  this._currentOriginData = this._commonForOrigin[documentOrigin];
+  window._currentOriginData = window._commonForOrigin[documentOrigin];
 
   // ### WEB STORAGE
 
-  this._localStorage = Storage.create(window, [], {
-    associatedWindow: this,
-    storageArea: this._currentOriginData.localStorageArea,
+  window._localStorage = Storage.create(window, [], {
+    associatedWindow: window,
+    storageArea: window._currentOriginData.localStorageArea,
     type: "localStorage",
-    url: this._document.documentURI,
-    storageQuota: this._storageQuota
+    url: window._document.documentURI,
+    storageQuota: window._storageQuota
   });
-  this._sessionStorage = Storage.create(window, [], {
-    associatedWindow: this,
-    storageArea: this._currentOriginData.sessionStorageArea,
+  window._sessionStorage = Storage.create(window, [], {
+    associatedWindow: window,
+    storageArea: window._currentOriginData.sessionStorageArea,
     type: "sessionStorage",
-    url: this._document.documentURI,
-    storageQuota: this._storageQuota
+    url: window._document.documentURI,
+    storageQuota: window._storageQuota
   });
 
   // ### SELECTION
 
   // https://w3c.github.io/selection-api/#dfn-selection
-  this._selection = Selection.createImpl(window);
+  window._selection = Selection.createImpl(window);
 
   // https://w3c.github.io/selection-api/#dom-window
-  this.getSelection = function () {
+  window.getSelection = function () {
     return window._selection;
   };
 
@@ -362,16 +380,16 @@ function Window(options) {
   const statusbar = BarProp.create(window);
   const toolbar = BarProp.create(window);
   const external = External.create(window);
-  const navigator = Navigator.create(window, [], { userAgent: this._resourceLoader._userAgent });
+  const navigator = Navigator.create(window, [], { userAgent: window._resourceLoader._userAgent });
   const performanceImpl = Performance.create(window, [], {
     timeOrigin: performance.timeOrigin + windowInitialized,
     nowAtTimeOrigin: windowInitialized
   });
   const screen = Screen.create(window);
   const crypto = Crypto.create(window);
-  this._customElementRegistry = CustomElementRegistry.create(window);
+  window._customElementRegistry = CustomElementRegistry.create(window);
 
-  define(this, {
+  define(window, {
     get length() {
       return window._length;
     },
@@ -443,34 +461,34 @@ function Window(options) {
       return window._origin;
     },
     get localStorage() {
-      if (idlUtils.implForWrapper(this._document)._origin === "null") {
+      if (idlUtils.implForWrapper(window._document)._origin === "null") {
         throw DOMException.create(window, [
           "localStorage is not available for opaque origins",
           "SecurityError"
         ]);
       }
 
-      return this._localStorage;
+      return window._localStorage;
     },
     get sessionStorage() {
-      if (idlUtils.implForWrapper(this._document)._origin === "null") {
+      if (idlUtils.implForWrapper(window._document)._origin === "null") {
         throw DOMException.create(window, [
           "sessionStorage is not available for opaque origins",
           "SecurityError"
         ]);
       }
 
-      return this._sessionStorage;
+      return window._sessionStorage;
     },
     get customElements() {
-      return this._customElementRegistry;
+      return window._customElementRegistry;
     },
     get event() {
       return window._currentEvent ? idlUtils.wrapperForImpl(window._currentEvent) : undefined;
     }
   });
 
-  Object.defineProperties(this, {
+  Object.defineProperties(window, {
     // [Replaceable]:
     self: makeReplaceablePropertyDescriptor("self", window),
     locationbar: makeReplaceablePropertyDescriptor("locationbar", window),
@@ -495,8 +513,6 @@ function Window(options) {
   });
 
 
-  namedPropertiesWindow.initializeWindow(this, this._globalProxy);
-
   // ### METHODS
 
   // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
@@ -506,7 +522,7 @@ function Window(options) {
   const listOfActiveTimers = new Map();
   let latestTimerId = 0;
 
-  this.setTimeout = function (handler, timeout = 0, ...args) {
+  window.setTimeout = function (handler, timeout = 0, ...args) {
     if (typeof handler !== "function") {
       handler = webIDLConversions.DOMString(handler);
     }
@@ -514,7 +530,7 @@ function Window(options) {
 
     return timerInitializationSteps(handler, timeout, args, { methodContext: window, repeat: false });
   };
-  this.setInterval = function (handler, timeout = 0, ...args) {
+  window.setInterval = function (handler, timeout = 0, ...args) {
     if (typeof handler !== "function") {
       handler = webIDLConversions.DOMString(handler);
     }
@@ -523,7 +539,7 @@ function Window(options) {
     return timerInitializationSteps(handler, timeout, args, { methodContext: window, repeat: true });
   };
 
-  this.clearTimeout = function (handle = 0) {
+  window.clearTimeout = function (handle = 0) {
     handle = webIDLConversions.long(handle);
 
     const nodejsTimer = listOfActiveTimers.get(handle);
@@ -532,12 +548,12 @@ function Window(options) {
       listOfActiveTimers.delete(handle);
     }
   };
-  this.clearInterval = function (handle = 0) {
+  window.clearInterval = function (handle = 0) {
     handle = webIDLConversions.long(handle);
 
     const nodejsTimer = listOfActiveTimers.get(handle);
     if (nodejsTimer) {
-      // We use setTimeout() in timerInitializationSteps even for this.setInterval().
+      // We use setTimeout() in timerInitializationSteps even for window.setInterval().
       clearTimeout(nodejsTimer);
       listOfActiveTimers.delete(handle);
     }
@@ -590,8 +606,8 @@ function Window(options) {
 
   // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#microtask-queuing
 
-  this.queueMicrotask = function (callback) {
-    callback = IDLFunction.convert(this, callback);
+  window.queueMicrotask = function (callback) {
+    callback = IDLFunction.convert(window, callback);
 
     queueMicrotask(() => {
       try {
@@ -612,9 +628,9 @@ function Window(options) {
   // requestAnimationFrame() calls outstanding, we don't fire the timer. This helps us track that.
   let numberOfOngoingAnimationFrameCallbacks = 0;
 
-  if (this._pretendToBeVisual) {
-    this.requestAnimationFrame = function (callback) {
-      callback = IDLFunction.convert(this, callback);
+  if (window._pretendToBeVisual) {
+    window.requestAnimationFrame = function (callback) {
+      callback = IDLFunction.convert(window, callback);
 
       const handle = ++animationFrameCallbackId;
       mapOfAnimationFrameCallbacks.set(handle, callback);
@@ -629,7 +645,7 @@ function Window(options) {
       return handle;
     };
 
-    this.cancelAnimationFrame = function (handle) {
+    window.cancelAnimationFrame = function (handle) {
       handle = webIDLConversions["unsigned long"](handle);
 
       removeAnimationFrameCallback(handle);
@@ -703,7 +719,7 @@ function Window(options) {
     return option;
   }
   Object.defineProperty(Option, "prototype", {
-    value: this.HTMLOptionElement.prototype,
+    value: window.HTMLOptionElement.prototype,
     configurable: false,
     enumerable: false,
     writable: false
@@ -729,7 +745,7 @@ function Window(options) {
     return img;
   }
   Object.defineProperty(Image, "prototype", {
-    value: this.HTMLImageElement.prototype,
+    value: window.HTMLImageElement.prototype,
     configurable: false,
     enumerable: false,
     writable: false
@@ -753,7 +769,7 @@ function Window(options) {
     return audio;
   }
   Object.defineProperty(Audio, "prototype", {
-    value: this.HTMLAudioElement.prototype,
+    value: window.HTMLAudioElement.prototype,
     configurable: false,
     enumerable: false,
     writable: false
@@ -765,9 +781,9 @@ function Window(options) {
     writable: true
   });
 
-  this.postMessage = postMessage(window);
+  window.postMessage = postMessage(window);
 
-  this.atob = function (str) {
+  window.atob = function (str) {
     try {
       return atob(str);
     } catch {
@@ -779,7 +795,7 @@ function Window(options) {
     }
   };
 
-  this.btoa = function (str) {
+  window.btoa = function (str) {
     try {
       return btoa(str);
     } catch {
@@ -791,46 +807,46 @@ function Window(options) {
     }
   };
 
-  this.stop = function () {
-    const manager = idlUtils.implForWrapper(this._document)._requestManager;
+  window.stop = function () {
+    const manager = idlUtils.implForWrapper(window._document)._requestManager;
     if (manager) {
       manager.close();
     }
   };
 
-  this.close = function () {
+  window.close = function () {
     // Recursively close child frame windows, then ourselves (depth-first).
-    for (let i = 0; i < this.length; ++i) {
-      this[i].close();
+    for (let i = 0; i < window.length; ++i) {
+      window[i].close();
     }
 
     // Clear out all listeners. Any in-flight or upcoming events should not get delivered.
-    idlUtils.implForWrapper(this)._eventListeners = Object.create(null);
+    idlUtils.implForWrapper(window)._eventListeners = Object.create(null);
 
-    if (this._document) {
-      if (this._document.body) {
-        this._document.body.innerHTML = "";
+    if (window._document) {
+      if (window._document.body) {
+        window._document.body.innerHTML = "";
       }
 
-      if (this._document.close) {
+      if (window._document.close) {
         // It's especially important to clear out the listeners here because document.close() causes a "load" event to
         // fire.
-        idlUtils.implForWrapper(this._document)._eventListeners = Object.create(null);
-        this._document.close();
+        idlUtils.implForWrapper(window._document)._eventListeners = Object.create(null);
+        window._document.close();
       }
-      const doc = idlUtils.implForWrapper(this._document);
+      const doc = idlUtils.implForWrapper(window._document);
       if (doc._requestManager) {
         doc._requestManager.close();
       }
-      delete this._document;
+      delete window._document;
     }
 
     stopAllTimers();
-    WebSocketImpl.cleanUpWindow(this);
+    WebSocketImpl.cleanUpWindow(window);
   };
 
-  this.getComputedStyle = function (elt, pseudoElt = undefined) {
-    elt = Element.convert(this, elt);
+  window.getComputedStyle = function (elt, pseudoElt = undefined) {
+    elt = Element.convert(window, elt);
     if (pseudoElt !== undefined && pseudoElt !== null) {
       pseudoElt = webIDLConversions.DOMString(pseudoElt);
     }
@@ -842,7 +858,7 @@ function Window(options) {
         throw new TypeError("Tried to get the computed style of a Shadow DOM pseudo-element.");
       }
 
-      notImplemented("window.getComputedStyle(elt, pseudoElt)", this);
+      notImplemented("window.getComputedStyle(elt, pseudoElt)", window);
     }
 
     const declaration = new CSSStyleDeclaration();
@@ -866,14 +882,14 @@ function Window(options) {
     return declaration;
   };
 
-  this.getSelection = function () {
+  window.getSelection = function () {
     return window._document.getSelection();
   };
 
   // The captureEvents() and releaseEvents() methods must do nothing
-  this.captureEvents = function () {};
+  window.captureEvents = function () {};
 
-  this.releaseEvents = function () {};
+  window.releaseEvents = function () {};
 
   // ### PUBLIC DATA PROPERTIES (TODO: should be getters)
 
@@ -883,7 +899,7 @@ function Window(options) {
     };
   }
 
-  this.console = {
+  window.console = {
     assert: wrapConsoleMethod("assert"),
     clear: wrapConsoleMethod("clear"),
     count: wrapConsoleMethod("count"),
@@ -911,7 +927,7 @@ function Window(options) {
     };
   }
 
-  define(this, {
+  define(window, {
     name: "",
     status: "",
     devicePixelRatio: 1,
@@ -943,37 +959,20 @@ function Window(options) {
     scrollBy: notImplementedMethod("window.scrollBy"),
     scrollTo: notImplementedMethod("window.scrollTo")
   });
-
-  // ### INITIALIZATION
-
-  process.nextTick(() => {
-    if (!window.document) {
-      return; // window might've been closed already
-    }
-
-    if (window.document.readyState === "complete") {
-      fireAnEvent("load", window, undefined, {}, true);
-    } else {
-      window.document.addEventListener("load", () => {
-        fireAnEvent("load", window, undefined, {}, true);
-        if (!window._document) {
-          return; // window might've been closed already
-        }
-
-        const documentImpl = idlUtils.implForWrapper(window._document);
-        if (!documentImpl._pageShowingFlag) {
-          documentImpl._pageShowingFlag = true;
-          fireAPageTransitionEvent("pageshow", window, false);
-        }
-      });
-    }
-  });
 }
 
-function contextifyWindow(window) {
-  if (vm.isContext(window)) {
-    return;
-  }
+function makeReplaceablePropertyDescriptor(property, window) {
+  const desc = {
+    set(value) {
+      Object.defineProperty(window, property, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value
+      });
+    }
+  };
 
-  vm.createContext(window);
+  Object.defineProperty(desc.set, "name", { value: `set ${property}` });
+  return desc;
 }

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -810,7 +810,6 @@ window-properties.https.html:
   "Window attribute: status": [fail, Incorrectly implemented as a data property]
   "Window method: createImageBitmap": [fail, Not implemented]
   "Window method: matchMedia": [fail, Not implemented]
-  "Window readonly attribute: applicationCache": [fail, Not implemented]
   "Window replaceable attribute: devicePixelRatio": [fail, Incorrectly implemented as a data property]
   "Window replaceable attribute: innerHeight": [fail, Incorrectly implemented as a data property]
   "Window replaceable attribute: innerWidth": [fail, Incorrectly implemented as a data property]


### PR DESCRIPTION
Restructure Window.js to be less convoluted, with a single createWindow function and no fake Window constructor that operates on a this object but then manually sets is prototype chain anyway.