### PR TITLE
Enable characterSet normalization WPTs

### DIFF
--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -773,8 +773,6 @@ DOMTokenList-coverage-for-attributes.html: [fail, Several DOMTokenList attribute
 DIR: dom/nodes
 
 Document-URL.html: [fail, Unknown]
-Document-characterSet-normalization-1.html: [timeout, Some encodings are not supported - see the whatwg-encoding module]
-Document-characterSet-normalization-2.html: [timeout, Some encodings are not supported - see the whatwg-encoding module]
 Document-createEvent.https.html:
   "DragEvent should be an alias for DragEvent.": [fail, Interface not implemented]
   "createEvent('DragEvent') should be initialized correctly.": [fail, Interface not implemented]


### PR DESCRIPTION
ddad97df73368768c5107e3d141b6bb994164c4d presumably made these start passing, but they were marked as skipped.