### PR TITLE
Fix assert.rejects() calls that were not being awaited

### DIFF
--- a/test/api/from-url.js
+++ b/test/api/from-url.js
@@ -25,7 +25,7 @@ describe("API: JSDOM.fromURL()", () => {
     });
 
     it("should reject when passing an invalid absolute URL for referrer", () => {
-      assert.rejects(JSDOM.fromURL("http://example.com/", { referrer: "asdf" }), TypeError);
+      return assert.rejects(JSDOM.fromURL("http://example.com/", { referrer: "asdf" }), TypeError);
     });
 
     it("should disallow passing a URL manually", () => {
@@ -67,7 +67,7 @@ describe("API: JSDOM.fromURL()", () => {
     it("should give an appropriate error for invalid redirect URLs (GH-3804)", async () => {
       const url = await resourceServer({ Location: "https://" }, undefined, { status: 301 });
 
-      assert.rejects(JSDOM.fromURL(url), "Invalid URL");
+      return assert.rejects(JSDOM.fromURL(url), /Invalid redirect URL/);
     });
 
     it("should be able to handle gzipped bodies", async () => {


### PR DESCRIPTION
Extracted from https://github.com/jsdom/jsdom/pull/4005 with a small fix to match the actual error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)