### PR TITLE
test: cleanup stray servers on shutdown

### DIFF
--- a/test/util.js
+++ b/test/util.js
@@ -2,6 +2,7 @@
 const path = require("path");
 const fs = require("fs");
 const http = require("http");
+const { after } = require("mocha-sugar-free");
 const enableDestroy = require("server-destroy");
 const { JSDOM } = require("..");
 const { Canvas } = require("../lib/jsdom/utils");
@@ -77,18 +78,31 @@ exports.delay = ms => new Promise(r => {
   setTimeout(r, ms);
 });
 
+// Track all created servers for cleanup.
+const activeServers = new Set();
+
 exports.createServer = handler => {
   return new Promise(resolve => {
     const server = http.createServer(handler);
     enablePromisifiedServerDestroy(server);
+    activeServers.add(server);
     server.listen(() => resolve(server));
   });
 };
+
+// Clean up any servers that weren't explicitly destroyed (e.g., due to test timeout).
+// This runs once at the very end of all tests.
+after(async () => {
+  const serversToDestroy = [...activeServers];
+  activeServers.clear();
+  await Promise.all(serversToDestroy.map(server => server.destroy().catch(() => {})));
+});
 
 function enablePromisifiedServerDestroy(server) {
   enableDestroy(server);
   const originalDestroy = server.destroy;
   server.destroy = function () {
+    activeServers.delete(this);
     return new Promise((resolve, reject) => {
       originalDestroy.call(this, err => {
         if (err) {


### PR DESCRIPTION
### Motivation

- Prevent HTTP servers created by tests from leaking after failures or timeouts by ensuring any remaining servers are destroyed when the test suite finishes.

### Description

- Added `after` from `mocha-sugar-free` and a module-level `activeServers` set in `test/util.js` to track created servers.
- Updated `createServer` to add created servers to `activeServers` and wrapped servers with `enablePromisifiedServerDestroy` for a promisified `server.destroy()` helper.
- Added a global `after` hook that iterates `activeServers` and calls `server.destroy()` on any leftover servers, and cleared the set afterward.
- Modified the promisified `destroy` wrapper to remove servers from `activeServers` when they are explicitly destroyed.

### Testing

- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef63aa1c0832cb9846eda2a6dd75e)