### PR TITLE
Add support for static AbortSignal.any method

### DIFF
--- a/lib/jsdom/living/aborting/AbortSignal-impl.js
+++ b/lib/jsdom/living/aborting/AbortSignal-impl.js
@@ -15,6 +15,9 @@ class AbortSignalImpl extends EventTargetImpl {
 
     this.reason = undefined;
     this.abortAlgorithms = new Set();
+    this._dependent = false;
+    this._sourceSignals = new Set();
+    this._dependentSignals = new Set();
   }
 
   get aborted() {
@@ -37,6 +40,33 @@ class AbortSignalImpl extends EventTargetImpl {
     return abortSignal;
   }
 
+  // https://dom.spec.whatwg.org/#abortsignal-dependent
+  static any(globalObject, signals) {
+    const resultSignal = AbortSignal.createImpl(globalObject, []);
+    for (const signal of signals) {
+      if (signal.aborted) {
+        resultSignal.reason = signal.reason;
+        return resultSignal;
+      }
+    }
+
+    resultSignal.dependent = true;
+    for (const signal of signals) {
+      if (!signal.dependent) {
+        resultSignal._sourceSignals.add(signal);
+        signal._dependentSignals.add(resultSignal);
+      } else {
+        for (const sourceSignal of signal._sourceSignals) {
+          if (!sourceSignal.aborted && !sourceSignal.dependent) {
+            resultSignal._sourceSignals.add(sourceSignal);
+            sourceSignal._dependentSignals.add(resultSignal);
+          }
+        }
+      }
+    }
+    return resultSignal;
+  }
+
   static timeout(globalObject, milliseconds) {
     const signal = AbortSignal.createImpl(globalObject, []);
     globalObject.setTimeout(() => {
@@ -46,6 +76,7 @@ class AbortSignalImpl extends EventTargetImpl {
     return signal;
   }
 
+  // https://dom.spec.whatwg.org/#abortsignal-signal-abort
   _signalAbort(reason) {
     if (this.aborted) {
       return;
@@ -57,6 +88,22 @@ class AbortSignalImpl extends EventTargetImpl {
       this.reason = DOMException.create(this._globalObject, ["The operation was aborted.", "AbortError"]);
     }
 
+    const dependentSignalsToAbort = [];
+    for (const dependentSignal of this._dependentSignals) {
+      if (!dependentSignal.aborted) {
+        dependentSignal.reason = this.reason;
+        dependentSignalsToAbort.push(dependentSignal);
+      }
+    }
+
+    this._runAbortStep();
+
+    for (const dependentSignal of dependentSignalsToAbort) {
+      dependentSignal._runAbortStep();
+    }
+  }
+
+  _runAbortStep() {
     for (const algorithm of this.abortAlgorithms) {
       algorithm();
     }

--- a/lib/jsdom/living/aborting/AbortSignal.webidl
+++ b/lib/jsdom/living/aborting/AbortSignal.webidl
@@ -2,6 +2,7 @@
 interface AbortSignal : EventTarget {
   [WebIDL2JSCallWithGlobal, NewObject] static AbortSignal abort(optional any reason);
   [WebIDL2JSCallWithGlobal, NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+  [WebIDL2JSCallWithGlobal, NewObject] static AbortSignal _any(sequence<AbortSignal> signals);
 
   readonly attribute boolean aborted;
   readonly attribute any reason;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -430,8 +430,6 @@ upgrading/upgrade-custom-element-error-event.html: [fail, Unknown]
 
 DIR: dom/abort
 
-abort-signal-any.any.html: [fail, Not implemented]
-
 ---
 
 DIR: dom/collections


### PR DESCRIPTION
This PR adds the [AbortSignal.any() static method](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) as a line-by-line translation of [the spec](https://dom.spec.whatwg.org/#create-a-dependent-abort-signal).

Thanks to [ezzatron](https://github.com/ezzatron) and [this closed PR](https://github.com/jsdom/jsdom/pull/3738) for paving the way.

<img width="831" alt="Screenshot 2024-12-23 at 12 58 38" src="https://github.com/user-attachments/assets/fc9c3b5f-fddd-41a7-92e2-22388976225c" />
