### PR TITLE
Skip response-body-errors.any.html test on Node.js v20

### DIFF
--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -2510,6 +2510,7 @@ progressevent-constructor.html:
   "Mixed integer and decimal number test.": [fail, Unknown]
   "Negative number.": [fail, Unknown]
 request-content-length.any.html: [fail, needs URL.createObjectURL]
+response-body-errors.any.html: [skip-node:20.x, "XHR worker timeouts seem to occur, so far only on Node v20? Monitor this..."]
 response-method.htm: [flaky, Usually fails with a parse error in Node.js v12 but occasionally passes as it did in previous versions]
 responseType-document-in-worker.html: [fail, Needs Worker implementation]
 responseXML-unavailable-in-worker.html: [fail, Needs Worker implementation]


### PR DESCRIPTION
As seen from recent CI runs, 5fbfde654e32c7da63f7d64a27deddcfcbe5188b did not manage to fix this. For now, only disable on Node.js v20, which is where the problem has been seen so far. If it occurs on other versions in the future, then we should investigate in more detail.

Part of #4062.