### PR TITLE
Rewrite getElementById ID caching for tree-order correctness

### DIFF
--- a/benchmark/dom/get-element-by-id.js
+++ b/benchmark/dom/get-element-by-id.js
@@ -1,0 +1,85 @@
+"use strict";
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+module.exports = () => {
+  const bench = new Bench();
+
+  // Lookup by unique ID in a moderately-sized document.
+  // Best case for the cache: only one element with this ID, so get() returns the cached element directly.
+  {
+    const ELEMENTS = 1000;
+    const { document } = (new JSDOM()).window;
+    for (let i = 0; i < ELEMENTS; i++) {
+      const el = document.createElement("div");
+      el.id = `el-${i}`;
+      document.body.appendChild(el);
+    }
+
+    bench.add(`getElementById: unique ID among ${ELEMENTS}`, () => {
+      document.getElementById("el-500");
+    });
+  }
+
+  // Lookup when multiple elements share the same ID.
+  // Forces a tree-order walk each time, since the cache can't pin a single element.
+  {
+    const DUPLICATES = 10;
+    const ELEMENTS = 1000;
+    const { document } = (new JSDOM()).window;
+    for (let i = 0; i < ELEMENTS; i++) {
+      const el = document.createElement("div");
+      el.id = i < DUPLICATES ? "dup" : `el-${i}`;
+      document.body.appendChild(el);
+    }
+
+    bench.add(`getElementById: duplicate ID (${DUPLICATES}x) among ${ELEMENTS}`, () => {
+      document.getElementById("dup");
+    });
+  }
+
+  // Lookup after tree mutations: remove and re-add an element each iteration.
+  // Tests that cache invalidation (add/delete) doesn't introduce regressions in mutation-heavy workloads.
+  {
+    const ELEMENTS = 1000;
+    const { document } = (new JSDOM()).window;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    for (let i = 0; i < ELEMENTS; i++) {
+      const el = document.createElement("div");
+      el.id = `el-${i}`;
+      container.appendChild(el);
+    }
+    const target = document.getElementById("el-500");
+
+    bench.add(`getElementById after mutation: ${ELEMENTS} elements`, () => {
+      container.removeChild(target);
+      container.appendChild(target);
+      document.getElementById("el-500");
+    });
+  }
+
+  // Bulk insert then lookup: measures getElementById during DOM construction.
+  // Common pattern: build up a document, then query by ID.
+  {
+    const ELEMENTS = 200;
+    const { document } = (new JSDOM()).window;
+
+    bench.add(`bulk insert ${ELEMENTS} + getElementById`, () => {
+      const frag = document.createDocumentFragment();
+      for (let i = 0; i < ELEMENTS; i++) {
+        const el = document.createElement("div");
+        el.id = `item-${i}`;
+        frag.appendChild(el);
+      }
+      document.body.appendChild(frag);
+      document.getElementById("item-100");
+    }, {
+      afterEach() {
+        document.body.innerHTML = "";
+      }
+    });
+  }
+
+  return bench;
+};

--- a/lib/jsdom/living/helpers/by-id-cache.js
+++ b/lib/jsdom/living/helpers/by-id-cache.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const NODE_TYPE = require("../node-type");
+const { domSymbolTree } = require("./internal-constants");
+
+// For use in implementing getElementById(). Notably it ensures that when you get the result, you will always get the
+// first in tree order, not the most- or least-recently-inserted. Somewhat modeled after
+// https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/tree_ordered_map.h.
+
+module.exports = class ByIdCache {
+  constructor(root) {
+    this._root = root;
+
+    // Keys are IDs (strings).
+    // Values are `{ element, count }` tuples, where `element` can be `null` indicating we need to recompute.
+    // `count` tracks the count of times `add()` was called for this ID. We need to track it because it lets us
+    // determine what to do when calling `delete()`: a count of 0 means we can remove the entry, whereas any other
+    // count means we need to set `element` to `null` for future recomputation.
+    this._map = new Map();
+  }
+
+  add(id, element) {
+    const value = this._map.get(id);
+    if (!value) {
+      this._map.set(id, { element, count: 1 });
+    } else {
+      value.element = null;
+      ++value.count;
+    }
+  }
+
+  delete(id, element) {
+    const value = this._map.get(id);
+    if (!value) {
+      return;
+    }
+
+    --value.count;
+    if (value.count === 0) {
+      this._map.delete(id);
+    } else if (value.element === element) {
+      value.element = null;
+    }
+  }
+
+  get(id) {
+    const value = this._map.get(id);
+    if (!value) {
+      return null;
+    }
+
+    if (value.element) {
+      return value.element;
+    }
+
+    for (const descendant of domSymbolTree.treeIterator(this._root)) {
+      if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE && descendant.getAttributeNS(null, "id") === id) {
+        value.element = descendant;
+        return descendant;
+      }
+    }
+
+    // If we didn't find any elements for this key, we can remove it.
+    this._map.delete(id);
+    return null;
+  }
+};

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -69,6 +69,7 @@ const RequestManager = require("../../browser/resources/request-manager");
 const AsyncResourceQueue = require("../../browser/resources/async-resource-queue");
 const ResourceQueue = require("../../browser/resources/resource-queue");
 const PerDocumentResourceLoader = require("../../browser/resources/per-document-resource-loader");
+const ByIdCache = require("../helpers/by-id-cache");
 
 function clearChildNodes(node) {
   for (let child = domSymbolTree.firstChild(node); child; child = domSymbolTree.firstChild(node)) {
@@ -143,7 +144,7 @@ class DocumentImpl extends NodeImpl {
 
     this._defaultView = privateData.options.defaultView || null;
     this._global = privateData.options.global;
-    this._ids = Object.create(null);
+    this._byIdCache = new ByIdCache(this);
     this._attached = true;
     this._currentScript = null;
     this._pageShowingFlag = false;
@@ -426,23 +427,9 @@ class DocumentImpl extends NodeImpl {
     this.write(...args, "\n");
   }
 
-  // This is implemented separately for Document (which has a _ids cache) and DocumentFragment (which does not).
+  // This is implemented separately for Document (which has a _byIdCache) and DocumentFragment (which does not).
   getElementById(id) {
-    if (!this._ids[id]) {
-      return null;
-    }
-
-    // Let's find the first element with where it's root is the document.
-    const matchElement = this._ids[id].find(candidate => {
-      let root = candidate;
-      while (domSymbolTree.parent(root)) {
-        root = domSymbolTree.parent(root);
-      }
-
-      return root === this;
-    });
-
-    return matchElement || null;
+    return this._byIdCache.get(id);
   }
 
   get referrer() {

--- a/lib/jsdom/living/nodes/DocumentFragment-impl.js
+++ b/lib/jsdom/living/nodes/DocumentFragment-impl.js
@@ -20,7 +20,7 @@ class DocumentFragmentImpl extends NodeImpl {
     this.nodeType = NODE_TYPE.DOCUMENT_FRAGMENT_NODE;
   }
 
-  // This is implemented separately for Document (which has a _ids cache) and DocumentFragment (which does not).
+  // This is implemented separately for Document (which has a _byIdCache) and DocumentFragment (which does not).
   getElementById(id) {
     if (id === "") {
       return null;

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -25,32 +25,6 @@ const Text = require("../../../generated/idl/Text");
 const { isValidHostElementName } = require("../helpers/shadow-dom");
 const { isValidCustomElementName, lookupCEDefinition } = require("../helpers/custom-elements");
 
-function attachId(id, elm, doc) {
-  if (id && elm && doc) {
-    if (!doc._ids[id]) {
-      doc._ids[id] = [];
-    }
-    doc._ids[id].push(elm);
-  }
-}
-
-function detachId(id, elm, doc) {
-  if (id && elm && doc) {
-    if (doc._ids && doc._ids[id]) {
-      const elms = doc._ids[id];
-      for (let i = 0; i < elms.length; i++) {
-        if (elms[i] === elm) {
-          elms.splice(i, 1);
-          --i;
-        }
-      }
-      if (elms.length === 0) {
-        delete doc._ids[id];
-      }
-    }
-  }
-}
-
 class ElementImpl extends NodeImpl {
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
@@ -84,7 +58,7 @@ class ElementImpl extends NodeImpl {
 
     const id = this.getAttributeNS(null, "id");
     if (id) {
-      attachId(id, this, this._ownerDocument);
+      this._ownerDocument._byIdCache.add(id, this);
     }
 
     // If the element is initially in an HTML document but is later
@@ -101,7 +75,7 @@ class ElementImpl extends NodeImpl {
 
     const id = this.getAttributeNS(null, "id");
     if (id) {
-      detachId(id, this, this._ownerDocument);
+      this._ownerDocument._byIdCache.delete(id, this);
     }
   }
 
@@ -111,9 +85,13 @@ class ElementImpl extends NodeImpl {
     windowProperties.elementAttributeModified(this, name, value, oldValue);
 
     if (name === "id" && this._attached) {
-      const doc = this._ownerDocument;
-      detachId(oldValue, this, doc);
-      attachId(value, this, doc);
+      const cache = this._ownerDocument._byIdCache;
+      if (oldValue) {
+        cache.delete(oldValue, this);
+      }
+      if (value) {
+        cache.add(value, this);
+      }
     }
 
     // update classList

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -1146,7 +1146,9 @@ class NodeImpl extends EventTargetImpl {
     }
 
     this._modified();
-    nodeImpl._detach();
+    if (nodeImpl._attached) {
+      nodeImpl._detach();
+    }
     this._descendantRemoved(this, nodeImpl);
 
     if (this.isConnected) {

--- a/lib/jsdom/living/nodes/SVGSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/SVGSVGElement-impl.js
@@ -15,8 +15,10 @@ class SVGSVGElementImpl extends SVGGraphicsElementImpl {
     return SVGRect.createImpl(this._globalObject, [], {});
   }
 
+  // Unlike `Document`'s `getElementById()`, this searches within this element's subtree, so the document-level
+  // `ByIdCache` can't be used (it might return an element outside this subtree). A per-`<svg>` cache isn't worthwhile
+  // since `SVGSVGElement`'s `getElementById()` is rarely called and `<svg>` subtrees are typically small.
   getElementById(elementId) {
-    // TODO: optimize with _ids caching trick; see Document class.
     for (const node of domSymbolTree.treeIterator(this)) {
       if (node.nodeType === ELEMENT_NODE && node.getAttributeNS(null, "id") === elementId) {
         return node;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -916,7 +916,6 @@ Document-createEvent.https.html:
   "createEvent('textevent') should be initialized correctly.": [fail, Interface not implemented]
   "TEXTEVENT should be an alias for TextEvent.": [fail, Interface not implemented]
   "createEvent('TEXTEVENT') should be initialized correctly.": [fail, Interface not implemented]
-Document-getElementById.html: [fail, We cache IDs in insertion order]
 Element-firstElementChild-entity-xhtml.xhtml: [fail, Unknown]
 Element-firstElementChild-entity.svg: [fail, Unknown]
 Element-getElementsByTagName-change-document-HTMLNess.html: [fail, Unknown]


### PR DESCRIPTION
Supersedes #3668 with improvements: fixes a null-ID leak in `_attrModified`, avoids orphaned map entries in `delete()`, and adds an `getElementById` benchmark suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)