### PR TITLE
Allow canvas 3.0.0-rc2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2 || 3.0.0-rc2"
+        "canvas": "^2.11.2 || 3.0.0-rc2 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^2.11.2 || 3.0.0-rc2"
       },
       "peerDependenciesMeta": {
         "canvas": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "xml-name-validator": "^5.0.0"
   },
   "peerDependencies": {
-    "canvas": "^2.11.2"
+    "canvas": "^2.11.2 || 3.0.0-rc2"
   },
   "peerDependenciesMeta": {
     "canvas": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "xml-name-validator": "^5.0.0"
   },
   "peerDependencies": {
-    "canvas": "^2.11.2 || 3.0.0-rc2"
+    "canvas": "^2.11.2 || 3.0.0-rc2 || ^3.0.0"
   },
   "peerDependenciesMeta": {
     "canvas": {


### PR DESCRIPTION
I'm having install issues using the 3.0.0 rc release with JSDOM because of the strict peer dependencies. As can be seen it's the only release that's been cut in more than a year.

[Canvas Releases](https://github.com/Automattic/node-canvas/releases)

The breaking change in v3.x is the sunset of Node 16, rather than something that makes jsdom incompatible.

