### PR TITLE
Unify API tests testsuite usage, fix async

### DIFF
--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -2,6 +2,7 @@
 const path = require("path");
 const { spawnSync } = require("child_process");
 const assert = require("node:assert/strict");
+const { stripVTControlCharacters } = require("node:util");
 const { describe, it } = require("mocha-sugar-free");
 const { JSDOM, VirtualConsole } = require("../..");
 const { delay } = require("../util");
@@ -47,7 +48,7 @@ describe("Test cases only possible to test from the outside", () => {
     const { status, stdout } = spawnSync("node", ["--expose-gc", timeoutWithGcFixturePath], { encoding: "utf-8" });
 
     assert.equal(status, 0);
-    const ratio = Number(stdout);
+    const ratio = Number(stripVTControlCharacters(stdout));
     assert(!Number.isNaN(ratio));
 
     // At least 70% of the memory must be freed up.

--- a/test/api/from-url.js
+++ b/test/api/from-url.js
@@ -19,7 +19,7 @@ describe("API: JSDOM.fromURL()", () => {
     });
 
     it("should reject when passing an invalid absolute URL for referrer", () => {
-      assert.rejects(JSDOM.fromURL("http://example.com/", { referrer: "asdf" }), TypeError);
+      return assert.rejects(JSDOM.fromURL("http://example.com/", { referrer: "asdf" }), TypeError);
     });
 
     it("should disallow passing a URL manually", () => {
@@ -61,7 +61,7 @@ describe("API: JSDOM.fromURL()", () => {
     it("should give an appropriate error for invalid redirect URLs (GH-3804)", async () => {
       const url = await badRedirectServer();
 
-      assert.rejects(JSDOM.fromURL(url), "Invalid URL");
+      return assert.rejects(JSDOM.fromURL(url), /Invalid URL/);
     });
 
     it("should be able to handle gzipped bodies", async () => {


### PR DESCRIPTION
1. Two instances of `assert.rejects` were incorrect, one actually failed due to invalid assertion usage
    Test runner failed to notice this
2. Replace mocha-style `{ async: true }` with returning a promise, which mocha also supports
3. Strip colors from the subprocess stdout before parsing it as a number

With this, you can just use `node:test` as a drop-in replacement for `mocha-sugar-free` inside `test/api` directory
The switch itself is not done by this PR though