### PR TITLE
Add cssstyle regression tests for CSS flex shorthand

### DIFF
--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -4,6 +4,9 @@ css/css-display/display-initial.html:
   "Revert value of display": [fail, Revert keyword is not supported]
   "Revert-layer value of display": [fail, Revert-layer keyword is not supported]
 css/cssom/css-rule-selector-text.html: [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/193]
+css/cssom/style-flex-shorthand.html:
+  "resolve flex shorthand with auto basis": [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/pull/245]
+  "resolve flex shorthand with grow and basis": [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/pull/245]
 css/cssom/style-set-custom-property-priority.html: [fail, Need to fix getComputedStyle; related https://github.com/jsdom/cssstyle/issues/225]
 css/cssom/style-set-property.html:
   "set null for cssRule.style.setProperty": [fail, Need cssstyle fix; https://github.com/jsdom/cssstyle/issues/196]

--- a/test/web-platform-tests/to-upstream/css/cssom/style-flex-shorthand.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-flex-shorthand.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Setting flex shorthand</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#flex-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- regression test for https://github.com/jsdom/cssstyle/pull/245 -->
+
+<div id="div"></div>
+<script>
+"use strict";
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "none";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "0");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "0");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "auto");
+}, "resolve flex none shorthand");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "auto";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "1");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "1");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "auto");
+}, "resolve flex auto shorthand");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "0 1 250px";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "0");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "1");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "250px");
+}, "resolve flex shorthand with explicit basis");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "0 0 auto";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "0");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "0");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "auto");
+}, "resolve flex shorthand with auto basis");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "0 auto";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "0");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "1");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "auto");
+}, "resolve flex shorthand with grow and basis");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "2";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "2");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "1");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "0%");
+}, "resolve flex shorthand with grow only");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "20%";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "1");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "1");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "20%");
+}, "resolve flex shorthand with basis only");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.display = "flex";
+  div.style.flex = "2 2";
+  assert_equals(div.style.getPropertyValue("flex-grow"), "2");
+  assert_equals(div.style.getPropertyValue("flex-shrink"), "2");
+  assert_equals(div.style.getPropertyValue("flex-basis"), "0%");
+}, "resolve flex shorthand with grow and shrink");
+</script>


### PR DESCRIPTION
As discussed in https://github.com/jsdom/cssstyle/pull/245, adds a regression test for CSS `flex` shorthand in cssstyle