### PR TITLE
Fix a potential race in the sync XHR worker

### DIFF
--- a/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
+++ b/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
@@ -53,22 +53,52 @@ function getSyncWorker() {
 
 const SYNC_WORKER_TIMEOUT_MS = 2 * 60 * 1000;
 
+// How long to wait for the worker to acknowledge it received our message. This detects the race
+// where the worker called process.exit() (idle timeout) but the main thread hasn't processed the
+// exit event yet — so getSyncWorker() returns a dead worker and postMessage() silently succeeds
+// but the message is never delivered.
+const SYNC_WORKER_ACK_TIMEOUT_MS = 5000;
+
 // Sends a serialized XHR request to the persistent worker thread and synchronously blocks
-// until it responds. The synchronization works as follows:
+// until it responds. Uses a two-phase protocol:
 //
-// - A SharedArrayBuffer is shared between the main thread and the worker, used as a signal.
-// - Atomics.wait() blocks the main thread until the worker writes to the shared buffer.
-// - The worker does the actual async fetch, then posts the response via a MessagePort and
-//   signals completion by writing to the SharedArrayBuffer with Atomics.store()/notify().
-// - After waking, receiveMessageOnPort() synchronously reads the response from the port.
+// 1. Ack phase: the worker writes 1 to sharedBuffer[0] immediately upon receiving the message.
+//    If this times out, the worker is assumed dead and we retry with a fresh worker.
+// 2. Done phase: the worker writes 1 to sharedBuffer[1] after posting the response to the
+//    MessagePort. After waking, receiveMessageOnPort() synchronously reads the response.
 function sendSyncWorkerRequest(config) {
-  const sharedBuffer = new SharedArrayBuffer(4);
+  const result = trySendSyncWorkerRequest(config, SYNC_WORKER_ACK_TIMEOUT_MS);
+  if (result !== null) {
+    return result;
+  }
+
+  // Ack timed out — worker likely dead from idle timeout race. Terminate and retry.
+  syncWorker?.terminate();
+  syncWorker = null;
+
+  const retryResult = trySendSyncWorkerRequest(config, SYNC_WORKER_TIMEOUT_MS);
+  if (retryResult !== null) {
+    return retryResult;
+  }
+
+  throw new Error("Sync XHR worker timed out");
+}
+
+function trySendSyncWorkerRequest(config, ackTimeout) {
+  const sharedBuffer = new SharedArrayBuffer(8);
   const int32 = new Int32Array(sharedBuffer);
   const { port1, port2 } = new MessageChannel();
 
   getSyncWorker().postMessage({ sharedBuffer, responsePort: port2, config }, [port2]);
 
-  const waitResult = Atomics.wait(int32, 0, 0, SYNC_WORKER_TIMEOUT_MS);
+  // Phase 1: wait for the worker to acknowledge receipt.
+  const ackResult = Atomics.wait(int32, 0, 0, ackTimeout);
+  if (ackResult === "timed-out") {
+    return null;
+  }
+
+  // Phase 2: wait for the actual response.
+  const waitResult = Atomics.wait(int32, 1, 0, SYNC_WORKER_TIMEOUT_MS);
   if (waitResult === "timed-out") {
     throw new Error("Sync XHR worker timed out");
   }

--- a/lib/jsdom/living/xhr/xhr-sync-worker.js
+++ b/lib/jsdom/living/xhr/xhr-sync-worker.js
@@ -5,11 +5,13 @@
 // thread, which blocks on Atomics.wait() until we signal completion. A single JSDOM instance is
 // created at startup and reused across requests to avoid the ~400ms initialization cost each time.
 //
-// The signaling protocol (shared with sendSyncWorkerRequest in XMLHttpRequest-impl.js):
-// 1. Main thread sends us a SharedArrayBuffer, a MessagePort, and the serialized request config.
-// 2. We perform the XHR asynchronously.
-// 3. When done, we post the serialized response to the MessagePort, then signal the main thread
-//    by writing 1 to the SharedArrayBuffer with Atomics.store() and waking it with Atomics.notify().
+// The signaling protocol uses a SharedArrayBuffer with two Int32 slots:
+//   [0] = ack:  worker writes 1 here immediately upon receiving the message
+//   [1] = done: worker writes 1 here after the response is ready
+//
+// The ack slot lets the main thread detect the race condition where the worker has exited (idle
+// timeout) but the main thread hasn't processed the exit event yet. See sendSyncWorkerRequest()
+// in XMLHttpRequest-impl.js for the main-thread side.
 
 const { parentPort } = require("node:worker_threads");
 const { JSDOM } = require("../../../..");
@@ -26,6 +28,10 @@ parentPort.on("message", ({ sharedBuffer, responsePort, config }) => {
 
   const int32 = new Int32Array(sharedBuffer);
 
+  // Acknowledge receipt so the main thread knows we're alive.
+  Atomics.store(int32, 0, 1);
+  Atomics.notify(int32, 0);
+
   const xhr = new dom.window.XMLHttpRequest();
   const xhrImpl = idlUtils.implForWrapper(xhr);
   xhrImpl._adoptSerializedRequest(config);
@@ -34,8 +40,8 @@ parentPort.on("message", ({ sharedBuffer, responsePort, config }) => {
     const response = xhrImpl._serializeResponse();
     const transfer = response.responseBytes ? [response.responseBytes.buffer] : [];
     responsePort.postMessage(response, transfer);
-    Atomics.store(int32, 0, 1);
-    Atomics.notify(int32, 0);
+    Atomics.store(int32, 1, 1);
+    Atomics.notify(int32, 1);
 
     idleTimer = setTimeout(() => process.exit(0), IDLE_TIMEOUT_MS);
     idleTimer.unref();


### PR DESCRIPTION
Adds a two-phase ack protocol to detect and recover from the race where the sync XHR worker has exited (idle timeout) but the main thread hasn't processed the exit event yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)