### PR TITLE
object instanceof ResourceLoader passes with multiple jsdom packages

### DIFF
--- a/lib/jsdom/browser/resources/resource-loader.js
+++ b/lib/jsdom/browser/resources/resource-loader.js
@@ -10,6 +10,13 @@ const Request = require("../../living/helpers/http-request");
 const IS_BROWSER = Object.prototype.toString.call(process) !== "[object process]";
 
 module.exports = class ResourceLoader {
+
+  static [Symbol.hasInstance](instance) {
+    return instance && instance._isResourceLoader;
+  }
+
+  _isResourceLoader = true;
+
   constructor({
     strictSSL = true,
     proxy = undefined,


### PR DESCRIPTION
- See https://stackoverflow.com/a/41592087/61624 for context
- TL;DR: `object instanceof ResourceLoader` fails if the `object` and `ResourceLoader` are from different jsdom packages, even if those jsdom packages are the same version
- ~I don't know how to reproduce the problem yet, and I'm too tired to continue investigating, but~ here is how my `npm ls jsdom` looks in my project with the problem:
    ```
    $ npm ls jsdom
    my-app@1.0.0 Apps\my-app
    ├─┬ jsdom-configurable-resource-loader@0.0.20 -> .\..\jsdom-configurable-resource-loader
    │ └── jsdom@26.1.0 
    ├── jsdom@26.1.0
    └─┬ another-package-of-mine@0.0.1 -> .\..\another-package-of-mine
      └── jsdom@26.1.0
    ```
    Notice that none of these jsdoms are deduped and child dependencies are links.
- Another relevant detail: "npm dedupe ignores modules that are symbolic links (e. g. when using npm link) resulting in incomplete deduplication." [Source](https://github.com/FunkMonkey/npm-dedupe-symlinks)
- I think (part) of the problem is "my-app" instantiates a `ConfigurableResourceLoader` and passes it to "another-package-of-mine". "another-package-of-mine" instantiates `JSDOM`, using the passed `ConfigurableResourceLoader`.
- When I apply this PR locally, I confirmed `object instanceof ResourceLoader` works as expected.
- I know this isn't a strong argument, but FWIW, [this technique seems good enough for moment.js](https://github.com/moment/moment/blob/develop/src/lib/moment/constructor.js#L78)
- Even if a sample project can consistently reproduce this issue, I don't know how I could write a failing test for it in the PR; there are multiple packages involved and external links to them.