### PR TITLE
Explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "generate-js-globals": "node ./scripts/generate-js-globals.js"
   },
   "main": "./lib/api.js",
+  "type": "commonjs",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0) that became enabled by [default in Node 22.7.0](https://nodejs.org/api/packages.html#syntax-detection).
Declaring the type will cause Node to skip detection on startup, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.