### PR TITLE
Improve spec alignment of Headers and header type tests

### DIFF
--- a/lib/jsdom/living/fetch/Headers-impl.js
+++ b/lib/jsdom/living/fetch/Headers-impl.js
@@ -1,11 +1,11 @@
 "use strict";
 
 const {
-  isForbidden,
-  isForbiddenResponse,
-  isPrivilegedNoCORSRequest,
-  isNoCORSSafelistedRequest,
-  isCORSWhitelisted
+  isForbiddenRequestHeader,
+  isForbiddenResponseHeaderName,
+  isPrivilegedNoCORSRequestHeaderName,
+  isNoCORSSafelistedRequestHeaderName,
+  isNoCORSSafelistedRequestHeader
 } = require("./header-types");
 const { isHeaderName, isHeaderValue, normalizeHeaderValue } = require("./header-utils");
 const HeaderList = require("./header-list");
@@ -25,14 +25,41 @@ function assertValue(value) {
 class HeadersImpl {
   constructor(globalObject, args) {
     this.guard = "none";
-    this.headersList = new HeaderList();
+    this.headerList = new HeaderList();
 
     if (args[0]) {
-      this._fill(args[0]);
+      this.#fill(args[0]);
     }
   }
 
-  _fill(init) {
+  // https://fetch.spec.whatwg.org/#headers-validate
+  #validate(name, value) {
+    assertName(name);
+    assertValue(value);
+
+    switch (this.guard) {
+      case "immutable": {
+        throw new TypeError("Headers is immutable");
+      }
+      case "request": {
+        if (isForbiddenRequestHeader(name, value)) {
+          return false;
+        }
+        break;
+      }
+      case "response": {
+        if (isForbiddenResponseHeaderName(name)) {
+          return false;
+        }
+        break;
+      }
+    }
+
+    return true;
+  }
+
+  // https://fetch.spec.whatwg.org/#concept-headers-fill
+  #fill(init) {
     if (Array.isArray(init)) {
       for (const header of init) {
         if (header.length !== 2) {
@@ -41,121 +68,103 @@ class HeadersImpl {
         this.append(header[0], header[1]);
       }
     } else {
-      for (const key of Object.keys(init)) {
-        this.append(key, init[key]);
+      for (const [key, value] of Object.entries(init)) {
+        this.append(key, value);
       }
     }
   }
 
-  has(name) {
-    assertName(name);
-    return this.headersList.contains(name);
+  // https://fetch.spec.whatwg.org/#concept-headers-remove-privileged-no-cors-request-headers
+  #removePrivilegedNoCORSHeaders() {
+    this.headerList.delete("range");
   }
 
-  getSetCookie() {
-    return this.headersList.getAll("Set-Cookie") || [];
-  }
-
-  get(name) {
-    assertName(name);
-    return this.headersList.get(name);
-  }
-
-  _removePrivilegedNoCORSHeaders() {
-    this.headersList.delete("range");
-  }
-
+  // https://fetch.spec.whatwg.org/#dom-headers-append
   append(name, value) {
     value = normalizeHeaderValue(value);
-    assertName(name);
-    assertValue(value);
-
-    switch (this.guard) {
-      case "immutable":
-        throw new TypeError("Headers is immutable");
-      case "request":
-        if (isForbidden(name)) {
-          return;
-        }
-        break;
-      case "request-no-cors": {
-        if (!isCORSWhitelisted(name, value)) {
-          return;
-        }
-        break;
-      }
-      case "response":
-        if (isForbiddenResponse(name)) {
-          return;
-        }
-        break;
+    if (!this.#validate(name, value)) {
+      return;
     }
 
-    this.headersList.append(name, value);
-    this._removePrivilegedNoCORSHeaders();
+    if (this.guard === "request-no-cors") {
+      let temporaryValue = this.headerList.get(name);
+      if (temporaryValue === null) {
+        temporaryValue = value;
+      } else {
+        temporaryValue += ", " + value;
+      }
+      if (!isNoCORSSafelistedRequestHeader(name, temporaryValue)) {
+        return;
+      }
+    }
+
+    this.headerList.append(name, value);
+
+    if (this.guard === "request-no-cors") {
+      this.#removePrivilegedNoCORSHeaders();
+    }
   }
 
+  // https://fetch.spec.whatwg.org/#dom-headers-delete
+  delete(name) {
+    if (!this.#validate(name, "")) {
+      return;
+    }
+
+    if (this.guard === "request-no-cors" &&
+      !isNoCORSSafelistedRequestHeaderName(name) &&
+      !isPrivilegedNoCORSRequestHeaderName(name)) {
+      return;
+    }
+
+    if (!this.headerList.contains(name)) {
+      return;
+    }
+
+    this.headerList.delete(name);
+
+    if (this.guard === "request-no-cors") {
+      this.#removePrivilegedNoCORSHeaders();
+    }
+  }
+
+  // https://fetch.spec.whatwg.org/#dom-headers-get
+  get(name) {
+    assertName(name);
+    return this.headerList.get(name);
+  }
+
+  // https://fetch.spec.whatwg.org/#dom-headers-getsetcookie
+  getSetCookie() {
+    return this.headerList.getAll("Set-Cookie") || [];
+  }
+
+  // https://fetch.spec.whatwg.org/#dom-headers-has
+  has(name) {
+    assertName(name);
+    return this.headerList.contains(name);
+  }
+
+  // https://fetch.spec.whatwg.org/#dom-headers-set
   set(name, value) {
     value = normalizeHeaderValue(value);
-    assertName(name);
-    assertValue(value);
-
-    switch (this.guard) {
-      case "immutable":
-        throw new TypeError("Headers is immutable");
-      case "request":
-        if (isForbidden(name)) {
-          return;
-        }
-        break;
-      case "request-no-cors": {
-        if (!isCORSWhitelisted(name, value)) {
-          return;
-        }
-        break;
-      }
-      case "response":
-        if (isForbiddenResponse(name)) {
-          return;
-        }
-        break;
+    if (!this.#validate(name, value)) {
+      return;
     }
-    this.headersList.set(name, value);
-    this._removePrivilegedNoCORSHeaders();
-  }
 
-  delete(name) {
-    assertName(name);
-
-    switch (this.guard) {
-      case "immutable":
-        throw new TypeError("Headers is immutable");
-      case "request":
-        if (isForbidden(name)) {
-          return;
-        }
-        break;
-      case "request-no-cors": {
-        if (
-          !isNoCORSSafelistedRequest(name) &&
-          !isPrivilegedNoCORSRequest(name)
-        ) {
-          return;
-        }
-        break;
-      }
-      case "response":
-        if (isForbiddenResponse(name)) {
-          return;
-        }
-        break;
+    if (this.guard === "request-no-cors" && !isNoCORSSafelistedRequestHeader(name, value)) {
+      return;
     }
-    this.headersList.delete(name);
-    this._removePrivilegedNoCORSHeaders();
+
+    this.headerList.set(name, value);
+
+    if (this.guard === "request-no-cors") {
+      this.#removePrivilegedNoCORSHeaders();
+    }
   }
 
   * [Symbol.iterator]() {
-    for (const header of this.headersList.sortAndCombine()) {
+    for (const header of this.headerList.sortAndCombine()) {
       yield header;
     }
   }

--- a/lib/jsdom/living/fetch/header-types.js
+++ b/lib/jsdom/living/fetch/header-types.js
@@ -2,30 +2,33 @@
 
 const { MIMEType } = require("whatwg-mimetype");
 
+// https://fetch.spec.whatwg.org/#privileged-no-cors-request-header-name
 const PRIVILEGED_NO_CORS_REQUEST = new Set(["range"]);
-function isPrivilegedNoCORSRequest(name) {
+function isPrivilegedNoCORSRequestHeaderName(name) {
   return PRIVILEGED_NO_CORS_REQUEST.has(name.toLowerCase());
 }
 
+// https://fetch.spec.whatwg.org/#no-cors-safelisted-request-header-name
 const NO_CORS_SAFELISTED_REQUEST = new Set([
   `accept`,
   `accept-language`,
   `content-language`,
   `content-type`
 ]);
-function isNoCORSSafelistedRequest(name) {
+function isNoCORSSafelistedRequestHeaderName(name) {
   return NO_CORS_SAFELISTED_REQUEST.has(name.toLowerCase());
 }
 
+// https://fetch.spec.whatwg.org/#forbidden-response-header-name
 const FORBIDDEN_RESPONSE = new Set(["set-cookie", "set-cookie2"]);
-function isForbiddenResponse(name) {
+function isForbiddenResponseHeaderName(name) {
   return FORBIDDEN_RESPONSE.has(name.toLowerCase());
 }
 
-const CORS_UNSAFE_BYTE = /[\x00-\x08\x0A-\x1F"():<>?@[\\\]{}\x7F]/;
 // https://fetch.spec.whatwg.org/#cors-safelisted-request-header
 // Note: name and value are already ensured by the IDL layer to be byte strings.
-function isCORSWhitelisted(name, value) {
+const CORS_UNSAFE_BYTE = /[\x00-\x08\x0A-\x1F"():<>?@[\\\]{}\x7F]/;
+function isCORSSafelistedRequestHeader(name, value) {
   name = name.toLowerCase();
   switch (name) {
     case "accept":
@@ -65,6 +68,14 @@ function isCORSWhitelisted(name, value) {
     return false;
   }
   return true;
+}
+
+// https://fetch.spec.whatwg.org/#no-cors-safelisted-request-header
+function isNoCORSSafelistedRequestHeader(name, value) {
+  if (!isNoCORSSafelistedRequestHeaderName(name)) {
+    return false;
+  }
+  return isCORSSafelistedRequestHeader(name, value);
 }
 
 const BASIC_FORBIDDEN_REQUEST_HEADERS = new Set([
@@ -185,9 +196,10 @@ function getDecodeAndSplit(input) {
 }
 
 module.exports = {
-  isPrivilegedNoCORSRequest,
-  isNoCORSSafelistedRequest,
-  isForbidden: isForbiddenRequestHeader,
-  isForbiddenResponse,
-  isCORSWhitelisted
+  isPrivilegedNoCORSRequestHeaderName,
+  isNoCORSSafelistedRequestHeaderName,
+  isNoCORSSafelistedRequestHeader,
+  isForbiddenRequestHeader,
+  isForbiddenResponseHeaderName,
+  isCORSSafelistedRequestHeader
 };

--- a/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
+++ b/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
@@ -8,7 +8,7 @@ const { utf8Encode } = require("../helpers/encoding");
 const tough = require("tough-cookie");
 const { MIMEType } = require("whatwg-mimetype");
 const { isHeaderName, isHeaderValue, normalizeHeaderValue } = require("../fetch/header-utils");
-const { isForbidden: isForbiddenRequestHeader } = require("../fetch/header-types");
+const { isForbiddenRequestHeader } = require("../fetch/header-types");
 
 const xhrUtils = require("./xhr-utils");
 const DOMException = require("../generated/DOMException");


### PR DESCRIPTION
This shouldn't have significant observable effects, since we don't actually create Headers instances with the more exotic guards.