### PR TITLE
Split rule processing into handleRule() and handleStyle()

### DIFF
--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -152,10 +152,7 @@ function prepareComputedStyleDeclaration(elementImpl, { styleCache }) {
   applyStyleSheetRules(elementImpl, declaration);
 
   for (let i = 0; i < style.length; i++) {
-    const property = style.item(i);
-    const value = style.getPropertyValue(property);
-    const priority = style.getPropertyPriority(property);
-    handlePropertyForInlineStyle(property, value, priority, declaration);
+    handlePropertyForInlineStyle(style.item(i), declaration, style);
   }
 
   styleCache.set(elementImpl, declaration);
@@ -186,27 +183,26 @@ function applyStyleSheetRules(elementImpl, declaration) {
 
 function handleSheet(sheet, elementImpl, declaration, specificities) {
   for (const rule of sheet.cssRules) {
-    const { constructor, cssRules, media, styleSheet } = rule;
-    if (media) {
+    if (rule.media) {
       let hasMediaScreen = false;
-      for (let i = 0; i < media.length; i++) {
-        hasMediaScreen = media[i] === "screen";
+      for (let i = 0; i < rule.media.length; i++) {
+        hasMediaScreen = rule.media[i] === "screen";
         if (hasMediaScreen) {
           break;
         }
       }
-      if (constructor.name === "CSSImportRule") {
+      if (rule.constructor.name === "CSSImportRule") {
         // Handle @import rules if:
         // - imported sheet loaded successfully
         // - media is empty or matches "screen"
-        if (styleSheet !== null && (media.length === 0 || hasMediaScreen)) {
-          for (const innerRule of styleSheet.cssRules) {
+        if (rule.styleSheet !== null && (rule.media.length === 0 || hasMediaScreen)) {
+          for (const innerRule of rule.styleSheet.cssRules) {
             handleRule(innerRule, elementImpl, declaration, specificities);
           }
         }
         // Keep handling @media rules only if media matches "screen"
       } else if (hasMediaScreen) {
-        for (const innerRule of cssRules) {
+        for (const innerRule of rule.cssRules) {
           handleRule(innerRule, elementImpl, declaration, specificities);
         }
       }
@@ -217,23 +213,22 @@ function handleSheet(sheet, elementImpl, declaration, specificities) {
 }
 
 function handleRule(rule, elementImpl, declaration, specificities) {
-  const { selectorText } = rule;
-  const { ast, match } = matches(selectorText, elementImpl);
+  const { ast, match } = matches(rule.selectorText, elementImpl);
   if (match) {
-    handleStyle(rule.style, declaration, specificities, ast ?? selectorText);
+    handleStyle(rule.style, declaration, specificities, ast);
   }
 }
 
 function handleStyle(style, declaration, specificities, ast) {
   for (let i = 0; i < style.length; i++) {
     const property = style[i];
-    const value = style.getPropertyValue(property);
-    const priority = style.getPropertyPriority(property);
-    handleProperty(property, value, priority, declaration, specificities, ast);
+    handleProperty(property, declaration, style, specificities, ast);
   }
 }
 
-function handleProperty(property, value, priority, declaration, specificities, ast) {
+function handleProperty(property, declaration, style, specificities, ast) {
+  const value = style.getPropertyValue(property);
+  const priority = style.getPropertyPriority(property);
   if (priority) {
     declaration.setProperty(property, value, priority);
   } else if (!declaration.getPropertyPriority(property)) {
@@ -250,7 +245,9 @@ function handleProperty(property, value, priority, declaration, specificities, a
   }
 }
 
-function handlePropertyForInlineStyle(property, value, priority, declaration) {
+function handlePropertyForInlineStyle(property, declaration, style) {
+  const value = style.getPropertyValue(property);
+  const priority = style.getPropertyPriority(property);
   if (!declaration.getPropertyPriority(property) || priority) {
     declaration.setProperty(property, value, priority);
   }


### PR DESCRIPTION
* <del>Fixed potential bug regarding AST.</del>
  <ins>Will add fix on dom-selector side.</ins>
* <del>Passing property, value, and priority to the style handlers.</del>
* <del>Simplify rule traversal by destructuring rule fields so `media`/`@import`/`@media` branches correctly process nested cssRules, and reduce repeated matches()/handleRule() code paths.</del>
* Split rule processing into handleRule() and handleStyle(); matches() now accepts selectorText, and then handleStyle() applies.
* <del>Overall cleanup improves clarity and fixes inconsistencies in how properties and priorities were extracted and applied.</del>
