### PR TITLE
Cache the root node for document-connected trees

### DIFF
--- a/benchmark/dom/root-node.js
+++ b/benchmark/dom/root-node.js
@@ -1,0 +1,84 @@
+"use strict";
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+module.exports = () => {
+  const bench = new Bench();
+
+  // Repeated getRootNode() on the deepest node of a static deep tree.
+  // Best case for caching: many reads, no mutations.
+  // Real-world: framework checking node.getRootNode() === document during a rendering cycle.
+  {
+    const DEPTH = 200;
+    const { document } = (new JSDOM()).window;
+    let deepest = document.body;
+    for (let i = 0; i < DEPTH; i++) {
+      const child = document.createElement("div");
+      deepest.appendChild(child);
+      deepest = child;
+    }
+
+    bench.add(`getRootNode: depth ${DEPTH}`, () => {
+      deepest.getRootNode();
+    });
+  }
+
+  // Event dispatch (bubbling) on a deep tree.
+  // Event dispatch calls nodeRoot internally multiple times per ancestor
+  // in the event path, making it O(depth^2) without caching.
+  {
+    const DEPTH = 100;
+    const { document, Event } = (new JSDOM()).window;
+    let deepest = document.body;
+    for (let i = 0; i < DEPTH; i++) {
+      const child = document.createElement("div");
+      deepest.appendChild(child);
+      deepest = child;
+    }
+    const event = new Event("test", { bubbles: true });
+
+    bench.add(`dispatchEvent (bubbling): depth ${DEPTH}`, () => {
+      deepest.dispatchEvent(event);
+    });
+  }
+
+  // isConnected on a deep static tree.
+  // isConnected uses shadowIncludingRoot -> nodeRoot internally.
+  // Common in frameworks to check if an element is still in the DOM.
+  {
+    const DEPTH = 200;
+    const { document } = (new JSDOM()).window;
+    let deepest = document.body;
+    for (let i = 0; i < DEPTH; i++) {
+      const child = document.createElement("div");
+      deepest.appendChild(child);
+      deepest = child;
+    }
+
+    bench.add(`isConnected: depth ${DEPTH}`, () => {
+      deepest.isConnected; // eslint-disable-line no-unused-expressions
+    });
+  }
+
+  // Append + remove at depth.
+  // Tests nodeRoot calls during tree mutation operations (slot checks, etc.).
+  // The parent's root doesn't change, so caching should help.
+  {
+    const DEPTH = 200;
+    const { document } = (new JSDOM()).window;
+    let parent = document.body;
+    for (let i = 0; i < DEPTH; i++) {
+      const child = document.createElement("div");
+      parent.appendChild(child);
+      parent = child;
+    }
+
+    bench.add(`appendChild+removeChild: at depth ${DEPTH}`, () => {
+      const child = document.createElement("div");
+      parent.appendChild(child);
+      parent.removeChild(child);
+    });
+  }
+
+  return bench;
+};

--- a/lib/jsdom/living/helpers/node.js
+++ b/lib/jsdom/living/helpers/node.js
@@ -21,11 +21,51 @@ function nodeLength(node) {
 
 // https://dom.spec.whatwg.org/#concept-tree-root
 function nodeRoot(node) {
-  while (domSymbolTree.parent(node)) {
-    node = domSymbolTree.parent(node);
+  if (node._cachedRoot !== null) {
+    return node._cachedRoot;
   }
 
-  return node;
+  // First pass: walk upward to find the root. This only advances `root`; intermediate nodes are not cached yet.
+  let root = node;
+  let parent;
+  while ((parent = domSymbolTree.parent(root))) {
+    if (parent._cachedRoot !== null) {
+      // Short-circuit: an ancestor already has a cached root, so we don't need to walk further — the ancestor's
+      // cached root is our root too. We can skip the second pass below because the ancestor's cache was itself set
+      // by a previous second pass (or short-circuit), meaning it already points at the tree's actual root.
+      const cachedRoot = parent._cachedRoot;
+      let current = node;
+      while (current !== parent) {
+        current._cachedRoot = cachedRoot;
+        current = domSymbolTree.parent(current);
+      }
+      return cachedRoot;
+    }
+    root = parent;
+  }
+
+  // Second pass (path compression): walk the same path again to cache every intermediate node. This makes the first
+  // call ~2x more expensive, but subsequent calls from any node on this path become O(1).
+  //
+  // We only cache when the root is a Document. Cache invalidation is piggybacked on the existing descendants loop in
+  // Node-impl.js's _remove(), which is gated on `this.isConnected`. That gate is true exactly when the tree is rooted
+  // at a Document (via shadowIncludingRoot). So Document-rooted caches are always properly invalidated on removal.
+  //
+  // Non-Document roots — standalone elements, DocumentFragments, and even ShadowRoots on disconnected hosts — don't
+  // get this invalidation, so caching them would produce stale entries. This is fine in practice: disconnected trees
+  // are typically being built up (write-heavy), so caching wouldn't help much anyway. Connected ShadowRoots *could*
+  // be cached safely (their host's `isConnected` is true, so removal would invalidate), but distinguishing connected
+  // vs. disconnected ShadowRoots here adds complexity for little gain.
+  if (root.nodeType === NODE_TYPE.DOCUMENT_NODE) {
+    let current = node;
+    while (current !== root) {
+      current._cachedRoot = root;
+      current = domSymbolTree.parent(current);
+    }
+    root._cachedRoot = root;
+  }
+
+  return root;
 }
 
 // https://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -125,6 +125,7 @@ class NodeImpl extends EventTargetImpl {
     this._childNodesList = null;
     this._childrenList = null;
     this._version = 0;
+    this._cachedRoot = null;
     this._memoizedQueries = {};
     this._registeredObserverList = [];
     this._referencedRanges = new Set(); // Set of WeakRef<Range>
@@ -157,7 +158,7 @@ class NodeImpl extends EventTargetImpl {
   }
 
   getRootNode(options) {
-    return options.composed ? shadowIncludingRoot(this) : nodeRoot(this);
+    return options?.composed ? shadowIncludingRoot(this) : nodeRoot(this);
   }
 
   get nodeName() {
@@ -1119,6 +1120,7 @@ class NodeImpl extends EventTargetImpl {
     const oldNextSiblingImpl = domSymbolTree.nextSibling(nodeImpl);
 
     domSymbolTree.remove(nodeImpl);
+    nodeImpl._cachedRoot = null;
 
     if (nodeImpl._assignedSlot) {
       assignSlotable(nodeImpl._assignedSlot);
@@ -1153,6 +1155,7 @@ class NodeImpl extends EventTargetImpl {
       }
 
       for (const descendantImpl of shadowIncludingDescendantsIterator(nodeImpl)) {
+        descendantImpl._cachedRoot = null;
         if (descendantImpl._ceState === "custom") {
           enqueueCECallbackReaction(descendantImpl, "disconnectedCallback", []);
         }


### PR DESCRIPTION
Supersedes and closes #3671 with an improved caching strategy that avoids the regression seen there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)