### PR TITLE
Implement our own multipart/form-data serialization

### DIFF
--- a/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
+++ b/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
@@ -24,6 +24,7 @@ const { setupForSimpleEventAccessors } = require("../helpers/create-event-access
 const { parseJSONFromBytes } = require("../helpers/json");
 const { fireAnEvent } = require("../helpers/events");
 const { copyToArrayBufferInNewRealm } = require("../helpers/binary-data");
+const { serializeEntryList, chunksToBuffer } = require("./multipart-form-data.js");
 
 const { READY_STATES } = xhrUtils;
 
@@ -31,6 +32,8 @@ const syncWorkerFile = require.resolve ? require.resolve("./xhr-sync-worker.js")
 
 const tokenRegexp = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const fieldValueRegexp = /^[ \t]*(?:[\x21-\x7E\x80-\xFF](?:[ \t][\x21-\x7E\x80-\xFF])?)*[ \t]*$/;
+
+const utf8Decoder = new TextDecoder();
 
 const forbiddenRequestHeaders = new Set([
   "accept-charset",
@@ -111,7 +114,6 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
       uri: "",
       timeout: 0,
       body: undefined,
-      formData: false,
       preflight: false,
       requestManager: _ownerDocument._requestManager,
       strictSSL: window._resourceLoader._strictSSL,
@@ -529,15 +531,14 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
         if (Document.isImpl(body)) {
           encoding = "UTF-8";
           mimeType = (body._parsingMode === "html" ? "text/html" : "application/xml") + ";charset=UTF-8";
-          flag.body = fragmentSerialization(body, { requireWellFormed: false });
+          flag.body = Buffer.from(fragmentSerialization(body, { requireWellFormed: false }));
         } else {
           if (typeof body === "string") {
             encoding = "UTF-8";
           }
-          const { buffer, formData, contentType } = extractBody(body);
+          const { buffer, contentType } = extractBody(body);
           mimeType = contentType;
-          flag.body = buffer || formData;
-          flag.formData = Boolean(formData);
+          flag.body = buffer;
         }
 
         const existingContentType = xhrUtils.getRequestHeader(flag.requestHeaders, "content-type");
@@ -968,9 +969,7 @@ function normalizeHeaderValue(value) {
 
 function extractBody(bodyInit) {
   // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
-  // except we represent the body as a Node.js Buffer instead,
-  // or a special case for FormData since we want request to handle that. Probably it would be
-  // cleaner (and allow a future without request) if we did the form encoding ourself.
+  // except we represent the body as a Node.js Buffer instead.
 
   if (Blob.isImpl(bodyInit)) {
     return {
@@ -988,28 +987,12 @@ function extractBody(bodyInit) {
       contentType: null
     };
   } else if (FormData.isImpl(bodyInit)) {
-    const formData = [];
-    for (const entry of bodyInit._entries) {
-      let val;
-      if (Blob.isImpl(entry.value)) {
-        const blob = entry.value;
-        val = {
-          name: entry.name,
-          value: blob._buffer,
-          options: {
-            filename: blob.name,
-            contentType: blob.type,
-            knownLength: blob.size
-          }
-        };
-      } else {
-        val = entry;
-      }
+    const { boundary, outputChunks } = serializeEntryList(bodyInit._entries);
 
-      formData.push(val);
-    }
-
-    return { formData };
+    return {
+      buffer: chunksToBuffer(outputChunks),
+      contentType: "multipart/form-data; boundary=" + utf8Decoder.decode(boundary)
+    };
   }
 
   // Must be a string

--- a/lib/jsdom/living/xhr/multipart-form-data.js
+++ b/lib/jsdom/living/xhr/multipart-form-data.js
@@ -1,0 +1,105 @@
+"use strict";
+const conversions = require("webidl-conversions");
+// https://fetch.spec.whatwg.org/#concept-bodyinit-extract (note: always UTF-8)
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart%2Fform-data-encoding-algorithm
+// https://andreubotella.github.io/multipart-form-data/
+
+const utf8Encoder = new TextEncoder();
+
+const contentDispositionPrefix = utf8Encoder.encode(`Content-Disposition: form-data; name="`);
+const filenamePrefix = utf8Encoder.encode(`; filename="`);
+const contentType = utf8Encoder.encode(`Content-Type: `);
+
+// https://andreubotella.github.io/multipart-form-data/#multipart-form-data-boundary
+function generateBoundary() {
+  let boundary = "--------------------------";
+  for (let i = 0; i < 24; ++i) {
+    boundary += Math.floor(Math.random() * 10).toString(16);
+  }
+  return utf8Encoder.encode(boundary);
+}
+
+// https://andreubotella.github.io/multipart-form-data/#escape-a-multipart-form-data-name
+function escapeName(name, isFilename = false) {
+  if (isFilename) {
+    name = conversions.USVString(name);
+  } else {
+    name = name.replace(/\r(?!\n)|(?<!\r)\n/g, "\r\n");
+  }
+
+  const encoded = utf8Encoder.encode(name);
+  const encodedWithSubs = [];
+  for (const originalByte of encoded) {
+    if (originalByte === 0x0A) {
+      encodedWithSubs.push(37, 48, 65); // `%0A`
+    } else if (originalByte === 0x0D) {
+      encodedWithSubs.push(37, 48, 68); // `%0D`
+    } else if (originalByte === 0x22) {
+      encodedWithSubs.push(37, 50, 50); // `%22`
+    } else {
+      encodedWithSubs.push(originalByte);
+    }
+  }
+
+  return new Uint8Array(encodedWithSubs);
+}
+
+// https://andreubotella.github.io/multipart-form-data/#multipart-form-data-chunk-serializer
+exports.serializeEntryList = entries => {
+  const boundary = generateBoundary();
+  const outputChunks = [];
+
+  for (const entry of entries) {
+    const chunkBytes = [
+      45, 45, // `--`
+      ...boundary,
+      0x0D, 0x0A
+    ];
+
+    chunkBytes.push(...contentDispositionPrefix, ...escapeName(entry.name), 0x22 /* `"` */);
+
+    let { value } = entry;
+    if (typeof value === "string") {
+      chunkBytes.push(0x0D, 0x0A, 0x0D, 0x0A);
+
+      value = value.replace(/\r(?!\n)|(?<!\r)\n/g, "\r\n");
+
+      chunkBytes.push(...utf8Encoder.encode(value));
+
+      chunkBytes.push(0x0D, 0x0A);
+
+      outputChunks.push(new Uint8Array(chunkBytes));
+    } else {
+      // value is a FileImpl object
+
+      chunkBytes.push(...filenamePrefix, ...escapeName(value.name, true), 0x22, 0x0D, 0x0A);
+
+      const type = value.type !== "" ? value.type : "application/octet-stream";
+      chunkBytes.push(...contentType, ...utf8Encoder.encode(type));
+
+      chunkBytes.push(0x0D, 0x0A, 0x0D, 0x0A);
+
+      outputChunks.push(
+        new Uint8Array(chunkBytes),
+        // The spec returns the File object here but for our purposes the bytes (as a `Buffer`) are more convenient.
+        value._buffer,
+        new Uint8Array([0x0D, 0x0A])
+      );
+    }
+  }
+
+  outputChunks.push(
+    new Uint8Array([45, 45]), // `--`
+    boundary,
+    new Uint8Array([45, 45]), // `--`
+    new Uint8Array([0x0D, 0x0A])
+  );
+
+  return { boundary, outputChunks };
+};
+
+// Inspired by https://andreubotella.github.io/multipart-form-data/#create-a-multipart-form-data-readable-stream
+// (But we don't stream in jsdom, at least for now.)
+exports.chunksToBuffer = chunks => {
+  return Buffer.concat(chunks);
+};

--- a/lib/jsdom/living/xhr/xhr-utils.js
+++ b/lib/jsdom/living/xhr/xhr-utils.js
@@ -9,7 +9,6 @@ const ProgressEvent = require("../generated/ProgressEvent");
 
 const agentFactory = require("../helpers/agent-factory");
 const Request = require("../helpers/http-request");
-const FormData = require("form-data");
 const { fireAnEvent } = require("../helpers/events");
 
 const headerListSeparatorRegexp = /,[ \t]*/;
@@ -287,40 +286,17 @@ function createClient(xhr) {
 
   function doRequest() {
     try {
-      let requestBody = body;
+      requestHeaders["Accept-Encoding"] = "gzip, deflate";
+
       let len = 0;
       if (hasBody) {
-        if (flag.formData) {
-          // TODO: implement https://html.spec.whatwg.org/#multipart-form-data
-          // directly instead of using an external library
-          requestBody = new FormData();
-          for (const entry of body) {
-            requestBody.append(entry.name, entry.value, entry.options);
-          }
-          len = requestBody.getLengthSync();
-          requestHeaders["Content-Type"] = `multipart/form-data; boundary=${requestBody.getBoundary()}`;
-        } else {
-          if (typeof body === "string") {
-            len = Buffer.byteLength(body);
-          } else {
-            len = body.length;
-          }
-          requestBody = Buffer.isBuffer(requestBody) ? requestBody : Buffer.from(requestBody);
-        }
+        len = body.byteLength;
         requestHeaders["Content-Length"] = len;
       }
-      requestHeaders["Accept-Encoding"] = "gzip, deflate";
+
       const requestClient = new Request(uri, options, { method: flag.method, headers: requestHeaders });
       if (hasBody) {
-        if (flag.formData) {
-          requestBody.on("error", err => {
-            requestClient.emit("error", err);
-            requestClient.abort();
-          });
-          requestClient.pipeRequest(requestBody);
-        } else {
-          requestClient.write(requestBody);
-        }
+        requestClient.write(body);
       }
       return requestClient;
     } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
         "decimal.js": "^10.5.0",
-        "form-data": "^4.0.1",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
@@ -611,12 +610,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -854,18 +847,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -956,15 +937,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -1387,20 +1359,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1818,27 +1776,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/minimatch": {
       "version": "9.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "cssstyle": "^4.2.1",
     "data-urls": "^5.0.0",
     "decimal.js": "^10.5.0",
-    "form-data": "^4.0.1",
     "html-encoding-sniffer": "^4.0.0",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",


### PR DESCRIPTION
This allows us to remove the form-data dependency, which was not very efficient, probably not very spec-compliant, and has recently been taken over by a maintainer that bloats it with dependencies.

Closes #3320.