### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -198,10 +198,7 @@ function matches(rule, elementImpl) {
   try {
     if (rule.selectorText) {
       const domSelector = elementImpl._ownerDocument._domSelector;
-      // Workaround for cssstyle issue.
-      // https://github.com/jsdom/cssstyle/issues/193
-      const selector = rule.selectorText.split(";").pop().trim();
-      const { match, pseudoElement } = domSelector.check(selector, elementImpl);
+      const { match, pseudoElement } = domSelector.check(rule.selectorText, elementImpl);
       // `pseudoElement` is a pseudo-element selector (e.g. `::before`).
       // However, we do not support getComputedStyle(element, pseudoElement), so return `false`.
       if (pseudoElement) {


### PR DESCRIPTION
## Motivation
This workaround was originally added to address an issue reported in `cssstyle`, which was actually caused by `rrweb-io/CSSOM`. 

This workaround is no longer necessary as jsdom has migrated its dependencies from `rrweb-io/CSSOM` to `@acemir/CSSOM`, which already resolves this issue.

## Impact
Closes https://github.com/jsdom/cssstyle/issues/193
