### PR TITLE
feat: support @napi-rs/canvas as canvas impl

### DIFF
--- a/.github/workflows/jsdom-ci.yml
+++ b/.github/workflows/jsdom-ci.yml
@@ -25,7 +25,13 @@ jobs:
       - name: Run ESLint
         run: npm run lint
   build-with-canvas:
-    name: Tests with node-canvas
+    name: Tests with ${{ matrix.canvas-library }}
+    strategy:
+      fail-fast: false
+      matrix:
+        canvas-library:
+          - canvas
+          - '@napi-rs/canvas'
     env:
       TEST_SUITE: 'node-canvas'
     runs-on: ubuntu-latest
@@ -37,13 +43,22 @@ jobs:
         with:
           node-version: 22
       - name: Install required image manipulation packages with APT
+        if: ${{ matrix.canvas-library == 'canvas' }}
         run: sudo apt-get update && sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - name: Setup hosts file for web platform tests server
         run: ./test/web-platform-tests/tests/wpt make-hosts-file | sudo tee -a /etc/hosts
       - name: Install dependencies and canvas
+        if: ${{ matrix.canvas-library == 'canvas' }}
         run: npm ci && npm i canvas@3
+      - name: Install @napi-rs/canvas
+        if: ${{ matrix.canvas-library == '@napi-rs/canvas' }}
+        run: npm ci && npm i @napi-rs/canvas
       - name: Run tests
+        if: ${{ matrix.canvas-library == 'canvas' }}
         run: npm test
+      - name: Run tests (excluding byte-level comparison tests)
+        if: ${{ matrix.canvas-library == '@napi-rs/canvas' }}
+        run: npm run test:api && npm run test:tuwpt && npm run test:wpt && npx mocha test/to-port-to-wpts/ --grep "canvas must resize correctly|produce the expected result" --invert && npx mocha test/to-port-to-wpts/level1/ && npx mocha test/to-port-to-wpts/level2/ && npx mocha test/to-port-to-wpts/level3/
   build:
     name: Tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -471,7 +471,31 @@ console.log(frag.firstChild.outerHTML); // logs "<p>Hello</p>"
 
 ### Canvas support
 
-jsdom includes support for using the [`canvas`](https://www.npmjs.com/package/canvas) package to extend any `<canvas>` elements with the canvas API. To make this work, you need to include `canvas` as a dependency in your project, as a peer of `jsdom`. If jsdom can find version 3.x of the `canvas` package, it will use it, but if it's not present, then `<canvas>` elements will behave like `<div>`s.
+jsdom includes support for using either the [`canvas`](https://www.npmjs.com/package/canvas) package or the [`@napi-rs/canvas`](https://www.npmjs.com/package/@napi-rs/canvas) package to extend any `<canvas>` elements with the canvas API.
+
+**Recommended**: Install `@napi-rs/canvas` for faster installation with zero system dependencies:
+
+```bash
+npm install @napi-rs/canvas
+```
+
+**Alternative**: Use the `canvas` package (requires system dependencies like Cairo, Pango, etc.):
+
+```bash
+npm install canvas
+```
+
+jsdom will automatically detect which package is installed. If both packages are installed, jsdom will prefer `@napi-rs/canvas`. If neither is installed, then `<canvas>` elements will behave like `<div>`s.
+
+**Migrating from canvas to @napi-rs/canvas**:
+
+If you're currently using `canvas` and want to switch to `@napi-rs/canvas`:
+
+1. Uninstall the old package: `npm uninstall canvas`
+2. Install the new package: `npm install @napi-rs/canvas`
+3. No code changes needed in your application - jsdom handles the rest!
+
+Note: Due to different rendering engines (Cairo vs Skia), there may be minor pixel-level differences in output. If you have tests that do pixel-perfect image comparisons, you may need to update test fixtures.
 
 ### Encoding sniffing
 

--- a/lib/jsdom/canvas-adapter.js
+++ b/lib/jsdom/canvas-adapter.js
@@ -1,0 +1,128 @@
+"use strict";
+
+/**
+ * Canvas Adapter - Provides unified interface for both @napi-rs/canvas and canvas (node-canvas)
+ *
+ * This adapter allows jsdom to support both canvas libraries with a preference for @napi-rs/canvas.
+ * It normalizes API differences and provides compatibility wrappers where needed.
+ */
+
+let canvasLib = null;
+let libraryName = null;
+let _createCanvas = null;
+let _Image = null;
+
+// Try to load @napi-rs/canvas first (preferred for better installation experience)
+try {
+  canvasLib = require("@napi-rs/canvas");
+  libraryName = "@napi-rs/canvas";
+  _createCanvas = canvasLib.createCanvas.bind(canvasLib);
+  _Image = canvasLib.Image;
+} catch {
+  // Fall back to canvas (node-canvas) if @napi-rs/canvas is not available
+  try {
+    canvasLib = require("canvas");
+    libraryName = "canvas";
+    _createCanvas = canvasLib.createCanvas.bind(canvasLib);
+    _Image = canvasLib.Image;
+  } catch {
+    // Neither library is available - jsdom will gracefully degrade
+    libraryName = null;
+  }
+}
+
+/**
+ * Create a canvas element with the specified dimensions
+ * @param {number} width - Canvas width
+ * @param {number} height - Canvas height
+ * @returns {Canvas} Canvas instance
+ */
+function createCanvas(width, height) {
+  if (!_createCanvas) {
+    return null;
+  }
+  return _createCanvas(width, height);
+}
+
+/**
+ * Wraps a canvas instance to provide compatibility between libraries
+ * Specifically handles toBuffer callback API differences
+ *
+ * @param {Canvas} canvas - Canvas instance to wrap
+ * @returns {Canvas} Wrapped canvas instance
+ */
+function wrapCanvas(canvas) {
+  if (!canvas) {
+    return canvas;
+  }
+
+  // For @napi-rs/canvas, we need to wrap toBuffer to provide callback-based API
+  if (libraryName === "@napi-rs/canvas") {
+    const originalToBuffer = canvas.toBuffer;
+
+    // Store reference to original for potential direct access
+    canvas._originalToBuffer = originalToBuffer;
+
+    // Override toBuffer to support both callback and direct call patterns
+    canvas.toBuffer = function (callbackOrMime, mimeOrQuality, optionsOrUndefined) {
+      // Detect if first argument is a callback function
+      if (typeof callbackOrMime === "function") {
+        // Callback-based API: toBuffer(callback, mimeType, options)
+        const callback = callbackOrMime;
+        const mimeType = mimeOrQuality || "image/png";
+        const { quality } = optionsOrUndefined || {};
+
+        // @napi-rs/canvas toBuffer is synchronous, but we wrap it in setTimeout
+        // to maintain async behavior expected by jsdom's toBlob implementation
+        setTimeout(() => {
+          try {
+            // @napi-rs/canvas signature: toBuffer(mime, quality?)
+            // quality is passed as second parameter, not in options object
+            let buffer;
+
+            if (quality !== undefined) {
+              buffer = originalToBuffer.call(canvas, mimeType, quality);
+            } else {
+              buffer = originalToBuffer.call(canvas, mimeType);
+            }
+
+            callback(null, buffer);
+          } catch (err) {
+            callback(err);
+          }
+        }, 0);
+
+        // Callback-based API doesn't return a value
+        return undefined;
+      }
+
+      // Direct call API: toBuffer(mimeType, quality?)
+      // Pass through to original @napi-rs/canvas method
+      return originalToBuffer.call(canvas, callbackOrMime, mimeOrQuality);
+    };
+  }
+  // For node-canvas, toBuffer already supports callback API - no wrapping needed
+
+  return canvas;
+}
+
+// Export unified interface
+// When no canvas library is available, export null to match the old behavior
+// This ensures checks like `if (!Canvas)` and `if (Canvas && ...)` work correctly
+if (libraryName === null) {
+  module.exports = null;
+} else {
+  module.exports = {
+    // Factory function for creating canvas
+    createCanvas,
+
+    // Image constructor
+    Image: _Image,
+
+    // Canvas wrapper for compatibility
+    wrapCanvas,
+
+    // Name of the loaded library
+    libraryName
+  };
+}

--- a/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
@@ -16,6 +16,8 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
   _getCanvas() {
     if (Canvas && !this._canvas) {
       this._canvas = Canvas.createCanvas(this.width, this.height);
+      // Apply compatibility wrapper (may mutate canvas) to handle API differences
+      this._canvas = Canvas.wrapCanvas(this._canvas);
     }
     return this._canvas;
   }
@@ -124,6 +126,12 @@ function wrapNodeCanvasMethod(ctx, name) {
     if (impl) {
       if (impl instanceof HTMLCanvasElementImpl && !impl._canvas) {
         impl._getCanvas();
+      }
+      // Per the HTML spec, if the image is not fully decoded, drawImage should silently return.
+      // https://html.spec.whatwg.org/multipage/canvas.html#drawing-images
+      // Check if this is an HTMLImageElement that is not completely available
+      if (impl._currentRequestState !== undefined && impl._currentRequestState !== "completely available") {
+        return undefined;
       }
       image = impl._image || impl._canvas;
     }

--- a/lib/jsdom/living/nodes/HTMLImageElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLImageElement-impl.js
@@ -8,6 +8,8 @@ class HTMLImageElementImpl extends HTMLElementImpl {
   constructor(...args) {
     super(...args);
     this._currentRequestState = "unavailable";
+    this._loadPromise = null;
+    this._loadPromiseResolve = null;
   }
 
   _attrModified(name, value, oldVal) {
@@ -65,6 +67,28 @@ class HTMLImageElementImpl extends HTMLElementImpl {
     return this._currentSrc || "";
   }
 
+  // https://html.spec.whatwg.org/multipage/images.html#dom-img-decode
+  decode() {
+    const performDecode = () => {
+      // Per spec, decode() must reject if the image is in a broken state
+      if (this._currentRequestState === "broken") {
+        return Promise.reject(new DOMException("The image could not be decoded", "EncodingError"));
+      }
+      if (this._image && typeof this._image.decode === "function") {
+        return this._image.decode();
+      }
+      // If no canvas library or decode not supported, resolve immediately
+      return Promise.resolve();
+    };
+
+    // If we're still loading, wait for that first
+    if (this._loadPromise) {
+      return this._loadPromise.then(() => performDecode());
+    }
+
+    return performDecode();
+  }
+
   // https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data
   _updateTheImageData() {
     const document = this._ownerDocument;
@@ -94,6 +118,39 @@ class HTMLImageElementImpl extends HTMLElementImpl {
     if (urlString !== null) {
       const resourceLoader = document._resourceLoader;
 
+      // If there's an existing load in progress, resolve its promise to avoid hanging decode()
+      if (this._loadPromiseResolve) {
+        this._loadPromiseResolve();
+      }
+
+      // Create a promise that decode() can wait on
+      this._loadPromise = new Promise(resolve => {
+        this._loadPromiseResolve = resolve;
+      });
+
+      // Capture the current load's resolver so callbacks don't interfere with newer loads
+      const currentLoadPromise = this._loadPromise;
+      const currentLoadPromiseResolve = this._loadPromiseResolve;
+
+      const finishLoading = () => {
+        this._currentSrc = srcAttributeValue;
+        this._currentRequestState = "completely available";
+        currentLoadPromiseResolve();
+        if (this._loadPromise === currentLoadPromise) {
+          this._loadPromise = null;
+          this._loadPromiseResolve = null;
+        }
+      };
+
+      const handleError = () => {
+        this._currentRequestState = "broken";
+        currentLoadPromiseResolve();
+        if (this._loadPromise === currentLoadPromise) {
+          this._loadPromise = null;
+          this._loadPromiseResolve = null;
+        }
+      };
+
       const onLoadImage = data => {
         let error = null;
         this._image.onerror = err => {
@@ -105,16 +162,31 @@ class HTMLImageElementImpl extends HTMLElementImpl {
         if (error) {
           throw new Error(error);
         }
-        this._currentSrc = srcAttributeValue;
-        this._currentRequestState = "completely available";
+
+        // For @napi-rs/canvas, we need to wait for decode() before the image can be drawn
+        // Return a Promise so resource loader waits for decode before firing load event
+        if (typeof this._image.decode === "function") {
+          return this._image.decode().then(() => {
+            // Check if the image is actually valid after decoding
+            // An image with 0x0 dimensions is considered broken
+            if (this._image.naturalWidth === 0 || this._image.naturalHeight === 0) {
+              handleError();
+              throw new Error("The image could not be decoded");
+            }
+            finishLoading();
+          });
+        }
+
+        // For libraries without decode (like node-canvas), finish immediately
+        finishLoading();
+        return undefined;
       };
 
       resourceLoader.fetch(urlString, {
         element: this,
         onLoad: onLoadImage,
-        onError: () => {
-          this._currentRequestState = "broken";
-        }
+        onError: handleError,
+        allowNon2xx: true
       });
     } else {
       this._image.src = "";

--- a/lib/jsdom/living/nodes/HTMLImageElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLImageElement.webidl
@@ -18,7 +18,7 @@ interface HTMLImageElement : HTMLElement {
   readonly attribute USVString currentSrc;
 //  [CEReactions] attribute DOMString referrerPolicy;
 
-//  Promise<void> decode();
+  Promise<void> decode();
 
   // also has obsolete members
 };

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -99,7 +99,7 @@ exports.treeOrderSorter = function (a, b) {
 };
 
 try {
-  exports.Canvas = require("canvas");
+  exports.Canvas = require("./canvas-adapter");
 } catch {
   exports.Canvas = null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.88",
         "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        },
         "canvas": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -45,10 +45,14 @@
     "xml-name-validator": "^5.0.0"
   },
   "peerDependencies": {
+    "@napi-rs/canvas": "^0.1.88",
     "canvas": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "canvas": {
+      "optional": true
+    },
+    "@napi-rs/canvas": {
       "optional": true
     }
   },

--- a/test/util.js
+++ b/test/util.js
@@ -2,6 +2,7 @@
 const path = require("path");
 const fs = require("fs");
 const { JSDOM } = require("..");
+const { Canvas } = require("../lib/jsdom/utils");
 const { pathToFileURL } = require("url");
 
 exports.toFileUrl = dirname => {
@@ -58,4 +59,18 @@ exports.injectIFrameWithScript = (document, scriptStr = "") => {
 
 exports.readTestFixture = relativePath => {
   return fs.promises.readFile(path.resolve(__dirname, relativePath), { encoding: "utf8" });
+};
+
+exports.isCanvasInstalled = (t, done) => {
+  if (!Canvas) {
+    t.ok(true, "test ignored; not running with a canvas package installed");
+    done();
+    return false;
+  }
+
+  return true;
+};
+
+exports.getCanvasLibraryName = () => {
+  return Canvas ? Canvas.libraryName : null;
 };

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1408,7 +1408,6 @@ DIR: html/canvas/element/drawing-images-to-the-canvas
 2d.drawImage.composite.html: [fail, Not implemented]
 2d.drawImage.detachedcanvas.html: [fail, Not implemented]
 2d.drawImage.floatsource.html: [fail, Not implemented]
-2d.drawImage.incomplete.*.html: [fail, Not implemented]
 2d.drawImage.negativedest.html: [fail, Not implemented]
 2d.drawImage.negativedir.html: [fail, Not implemented]
 2d.drawImage.negativesource.html: [fail, Not implemented]


### PR DESCRIPTION
**Benefits of @napi-rs/canvas**:

- Faster installation (no compilation step, pre-built binaries)
- Zero system dependencies (no need to install Cairo, Pango, etc.)
- No node-gyp required (avoids build toolchain issues)
- Better performance with Skia rendering engine

The download counts for `@napi-rs/canvas` and `canvas` are quite similar: https://www.npmcharts.com/compare/@napi-rs/canvas,canvas. I am planning to release version 1.0 very soon, as it is now quite stable.

Ref: https://github.com/jsdom/jsdom/issues/2390#issuecomment-1615938571

Close:
- https://github.com/jsdom/jsdom/issues/3978
- https://github.com/jsdom/jsdom/issues/2154