### PR TITLE
Make querySelectorAll follow the always-impl rule

### DIFF
--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -201,7 +201,8 @@ function refreshAccessors(document) {
   }
 
   _defaultView._length = frames.length;
-  Array.prototype.forEach.call(frames, (frame, i) => {
+  for (let i = 0; i < frames.length; ++i) {
+    const frame = frames.item(i);
     Object.defineProperty(_defaultView, i, {
       configurable: true,
       enumerable: true,
@@ -209,7 +210,7 @@ function refreshAccessors(document) {
         return frame.contentWindow;
       }
     });
-  });
+  }
 }
 
 class HTMLFrameElementImpl extends HTMLElementImpl {

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -69,15 +69,17 @@ class ParentNodeImpl {
     return idlUtils.implForWrapper(matcher.first(selectors, idlUtils.wrapperForImpl(this)));
   }
 
-  // Warning for internal users: this returns a NodeList containing IDL wrappers instead of impls
+  // WARNING FOR INTERNAL USERS:
+  // This returns a NodeList impl, not a NodeList wrapper. NodeList impls are not iterable and do not have indexed
+  // properties. To iterate over them, use `for (let i = 0; i < nodeListImpl.length; ++i) { nodeListImpl.item(i) }`.
   querySelectorAll(selectors) {
     if (shouldAlwaysSelectNothing(this)) {
-      return NodeList.create(this._globalObject, [], { nodes: [] });
+      return NodeList.createImpl(this._globalObject, [], { nodes: [] });
     }
     const matcher = addNwsapi(this);
     const list = matcher.select(selectors, idlUtils.wrapperForImpl(this));
 
-    return NodeList.create(this._globalObject, [], { nodes: list.map(n => idlUtils.tryImplForWrapper(n)) });
+    return NodeList.createImpl(this._globalObject, [], { nodes: list.map(n => idlUtils.tryImplForWrapper(n)) });
   }
 }
 


### PR DESCRIPTION
This is an internal refactoring to improve consistency. In general, we prefer to only deal with impls inside the impl classes. ParentNode's querySelectorAll implementation was not following that rule, creating NodeList wrappers instead of impls.

FYI @hesxenon