### PR TITLE
Mark header-values tests as fail-slow due to Node.js bug

### DIFF
--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1051,8 +1051,8 @@ DIR: fetch/api/headers
 
 header-setcookie.any.html:
   "Set-Cookie is a forbidden response header": [fail, Response is not defined]
-header-values-normalize.any.html: [fail, fetch is not defined]
-header-values.any.html: [fail, fetch is not defined]
+header-values-normalize.any.html: [fail-slow, "https://github.com/nodejs/node/issues/61582"]
+header-values.any.html: [fail-slow, "https://github.com/nodejs/node/issues/61582"]
 headers-no-cors.any.html: [fail, Request is not defined]
 
 ---


### PR DESCRIPTION
Node.js rejects header values containing control characters (like 0x01) that are allowed by the Fetch spec and accepted by browsers. This causes these tests to timeout waiting for XHR responses instead of failing fast.

This started happening in bd8481b5831e398099520c23cc7113dfef9a794d when our header validation was updated to match the spec, and thus these header values made it further into the stack.