### PR TITLE
Fix ElementInternals accessibility getters/setters

### DIFF
--- a/lib/jsdom/living/custom-elements/ElementInternals-impl.js
+++ b/lib/jsdom/living/custom-elements/ElementInternals-impl.js
@@ -35,15 +35,19 @@ class ElementInternalsImpl {
   }
 
   _reflectGetTheContentAttribute(reflectedContentAttributeName) {
-    return this._targetElement._internalContentAttributeMap.get(reflectedContentAttributeName) ?? null;
+    return this._targetElement._internalContentAttributeMap?.get(reflectedContentAttributeName) ?? null;
   }
 
   _reflectSetTheContentAttribute(reflectedContentAttributeName, value) {
+    if (!this._targetElement._internalContentAttributeMap) {
+      this._targetElement._internalContentAttributeMap = new Map();
+    }
+
     this._targetElement._internalContentAttributeMap.set(reflectedContentAttributeName, value);
   }
 
   _reflectDeleteTheContentAttribute(reflectedContentAttributeName) {
-    this._targetElement._internalContentAttributeMap.delete(reflectedContentAttributeName);
+    this._targetElement._internalContentAttributeMap?.delete(reflectedContentAttributeName);
   }
 }
 

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -2,6 +2,17 @@ css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/
 css/css-conditional/container-queries-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3597]
 css/cssom/css-rule-selector-text.html: [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/193]
 css/cssom/style-width-calc-vh-vw.html: [fail, https://github.com/jsdom/jsdom/issues/1332]
+custom-elements/ElementInternals-accessibility.html:
+  "ariaActiveDescendantElement": [fail, Element reflection not implemented]
+  "ariaBrailleLabel": [fail, Element reflection not implemented]
+  "ariaBrailleRoleDescription": [fail, Element reflection not implemented]
+  "ariaControlsElements": [fail, Element reflection not implemented]
+  "ariaDescribedByElements": [fail, Element reflection not implemented]
+  "ariaDetailsElements": [fail, Element reflection not implemented]
+  "ariaErrorMessageElements": [fail, Element reflection not implemented]
+  "ariaFlowToElements": [fail, Element reflection not implemented]
+  "ariaLabelledByElements": [fail, Element reflection not implemented]
+  "ariaOwnsElements": [fail, Element reflection not implemented]
 html/semantics/scripting-1/the-script-element/execution-timing/insert-script.html: [fail, https://github.com/jsdom/jsdom/issues/159]
 jsdom-only/failure-example-1.html: [fail, https://github.com/jsdom/jsdom/issues/3835]
 jsdom-only/failure-example-2.html:

--- a/test/web-platform-tests/to-upstream/custom-elements/ElementInternals-accessibility.html
+++ b/test/web-platform-tests/to-upstream/custom-elements/ElementInternals-accessibility.html
@@ -1,0 +1,109 @@
+<!DOCTYPE HTML>
+<!-- jsdom updates the original file to actually test the setters, per https://github.com/jsdom/jsdom/issues/3732. Also some other minor simplifications. -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+class TestElement extends HTMLElement {
+  constructor() {
+    super();
+    this.internals = this.attachInternals();
+  }
+}
+customElements.define("test-element", TestElement);
+</script>
+
+<test-element id= "testElement"></test-element>
+
+<script>
+"use strict";
+const element = document.getElementById("testElement");
+const properties = [
+  "role",
+  "ariaActiveDescendantElement",
+  "ariaAtomic",
+  "ariaAutoComplete",
+  "ariaBrailleLabel",
+  "ariaBrailleRoleDescription",
+  "ariaBusy",
+  "ariaChecked",
+  "ariaColCount",
+  "ariaColIndex",
+  // "ariaColIndexText", // tentative -> ElementInternals-accessibility.tentative.html
+  "ariaColSpan",
+  "ariaControlsElements",
+  "ariaCurrent",
+  "ariaDescribedByElements",
+  // "ariaDescription", // tentative -> ElementInternals-accessibility.tentative.html
+  "ariaDetailsElements",
+  "ariaDisabled",
+  "ariaErrorMessageElements",
+  "ariaExpanded",
+  "ariaFlowToElements",
+  "ariaHasPopup",
+  "ariaHidden",
+  "ariaInvalid",
+  "ariaKeyShortcuts",
+  "ariaLabel",
+  "ariaLabelledByElements",
+  "ariaLevel",
+  "ariaLive",
+  "ariaModal",
+  "ariaMultiLine",
+  "ariaMultiSelectable",
+  "ariaOrientation",
+  "ariaOwnsElements",
+  "ariaPlaceholder",
+  "ariaPosInSet",
+  "ariaPressed",
+  "ariaReadOnly",
+  "ariaRelevant",
+  "ariaRequired",
+  "ariaRoleDescription",
+  "ariaRowCount",
+  "ariaRowIndex",
+  // "ariaRowIndexText", // tentative -> ElementInternals-accessibility.tentative.html
+  "ariaRowSpan",
+  "ariaSelected",
+  "ariaSetSize",
+  "ariaSort",
+  "ariaValueMax",
+  "ariaValueMin",
+  "ariaValueNow",
+  "ariaValueText"
+];
+
+for (const property of properties) {
+  test(() => {
+    assert_inherits(element.internals, property, "defined in ElementInternals");
+
+    assert_equals(element.internals[property], null, "null default value");
+
+    if (property.endsWith("Element")) {
+      element.internals[property] = document.body;
+
+      assert_equals(element.internals[property], document.body, "can be set to an Element");
+    } else if (property.endsWith("Elements")) {
+      const originalArray = [document.body];
+      element.internals[property] = originalArray;
+
+      assert_array_equals(element.internals[property], originalArray, "same contents");
+      assert_not_equals(element.internals[property], originalArray, "not equal to the original array");
+      assert_true(Object.isFrozen(element.internals[property]), "is frozen");
+      assert_equals(element.internals[property], element.internals[property], "getter returns the same value");
+    } else {
+      // It's DOMString?
+      element.internals[property] = {
+        toString() {
+          return "a string";
+        }
+      };
+
+      assert_equals(element.internals[property], "a string", "can be set to a string");
+    }
+  }, property);
+}
+test(() => {
+  assert_false("ariaErrorMessageElement" in element.internals);
+}, "ariaErrorMessageElement is not defined in ElementInternals");
+</script>


### PR DESCRIPTION
The web platform test coverage for these was woefully incomplete, so when we added them in d6c0ab258a84a0ce01ee1d0ae78195ddeadaa3aa they did not actually work at all.

Closes #3732.