### PR TITLE
Implement window.TextEncoder & window.TextDecoder

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -1,5 +1,6 @@
 "use strict";
 const vm = require("vm");
+const { TextEncoder, TextDecoder } = require("util");
 const webIDLConversions = require("webidl-conversions");
 const { CSSStyleDeclaration } = require("cssstyle");
 const whatwgURL = require("whatwg-url");
@@ -503,6 +504,18 @@ function installOwnProperties(window, options) {
     screen: makeReplaceablePropertyDescriptor("screen", window),
     origin: makeReplaceablePropertyDescriptor("origin", window),
     event: makeReplaceablePropertyDescriptor("event", window),
+    TextEncoder: {
+      value: TextEncoder,
+      configurable: true,
+      enumerable: false,
+      writable: true
+    },
+    TextDecoder: {
+      value: TextDecoder,
+      configurable: true,
+      enumerable: false,
+      writable: true
+    },
 
     // [LegacyUnforgeable]:
     window: { configurable: false },


### PR DESCRIPTION
Attempt to fix https://github.com/jsdom/jsdom/issues/2524
This just forwards `TextEncoder` & `TextDecoder` from `node:util` to the top level variables defined on the window

This is my 1st contribution to JSDOM so Idk if I'm missing something.
I'm also not sure if I have to add a test (because it seems that we already have a lot of tests with those in WPT and in `to-run.yaml`) and if so, where