### PR TITLE
Fix potential sync XHR worker hang from unhandled dispatch errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ npm run test:wpt -- --fgrep "some-test.htm" 2>&1              # Just run it, no 
 
 All these commands can be restricted to specific tests, e.g. `npm run test:tuwpt -- --fgrep css-borders` or `npm run test:wpt -- --fgrep WebSocket/readyState/006.html`. It is often best to run a single test in that latter fashion while iterating, before finally running a larger suite like `npm run test:wpt -- --fgrep xhr` or `npm run test:tuwpt`.
 
+**IMPORTANT:** The `--fgrep` value is a plain substring match against test titles, NOT a file path. Do not include trailing slashes (e.g. use `--fgrep xhr`, not `--fgrep "xhr/"`).
+
 ## npm scripts
 
 Always use the project's npm scripts rather than running tools directly. Use `npm run lint` instead of `npx eslint`, `npm run test:api` instead of `npx mocha test/api`, etc. The scripts have specific configurations.

--- a/lib/jsdom/browser/resources/jsdom-dispatcher.js
+++ b/lib/jsdom/browser/resources/jsdom-dispatcher.js
@@ -89,8 +89,13 @@ class JSDOMDispatcher extends Dispatcher {
       return this.#dispatchFileURL(urlRecord, wrappedHandler);
     }
 
-    // HTTP(S) - handles redirects, CORS, preflight, and WebSocket upgrades
-    this.#dispatchHTTP(urlRecord, wrappedHandler, opts);
+    // HTTP(S) - handles redirects, CORS, preflight, and WebSocket upgrades.
+    // #dispatchHTTP is async but we can't await it here (dispatch() must be sync per the undici Dispatcher API).
+    // Catch rejections so that errors (e.g. from the undici dispatch chain throwing) are forwarded to the handler
+    // instead of becoming unhandled rejections that silently prevent the response promise from ever resolving.
+    this.#dispatchHTTP(urlRecord, wrappedHandler, opts).catch(err => {
+      wrappedHandler.onResponseError?.(null, err);
+    });
     return true;
   }
 

--- a/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
+++ b/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
@@ -768,15 +768,6 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
 
           // Stream the response body
           if (response.body) {
-            let rawBytesReceived = 0;
-
-            // Body is already decompressed by the decompress interceptor.
-            // Track bytes for progress as they arrive.
-            response.body.on("data", chunk => {
-              rawBytesReceived += chunk.length;
-              progressObj.loaded = rawBytesReceived;
-            });
-
             for await (const chunk of response.body) {
               // Check if aborted
               if (abortController.signal.aborted) {
@@ -804,11 +795,10 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
               }
               fireAnEvent("readystatechange", this);
 
-              if (progressObj.total !== progressObj.loaded || this._totalReceivedChunkSize === rawBytesReceived) {
-                if (lastProgressReported !== progressObj.loaded) {
-                  lastProgressReported = progressObj.loaded;
-                  fireAnEvent("progress", this, ProgressEvent, progressObj);
-                }
+              progressObj.loaded = this._totalReceivedChunkSize;
+              if (lastProgressReported !== progressObj.loaded) {
+                lastProgressReported = progressObj.loaded;
+                fireAnEvent("progress", this, ProgressEvent, progressObj);
               }
             }
           }


### PR DESCRIPTION
Catch rejections from `#dispatchHTTP()` in `JSDOMDispatcher.dispatch()` to prevent sync XHR worker hangs, and simplify XHR progress tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)