### PR TITLE
Fix reconfigure() not updating base URL caches

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -96,6 +96,7 @@ class JSDOM {
       document._URL = url;
       document._origin = whatwgURL.serializeURLOrigin(document._URL);
       this[window]._sessionHistory.currentEntry.url = url;
+      document._clearBaseURLCache();
     }
   }
 

--- a/scripts/webidl/reflection.js
+++ b/scripts/webidl/reflection.js
@@ -72,18 +72,21 @@ module.exports = (transformer, idl, implObj) => {
     const serializeURL = transformer.addImport("whatwg-url", "serializeURL");
     return {
       get: `
-        const value = ${implObj}._reflectGetTheContentAttribute("${attrName}");
+        const impl = ${implObj};
+        const value = impl._reflectGetTheContentAttribute("${attrName}");
         if (value === null) {
           return "";
         }
 
-        if (this._${attrName}URLCacheKey === value) {
+        const document = impl._ownerDocument;
+        if (this._${attrName}URLCacheKey === value && this._baseURLCache === document._baseURLCache) {
           return this._${attrName}URLCache;
         }
 
         this._${attrName}URLCacheKey = value;
+        this._baseURLCache = document._baseURLCache;
 
-        const urlRecord = ${implObj}._ownerDocument.encodingParseAURL(value);
+        const urlRecord = document.encodingParseAURL(value);
         if (urlRecord !== null) {
           this._${attrName}URLCache = ${serializeURL}(urlRecord);
           return this._${attrName}URLCache;

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -338,6 +338,19 @@ describe("API: JSDOM class's methods", () => {
 
         assert.equal(window.document.URL, "http://localhost/");
       });
+
+      it("should update the document base URL", () => {
+        const dom = new JSDOM(`<img src="foo.jpg">`, { url: "http://example.com/" });
+        const { window } = dom;
+
+        assert.equal(window.document.baseURI, "http://example.com/");
+        assert.equal(window.document.querySelector("img").src, "http://example.com/foo.jpg");
+
+        dom.reconfigure({ url: "http://localhost/bar/index.html" });
+
+        assert.equal(window.document.baseURI, "http://localhost/bar/index.html");
+        assert.equal(window.document.querySelector("img").src, "http://localhost/bar/foo.jpg");
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #3915. This regressed in e88c8aa824407e27088ef275a9e0cb8755348042 and b722cbdd9b72b5a100ffe58b8258e6db9993eb70.