### PR TITLE
Update README to say canvas 3.x, not 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ console.log(frag.firstChild.outerHTML); // logs "<p>Hello</p>"
 
 ### Canvas support
 
-jsdom includes support for using the [`canvas`](https://www.npmjs.com/package/canvas) package to extend any `<canvas>` elements with the canvas API. To make this work, you need to include `canvas` as a dependency in your project, as a peer of `jsdom`. If jsdom can find the `canvas` package, it will use it, but if it's not present, then `<canvas>` elements will behave like `<div>`s. Since jsdom v13, version 2.x of `canvas` is required; version 1.x is no longer supported.
+jsdom includes support for using the [`canvas`](https://www.npmjs.com/package/canvas) package to extend any `<canvas>` elements with the canvas API. To make this work, you need to include `canvas` as a dependency in your project, as a peer of `jsdom`. If jsdom can find version 3.x of the `canvas` package, it will use it, but if it's not present, then `<canvas>` elements will behave like `<div>`s.
 
 ### Encoding sniffing
 


### PR DESCRIPTION
As of this commit, jsdom's package.json refers to canvas 3.x. I've modified this part of the readme to mention 3.x. I also removed mention of 2.x and 1.x, but I don't know if that is a desirable change. I wouldn't know what to replace it with anyway.

If a different modification is preferred, consider this PR as a reminder to change the docs; feel free to rewrite my PR.