### PR TITLE
swap rweb-cssom to @acemir/cssom for better css nesting support

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -1,5 +1,5 @@
 "use strict";
-const cssom = require("rrweb-cssom");
+const cssom = require("@acemir/cssom");
 const cssstyle = require("cssstyle");
 
 exports.addToCore = core => {

--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -1,5 +1,5 @@
 "use strict";
-const cssom = require("rrweb-cssom");
+const cssom = require("@acemir/cssom");
 const path = require("path");
 const fs = require("fs");
 const { CSSStyleDeclaration } = require("cssstyle");

--- a/lib/jsdom/living/helpers/stylesheets.js
+++ b/lib/jsdom/living/helpers/stylesheets.js
@@ -1,5 +1,5 @@
 "use strict";
-const cssom = require("rrweb-cssom");
+const cssom = require("@acemir/cssom");
 const whatwgEncoding = require("whatwg-encoding");
 const whatwgURL = require("whatwg-url");
 const { invalidateStyleCache } = require("./style-rules");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "27.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
+        "@acemir/cssom": "^0.9.1",
         "@asamuzakjp/dom-selector": "^6.5.0",
         "cssstyle": "^4.6.0",
         "data-urls": "^5.0.0",
@@ -18,7 +19,6 @@
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
         "parse5": "^7.3.0",
-        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^5.1.2",
@@ -57,6 +57,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.1.tgz",
+      "integrity": "sha512-8T5KnkRuFczcPxd+0dRoKhkUazJ9DP2mH/fISAyykoB1glYDRGIeh1wZT0C/qpO7vgBpQbLCJjxef4DNl7ZTVw==",
+      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/jsdom/jsdom.git"
   },
   "dependencies": {
+    "@acemir/cssom": "^0.9.1",
     "@asamuzakjp/dom-selector": "^6.5.0",
     "cssstyle": "^4.6.0",
     "data-urls": "^5.0.0",
@@ -32,7 +33,6 @@
     "https-proxy-agent": "^7.0.6",
     "is-potential-custom-element-name": "^1.0.1",
     "parse5": "^7.3.0",
-    "rrweb-cssom": "^0.8.0",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",
     "tough-cookie": "^5.1.2",


### PR DESCRIPTION
The updated dependency package enhances the parser's ability to correctly process complex CSS structures, including nested selectors, nested declarations, layer statements and at-rules validations.

## Key Changes

### Introducing CSS Nesting Module support
- Added support for [CSSNestedDeclarations](https://drafts.csswg.org/css-nesting-1/#cssnesteddeclarations)
- [CSSStyleRule](https://drafts.csswg.org/cssom/#the-cssstylerule-interface) now inherits properties from [CSSGroupingRule](https://drafts.csswg.org/cssom/#the-cssgroupingrule-interface)

### Improved At-Rule Validation
- Refactored at-rule validation logic ensuring that invalid or malformed at-rules are ignored more reliably.
- Improved handling of edge cases, such as unbalanced braces and complex at-rule conditions.
- Enhanced handling of at-rules that cannot be nested.

### Improvements in CSS Cascading
- Added support for [CSSLayerStatement](https://drafts.csswg.org/css-cascade-5/#csslayerstatementrule)
- Improves [CSSLayerBlockRule ](https://drafts.csswg.org/css-cascade-5/#csslayerblockrule)interface and layer name validation
- Added support for layerName and supportsText to [CSSImportRule](https://drafts.csswg.org/cssom/#the-cssimportrule-interface)