### PR TITLE
Fix Windows-specific task kill timeouts

### DIFF
--- a/test/web-platform-tests/run-tuwpts.js
+++ b/test/web-platform-tests/run-tuwpts.js
@@ -55,9 +55,7 @@ before({ timeout: 30_000 }, async () => {
   serverProcess = subprocess;
 });
 
-after(() => {
-  killSubprocess(serverProcess);
-});
+after({ timeout: 5000 }, () => killSubprocess(serverProcess));
 
 describe("Local tests in web-platform-test format (to-upstream)", () => {
   for (const testFilePath of possibleTestFilePaths) {

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -24,9 +24,7 @@ before({ timeout: 30_000 }, async () => {
   serverProcess = subprocess;
 });
 
-after(() => {
-  killSubprocess(serverProcess);
-});
+after({ timeout: 5000 }, () => killSubprocess(serverProcess));
 
 describe("web-platform-tests", () => {
   for (const toRunDoc of toRunDocs) {

--- a/test/web-platform-tests/utils.js
+++ b/test/web-platform-tests/utils.js
@@ -5,16 +5,20 @@ const https = require("node:https");
 const os = require("node:os");
 
 exports.killSubprocess = subprocess => {
-  if (os.platform() === "win32") {
-    // subprocess.kill() doesn't seem to be able to kill descendant processes on Windows,
-    // at least with whatever's going on inside the web-platform-tests Python.
-    // Use this technique instead.
-    const { pid } = subprocess;
-    childProcess.spawnSync("taskkill", ["/F", "/T", "/PID", pid], { detached: true, windowsHide: true });
-  } else {
-    // SIGINT is necessary so that the Python script can clean up its subprocesses.
-    subprocess.kill("SIGINT");
-  }
+  return new Promise(resolve => {
+    subprocess.on("close", resolve);
+
+    if (os.platform() === "win32") {
+      // subprocess.kill() doesn't seem to be able to kill descendant processes on Windows,
+      // at least with whatever's going on inside the web-platform-tests Python.
+      // Use taskkill asynchronously since it can take several seconds to complete.
+      const { pid } = subprocess;
+      childProcess.spawn("taskkill", ["/F", "/T", "/PID", pid], { detached: true, windowsHide: true });
+    } else {
+      // SIGINT is necessary so that the Python script can clean up its subprocesses.
+      subprocess.kill("SIGINT");
+    }
+  });
 };
 
 // We need rejectUnauthorized support so we can't use built-in fetch(), sadly.


### PR DESCRIPTION
Recently, randomly, seemingly unrelated to any changes on the main branch, my local machine was giving timeouts when trying to shut down the WPT testing process. Apparently the taskkill spawn was taking more than 2 seconds to complete, causing Mocha to complain. Give it a bit longer, and ensure Mocha is aware of the asynchronous nature of the task killing.