### PR TITLE
3899: Fixes a bug where faketimers did not work for expiring cookies

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -925,7 +925,7 @@ class DocumentImpl extends NodeImpl {
   }
 
   get cookie() {
-    return this._cookieJar.getCookieStringSync(this.URL, { http: false });
+    return this._cookieJar.getCookieStringSync(this.URL, { http: false, now: new Date() });
   }
   set cookie(cookieStr) {
     cookieStr = String(cookieStr);


### PR DESCRIPTION
I reported the original issue in jest, but I think the actual issue is this line in jsdom.

Original issue: https://github.com/jestjs/jest/issues/15727

This should make fake timers expire cookies correctly. Code comes from the original issue in jest repo: https://github.com/jestjs/jest/issues/11585, by @g2guy-aefxx

