### PR TITLE
Replace custom delay helper with node:timers/promises

### DIFF
--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -4,7 +4,7 @@ const { spawnSync } = require("child_process");
 const assert = require("node:assert/strict");
 const { describe, it } = require("mocha-sugar-free");
 const { JSDOM, VirtualConsole } = require("../..");
-const { delay } = require("../util");
+const delay = require("node:timers/promises").setTimeout;
 const { slowStreamingServer } = require("./helpers/resources");
 
 describe("Test cases only possible to test from the outside", () => {

--- a/test/api/helpers/resources.js
+++ b/test/api/helpers/resources.js
@@ -4,7 +4,8 @@ const fs = require("fs");
 const crypto = require("crypto");
 const http = require("http");
 const assert = require("node:assert/strict");
-const { delay, createServer } = require("../../util.js");
+const delay = require("node:timers/promises").setTimeout;
+const { createServer } = require("../../util.js");
 const { VirtualConsole } = require("../../..");
 const enableDestroy = require("server-destroy");
 

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -1,7 +1,7 @@
 "use strict";
 const assert = require("node:assert/strict");
 const { describe, it } = require("mocha-sugar-free");
-const { delay } = require("../util.js");
+const delay = require("node:timers/promises").setTimeout;
 
 const { JSDOM, VirtualConsole } = require("../..");
 const jsGlobals = Object.keys(require("../../lib/jsdom/browser/js-globals.json"));

--- a/test/api/resources-interceptors.js
+++ b/test/api/resources-interceptors.js
@@ -1,7 +1,7 @@
 "use strict";
 const assert = require("node:assert/strict");
 const { describe, it } = require("mocha-sugar-free");
-const { delay } = require("../util.js");
+const delay = require("node:timers/promises").setTimeout;
 const canvas = require("../../lib/jsdom/utils.js").Canvas;
 
 const { JSDOM, VirtualConsole, requestInterceptor } = require("../..");

--- a/test/to-port-to-wpts/level2/style.js
+++ b/test/to-port-to-wpts/level2/style.js
@@ -7,7 +7,8 @@ const assert = require("node:assert/strict");
 const { beforeEach, afterEach, describe, specify } = require("mocha-sugar-free");
 
 const { JSDOM } = require("../../..");
-const { createServer, delay } = require("../../util.js");
+const delay = require("node:timers/promises").setTimeout;
+const { createServer } = require("../../util.js");
 
 describe("level2/style", () => {
   specify("HTMLStyleElement01", () => {

--- a/test/util.js
+++ b/test/util.js
@@ -74,10 +74,6 @@ exports.isCanvasInstalled = (t, done) => {
   return true;
 };
 
-exports.delay = ms => new Promise(r => {
-  setTimeout(r, ms);
-});
-
 // Track all created servers for cleanup.
 const activeServers = new Set();
 


### PR DESCRIPTION
## Summary

- Replaced the hand-rolled `exports.delay` in `test/util.js` with `require("node:timers/promises").setTimeout` at each call site
- This built-in was already in use in `test/web-platform-tests/wpt-server.js`

## Test plan

- [x] `npm run test:api` — all 572 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)