### PR TITLE
Fixed the global default encoding to UTF-8, which is currently the de…

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -297,7 +297,7 @@ function normalizeHTML(html, mimeType) {
 
   if (Buffer.isBuffer(html)) {
     encoding = sniffHTMLEncoding(html, {
-      defaultEncoding: mimeType.isXML() ? "UTF-8" : "windows-1252",
+      defaultEncoding: "UTF-8",
       transportLayerEncodingLabel: mimeType.parameters.get("charset")
     });
     html = whatwgEncoding.decode(html, encoding);


### PR DESCRIPTION
Using windows-1252 as the default value may result in different results from browsers when loading some Unicode special characters such as `\u202E`.