### PR TITLE
add support for getClientRects in Range

### DIFF
--- a/lib/jsdom/living/range/Range-impl.js
+++ b/lib/jsdom/living/range/Range-impl.js
@@ -421,12 +421,12 @@ class RangeImpl extends AbstractRangeImpl {
 
     class FakeDOMRectList {
       constructor(rects) {
-        this._rects = rects;
+        rects.forEach((rect, i) => (this[i] = rect));
         Object.defineProperty(this, "length", { value: rects.length, writable: false });
       }
 
       item(index) {
-        return this._rects[index] || null;
+        return this[index] || null;
       }
 
       get [Symbol.toStringTag]() {
@@ -435,7 +435,6 @@ class RangeImpl extends AbstractRangeImpl {
     }
 
     const rect = new FakeDOMRect(0, 0, 10, 10);
-
     return new FakeDOMRectList([rect]);
   }
 

--- a/lib/jsdom/living/range/Range-impl.js
+++ b/lib/jsdom/living/range/Range-impl.js
@@ -407,6 +407,38 @@ class RangeImpl extends AbstractRangeImpl {
     return s;
   }
 
+  // https://drafts.csswg.org/cssom-view/#dom-range-getclientrects
+  getClientRects() {
+    class FakeDOMRect {
+      constructor(x, y, width, height) {
+        Object.assign(this, { x, y, width, height, top: y, right: x + width, bottom: y + height, left: x });
+      }
+
+      get [Symbol.toStringTag]() {
+        return "DOMRect";
+      }
+    }
+
+    class FakeDOMRectList {
+      constructor(rects) {
+        this._rects = rects;
+        Object.defineProperty(this, "length", { value: rects.length, writable: false });
+      }
+
+      item(index) {
+        return this._rects[index] || null;
+      }
+
+      get [Symbol.toStringTag]() {
+        return "DOMRectList";
+      }
+    }
+
+    const rect = new FakeDOMRect(0, 0, 10, 10);
+
+    return new FakeDOMRectList([rect]);
+  }
+
   // https://w3c.github.io/DOM-Parsing/#dom-range-createcontextualfragment
   createContextualFragment(fragment) {
     const { node } = this._start;

--- a/lib/jsdom/living/range/Range.webidl
+++ b/lib/jsdom/living/range/Range.webidl
@@ -35,6 +35,8 @@ interface Range : AbstractRange {
 
   boolean intersectsNode(Node node);
 
+  [NewObject] sequence<DOMRect> getClientRects();
+
   stringifier;
 };
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -263,7 +263,8 @@ xml-stylesheet-pi-in-doctype.xhtml: [fail, Unknown]
 DIR: css/cssom-view
 
 CaretPosition-001.html: [fail, Unknown]
-DOMRectList.html: [fail, Unknown]
+DOMRectList.html:
+  "Element getClientRects()": [fail, Unknown]
 Element-currentCSSZoom.html: [fail, Not implemented]
 GetBoundingRect.html: [fail, Not implemented]
 HTMLBody-ScrollArea_quirksmode.html: [fail, Unknown]


### PR DESCRIPTION
# Summary

Add support for `range.getClientRects` and reduce cases of "target.getClientRects is not a function" 

# Details

JSDOM does not currently handle getClientRects() for Ranges and this affects users trying to run tests in a variety of situations, including [Tiptap](https://tiptap.dev/), other extensions of ProseMirror and more

Fixes https://github.com/jsdom/jsdom/issues/3729

Conversations related to this issue:
- [Stackoverflow issue](https://stackoverflow.com/questions/68023284/react-testing-library-user-event-throws-error-typeerror-root-elementfrompoint/77219899#77219899)
- [Tiptap discussion](https://github.com/ueberdosis/tiptap/discussions/4008)