### PR TITLE
Fix #3882 add search tag and ensure all non-inherited tags are tested

### DIFF
--- a/lib/jsdom/living/helpers/create-element.js
+++ b/lib/jsdom/living/helpers/create-element.js
@@ -23,7 +23,7 @@ const INTERFACE_TAG_MAPPING = {
     HTMLElement: [
       "abbr", "address", "article", "aside", "b", "bdi", "bdo", "cite", "code", "dd", "dfn", "dt", "em", "figcaption",
       "figure", "footer", "header", "hgroup", "i", "kbd", "main", "mark", "nav", "noscript", "rp", "rt", "ruby", "s",
-      "samp", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr"
+      "samp", "search", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr"
     ],
     HTMLAnchorElement: ["a"],
     HTMLAreaElement: ["area"],

--- a/test/to-port-to-wpts/htmlelement.js
+++ b/test/to-port-to-wpts/htmlelement.js
@@ -6,9 +6,9 @@ const { describe, specify } = require("mocha-sugar-free");
 const { JSDOM } = require("../..");
 
 const nonInheritedTags = [
-  "article", "section", "nav", "aside", "hgroup", "header", "footer", "address", "dt",
-  "dd", "figure", "figcaption", "main", "em", "strong", "small", "s", "cite", "abbr",
-  "code", "i", "b", "u"
+  "abbr", "address", "article", "aside", "b", "bdi", "bdo", "cite", "code", "dd", "dfn", "dt", "em", "figcaption",
+  "figure", "footer", "header", "hgroup", "i", "kbd", "main", "mark", "nav", "noscript", "rp", "rt", "ruby", "s",
+  "samp", "search", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr"
 ];
 
 describe("htmlelement", () => {
@@ -66,7 +66,7 @@ describe("htmlelement", () => {
     t.timeout(5000); // give this a bit of leeway. It's apparently slow
 
     for (let i = 0; i < nonInheritedTags.length; ++i) {
-      const doc = (new JSDOM("<" + nonInheritedTags[i] + ">")).window.document;
+      const doc = (new JSDOM("<body><" + nonInheritedTags[i] + "></body>")).window.document;
       const el = doc.body.firstChild;
       assert.ok(
         el.constructor === doc.defaultView.HTMLElement,


### PR DESCRIPTION
* Add support for the `<search>` tag (fixes #3882)
* Align tests with `create-element.js` to ensure all non-inherited tags are tested (this required adding a `<body>` wrapper to stop the test failing for the `noscript` tag.)