### PR TITLE
Use new DOMSelector instance for internal querySelector()

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -226,7 +226,10 @@ class DocumentImpl extends NodeImpl {
       return this._baseURLCache;
     }
 
-    const firstBase = this.querySelector("base[href]");
+    const firstBase = new DOMSelector(this._globalObject, this._ownerDocument, {
+      domSymbolTree,
+      idlUtils
+    }).querySelector("base[href]", this);
 
     this._baseURLCache = firstBase === null ?
       this._fallbackBaseURL() :


### PR DESCRIPTION
Fix #3928
See also https://github.com/jsdom/jsdom/issues/3931#issuecomment-3299518202
