### PR TITLE
improve asciiLowercase / asciiUppercase perf on ascii

### DIFF
--- a/lib/jsdom/living/helpers/strings.js
+++ b/lib/jsdom/living/helpers/strings.js
@@ -6,7 +6,9 @@ exports.asciiWhitespaceRe = asciiWhitespaceRe;
 
 // https://infra.spec.whatwg.org/#ascii-lowercase
 exports.asciiLowercase = s => {
-  if (!/[^\x00-\x7f]/.test(s)) return s.toLowerCase()
+  if (!/[^\x00-\x7f]/.test(s)) {
+    return s.toLowerCase();
+  }
   const len = s.length;
   const out = new Array(len);
   for (let i = 0; i < len; i++) {
@@ -19,7 +21,9 @@ exports.asciiLowercase = s => {
 
 // https://infra.spec.whatwg.org/#ascii-uppercase
 exports.asciiUppercase = s => {
-  if (!/[^\x00-\x7f]/.test(s)) return s.toUpperCase()
+  if (!/[^\x00-\x7f]/.test(s)) {
+    return s.toUpperCase();
+  }
   const len = s.length;
   const out = new Array(len);
   for (let i = 0; i < len; i++) {


### PR DESCRIPTION
Coming from ce779560c10abf4bbe851c6520053a2cc02e5068 and https://github.com/jsdom/whatwg-encoding/issues/22#issuecomment-3652806899

If the input is ASCII most of the time, this is ~3x-10x faster

Also, if this is used for tagname, a direct comparison to the two top-frequent-tag names (or a map) could improve perf further