### PR TITLE
Regression tests for cssstyle

### DIFF
--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,6 +1,9 @@
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]
 css/css-conditional/container-queries-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3597]
 css/cssom/css-rule-selector-text.html: [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/193]
+css/cssom/style-background-position.html: [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/209]
+css/cssom/style-background-repeat.html: [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/209]
+css/cssom/style-background-shorthand.html: [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/209]
 css/cssom/style-set-custom-property-priority.html: [fail, Need to fix getComputedStyle; related https://github.com/jsdom/cssstyle/issues/225]
 css/cssom/style-set-property.html:
   "set null for cssRule.style.setProperty": [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/196]

--- a/test/web-platform-tests/to-upstream/css/cssom/style-background-position.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-background-position.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<title>background-position with multiple values</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background-position">
+<!-- Regression test for https://github.com/jsdom/cssstyle/issues/209 -->
+
+<div id="test"></div>
+
+<script>
+"use strict";
+
+const div = document.getElementById("test");
+
+test(() => {
+  div.style.backgroundPosition = null;
+  assert_equals(div.style.backgroundPosition, "");
+}, "Sanity check");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundPosition = null;
+  });
+
+  div.style.backgroundPosition = "10";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "left right";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "top bottom";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "10px left";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "top 10px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "left right top";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "10px 20px 30px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "left 10px right";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "top 10px bottom";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "left 10px 20px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "10px top 20px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "center 10px center";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "center center 10px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "left bottom right top";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "10px 20px 30px 40px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "center 10px center 20px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "left 10px right 20px";
+  assert_equals(div.style.backgroundPosition, "");
+
+  div.style.backgroundPosition = "right 10px left 20px";
+  assert_equals(div.style.backgroundPosition, "");
+}, "Invalid values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundPosition = null;
+  });
+
+  div.style.backgroundPosition = "center";
+  assert_equals(div.style.backgroundPosition, "center center");
+
+  div.style.backgroundPosition = "left";
+  assert_equals(div.style.backgroundPosition, "left center");
+
+  div.style.backgroundPosition = "right";
+  assert_equals(div.style.backgroundPosition, "right center");
+
+  div.style.backgroundPosition = "top";
+  assert_equals(div.style.backgroundPosition, "center top");
+
+  div.style.backgroundPosition = "bottom";
+  assert_equals(div.style.backgroundPosition, "center bottom");
+
+  div.style.backgroundPosition = "10px";
+  assert_equals(div.style.backgroundPosition, "10px center");
+
+  div.style.backgroundPosition = "10%";
+  assert_equals(div.style.backgroundPosition, "10% center");
+}, "1 value");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundPosition = null;
+  });
+
+  div.style.backgroundPosition = "center center";
+  assert_equals(div.style.backgroundPosition, "center center");
+
+  div.style.backgroundPosition = "left top";
+  assert_equals(div.style.backgroundPosition, "left top");
+
+  div.style.backgroundPosition = "left center";
+  assert_equals(div.style.backgroundPosition, "left center");
+
+  div.style.backgroundPosition = "top center";
+  assert_equals(div.style.backgroundPosition, "center top");
+
+  div.style.backgroundPosition = "top left";
+  assert_equals(div.style.backgroundPosition, "left top");
+
+  div.style.backgroundPosition = "left 10px";
+  assert_equals(div.style.backgroundPosition, "left 10px");
+
+  div.style.backgroundPosition = "10px top";
+  assert_equals(div.style.backgroundPosition, "10px top");
+
+  div.style.backgroundPosition = "left 10%";
+  assert_equals(div.style.backgroundPosition, "left 10%");
+
+  div.style.backgroundPosition = "10% top";
+  assert_equals(div.style.backgroundPosition, "10% top");
+}, "2 values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundPosition = null;
+  });
+
+  div.style.backgroundPosition = "left 10px top";
+  assert_equals(div.style.backgroundPosition, "left 10px top");
+
+  div.style.backgroundPosition = "left top 10px";
+  assert_equals(div.style.backgroundPosition, "left top 10px");
+
+  div.style.backgroundPosition = "top 10px left";
+  assert_equals(div.style.backgroundPosition, "left top 10px");
+
+  div.style.backgroundPosition = "top left 10px";
+  assert_equals(div.style.backgroundPosition, "left 10px top");
+}, "3 values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundPosition = null;
+  });
+
+  div.style.backgroundPosition = "left 10px top 20px";
+  assert_equals(div.style.backgroundPosition, "left 10px top 20px");
+
+  div.style.backgroundPosition = "top 10px left 20px";
+  assert_equals(div.style.backgroundPosition, "left 20px top 10px");
+}, "4 values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundPosition = null;
+  });
+
+  div.style.backgroundPosition = "left, top, 10px";
+  assert_equals(div.style.backgroundPosition, "left center, center top, 10px center");
+
+  div.style.backgroundPosition = "left top, right bottom";
+  assert_equals(div.style.backgroundPosition, "left top, right bottom");
+
+  div.style.backgroundPosition = "top left, bottom right";
+  assert_equals(div.style.backgroundPosition, "left top, right bottom");
+
+  div.style.backgroundPosition = "left 10px top, right 20px bottom";
+  assert_equals(div.style.backgroundPosition, "left 10px top, right 20px bottom");
+
+  div.style.backgroundPosition = "top 10px left, bottom right 20px";
+  assert_equals(div.style.backgroundPosition, "left top 10px, right 20px bottom");
+
+  div.style.backgroundPosition = "left 10px top 20px, right 30px bottom 40px";
+  assert_equals(div.style.backgroundPosition, "left 10px top 20px, right 30px bottom 40px");
+
+  div.style.backgroundPosition = "top 10px left 20px, bottom 30px right 40px";
+  assert_equals(div.style.backgroundPosition, "left 20px top 10px, right 40px bottom 30px");
+}, "Multiple background positions");
+</script>

--- a/test/web-platform-tests/to-upstream/css/cssom/style-background-repeat.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-background-repeat.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>background-repeat with multiple values</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background-repeat">
+<!-- Regression test for https://github.com/jsdom/cssstyle/issues/209 -->
+
+<div id="test"></div>
+
+<script>
+"use strict";
+
+const div = document.getElementById("test");
+
+test(() => {
+  div.style.backgroundRepeat = null;
+  assert_equals(div.style.backgroundRepeat, "");
+}, "Sanity check");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundRepeat = null;
+  });
+
+  div.style.backgroundRepeat = "repeat";
+  assert_equals(div.style.backgroundRepeat, "repeat");
+
+  div.style.backgroundRepeat = "no-repeat";
+  assert_equals(div.style.backgroundRepeat, "no-repeat");
+
+  div.style.backgroundRepeat = "repeat-x";
+  assert_equals(div.style.backgroundRepeat, "repeat-x");
+
+  div.style.backgroundRepeat = "repeat-y";
+  assert_equals(div.style.backgroundRepeat, "repeat-y");
+
+  div.style.backgroundRepeat = "space";
+  assert_equals(div.style.backgroundRepeat, "space");
+
+  div.style.backgroundRepeat = "round";
+  assert_equals(div.style.backgroundRepeat, "round");
+
+  div.style.backgroundRepeat = "repeat, no-repeat";
+  assert_equals(div.style.backgroundRepeat, "repeat, no-repeat");
+}, "1 value");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.backgroundRepeat = null;
+  });
+
+  div.style.backgroundRepeat = "repeat repeat";
+  assert_equals(div.style.backgroundRepeat, "repeat");
+
+  div.style.backgroundRepeat = "repeat no-repeat";
+  assert_equals(div.style.backgroundRepeat, "repeat-x");
+
+  div.style.backgroundRepeat = "no-repeat repeat";
+  assert_equals(div.style.backgroundRepeat, "repeat-y");
+
+  div.style.backgroundRepeat = "space space";
+  assert_equals(div.style.backgroundRepeat, "space");
+
+  div.style.backgroundRepeat = "round round";
+  assert_equals(div.style.backgroundRepeat, "round");
+
+  div.style.backgroundRepeat = "repeat space";
+  assert_equals(div.style.backgroundRepeat, "repeat space");
+
+  div.style.backgroundRepeat = null;
+  div.style.backgroundRepeat = "repeat-x repeat-y";
+  assert_equals(div.style.backgroundRepeat, "");
+
+  div.style.backgroundRepeat = "repeat space, no-repeat repeat";
+  assert_equals(div.style.backgroundRepeat, "repeat space, repeat-y");
+}, "2 values");
+</script>

--- a/test/web-platform-tests/to-upstream/css/cssom/style-background-shorthand.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-background-shorthand.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<title>background shorthand</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background">
+<!-- Regression test for https://github.com/jsdom/cssstyle/issues/209 -->
+
+<div id="test"></div>
+
+<script>
+"use strict";
+
+const div = document.getElementById("test");
+
+test(() => {
+  div.style.backgroundColor = "red";
+  div.style.backgroundImage = "url(example.png)";
+  div.style.backgroundPosition = "left";
+  div.style.backgroundSize = "50%";
+  div.style.backgroundRepeat = "repeat";
+  div.style.backgroundOrigin = "padding-box";
+  div.style.backgroundClip = "border-box";
+  div.style.backgroundAttachment = "fixed";
+
+  div.style.background = null;
+  assert_equals(div.style.backgroundColor, "", "color");
+  assert_equals(div.style.backgroundImage, "", "image");
+  assert_equals(div.style.backgroundPosition, "", "position");
+  assert_equals(div.style.backgroundSize, "", "size");
+  assert_equals(div.style.backgroundRepeat, "", "repeat");
+  assert_equals(div.style.backgroundOrigin, "", "origin");
+  assert_equals(div.style.backgroundClip, "", "clip");
+  assert_equals(div.style.backgroundAttachment, "", "attachment");
+  assert_equals(div.style.background, "", "background");
+}, "Sanity check");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.background = null;
+  });
+
+  div.style.background = "none";
+  assert_equals(div.style.background, "none", "background");
+  assert_equals(div.style.backgroundImage, "none", "image");
+  assert_equals(div.style.backgroundPosition, "0% 0%", "position");
+  assert_equals(div.style.backgroundSize, "auto", "size");
+  assert_equals(div.style.backgroundRepeat, "repeat", "repeat");
+  assert_equals(div.style.backgroundOrigin, "padding-box", "origin");
+  assert_equals(div.style.backgroundClip, "border-box", "clip");
+  assert_equals(div.style.backgroundAttachment, "scroll", "attachment");
+  assert_equals(div.style.backgroundColor, "transparent", "color");
+}, "`none` sets default longhand values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.background = null;
+  });
+
+  div.style.background = "transparent";
+  assert_equals(div.style.background, "transparent", "background");
+  assert_equals(div.style.backgroundImage, "none", "image");
+  assert_equals(div.style.backgroundPosition, "0% 0%", "position");
+  assert_equals(div.style.backgroundSize, "auto", "size");
+  assert_equals(div.style.backgroundRepeat, "repeat", "repeat");
+  assert_equals(div.style.backgroundOrigin, "padding-box", "origin");
+  assert_equals(div.style.backgroundClip, "border-box", "clip");
+  assert_equals(div.style.backgroundAttachment, "scroll", "attachment");
+  assert_equals(div.style.backgroundColor, "transparent", "color");
+}, "`transparent` sets default longhand values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.background = null;
+  });
+
+  div.style.background = "fixed left / 50% repeat url(example.png) green";
+  const value = div.style.background;
+  // Firefox omits properties with default value, i.e. `repeat` in this case.
+  const expectedValues = [
+    "green",
+    'url("example.png")',
+    "left center / 50%",
+    "fixed"
+  ];
+  for (const expectedValue of expectedValues) {
+    assert_true(value.includes(expectedValue), expectedValue);
+  }
+  // Unspecified properties with default value should not be included in shorthand
+  const unexpectedValues = [
+    "padding-box",
+    "border-box"
+  ];
+  for (const unexpectedValue of unexpectedValues) {
+    assert_false(value.includes(unexpectedValue), unexpectedValue);
+  }
+  assert_equals(div.style.backgroundImage, 'url("example.png")', "image");
+  assert_equals(div.style.backgroundPosition, "left center", "position");
+  assert_equals(div.style.backgroundSize, "50%", "size");
+  assert_equals(div.style.backgroundRepeat, "repeat", "repeat");
+  assert_equals(div.style.backgroundOrigin, "padding-box", "origin");
+  assert_equals(div.style.backgroundClip, "border-box", "clip");
+  assert_equals(div.style.backgroundAttachment, "fixed", "attachment");
+  assert_equals(div.style.backgroundColor, "green", "color");
+}, "Background shorthand sets longhand values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.background = null;
+  });
+
+  div.style.background = "fixed left / 50% repeat url(example.png) red";
+  div.style.backgroundColor = "green";
+  const value = div.style.background;
+  // Firefox omits properties with default value, i.e. `repeat` in this case.
+  const expectedValues = [
+    "green",
+    'url("example.png")',
+    "left center / 50%",
+    "fixed"
+  ];
+  for (const expectedValue of expectedValues) {
+    assert_true(value.includes(expectedValue), expectedValue);
+  }
+  // Unspecified properties with default value should not be included in shorthand
+  const unexpectedValues = [
+    "padding-box",
+    "border-box"
+  ];
+  for (const unexpectedValue of unexpectedValues) {
+    assert_false(value.includes(unexpectedValue), unexpectedValue);
+  }
+  assert_equals(div.style.backgroundImage, 'url("example.png")', "image");
+  assert_equals(div.style.backgroundPosition, "left center", "position");
+  assert_equals(div.style.backgroundSize, "50%", "size");
+  assert_equals(div.style.backgroundRepeat, "repeat", "repeat");
+  assert_equals(div.style.backgroundOrigin, "padding-box", "origin");
+  assert_equals(div.style.backgroundClip, "border-box", "clip");
+  assert_equals(div.style.backgroundAttachment, "fixed", "attachment");
+  assert_equals(div.style.backgroundColor, "green", "color");
+}, "Update longhand sets background value with its updated value");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.background = null;
+  });
+
+  div.style.background = "fixed left / 50% repeat url(example.png) green var(--foo)";
+  assert_equals(div.style.background, "fixed left / 50% repeat url(example.png) green var(--foo)", "background");
+  assert_equals(div.style.backgroundImage, "", "image");
+  assert_equals(div.style.backgroundPosition, "", "position");
+  assert_equals(div.style.backgroundSize, "", "size");
+  assert_equals(div.style.backgroundRepeat, "", "repeat");
+  assert_equals(div.style.backgroundOrigin, "", "origin");
+  assert_equals(div.style.backgroundClip, "", "clip");
+  assert_equals(div.style.backgroundAttachment, "", "attachment");
+  assert_equals(div.style.backgroundColor, "", "color");
+}, "Background with var() sets empty longhand values");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.background = null;
+  });
+
+  div.style.background = "fixed left / 50% repeat url(example.png) red";
+  div.style.backgroundColor = "var(--foo)";
+  assert_equals(div.style.background, "", "background");
+  assert_equals(div.style.backgroundImage, 'url("example.png")', "image");
+  assert_equals(div.style.backgroundPosition, "left center", "position");
+  assert_equals(div.style.backgroundSize, "50%", "size");
+  assert_equals(div.style.backgroundRepeat, "repeat", "repeat");
+  assert_equals(div.style.backgroundOrigin, "padding-box", "origin");
+  assert_equals(div.style.backgroundClip, "border-box", "clip");
+  assert_equals(div.style.backgroundAttachment, "fixed", "attachment");
+  assert_equals(div.style.backgroundColor, "var(--foo)", "color");
+}, "Update longhand with var() sets empty background value");
+</script>


### PR DESCRIPTION
Regression tests for https://github.com/jsdom/cssstyle/issues/209

Re: `style-background-shorthand.html`, there are some bugs in browsers?
* When background shorthand is set to `none`, i.e. `div.style.background = "none";`, Firefox resolves default `transparent` keyword of the backgroundColor to `rgba(0, 0, 0, 0)`.
* Chrome resolves default values to `initial` keyword.
