### PR TITLE
querySelectorAll Fix `TypeError: list.map is not a function`

### DIFF
--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -75,7 +75,7 @@ class ParentNodeImpl {
       return NodeList.create(this._globalObject, [], { nodes: [] });
     }
     const matcher = addNwsapi(this);
-    const list = matcher.select(selectors, idlUtils.wrapperForImpl(this)) ?? [];
+    const list = Array.from(matcher.select(selectors, idlUtils.wrapperForImpl(this)));
 
     return NodeList.create(this._globalObject, [], { nodes: list.map(n => idlUtils.tryImplForWrapper(n)) });
   }

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -75,7 +75,7 @@ class ParentNodeImpl {
       return NodeList.create(this._globalObject, [], { nodes: [] });
     }
     const matcher = addNwsapi(this);
-    const list = matcher.select(selectors, idlUtils.wrapperForImpl(this));
+    const list = matcher.select(selectors, idlUtils.wrapperForImpl(this)) ?? [];
 
     return NodeList.create(this._globalObject, [], { nodes: list.map(n => idlUtils.tryImplForWrapper(n)) });
   }


### PR DESCRIPTION
I am using Vitest, and this error shows up, even when no React/UI code is being rendered.
`TypeError: list.map is not a function`