### PR TITLE
Update ESLint toolchain, fix XHR JSON response bug, and raise minimum Node.js

### DIFF
--- a/.github/workflows/jsdom-ci.yml
+++ b/.github/workflows/jsdom-ci.yml
@@ -14,10 +14,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Install dependencies
@@ -30,10 +30,10 @@ jobs:
       TEST_SUITE: 'node-canvas'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Install required image manipulation packages with APT
@@ -54,16 +54,16 @@ jobs:
           # Explicitly test minimum Node.js versions. Keep in sync with package.json.
           - 20.19.0
           - 20
-          - 22.12.0
+          - 22.13.0
           - 22
           - 24.0.0
           - lts/*   # currently 24
           - latest  # currently 25
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - name: Setup hosts file for web platform tests server

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,9 @@
 import domenicConfig from "@domenic/eslint-config";
+import domenicStylistic from "@domenic/eslint-config/stylistic";
 import globals from "globals";
 import html from "eslint-plugin-html";
-import n from "eslint-plugin-n";
 import jsdomInternal from "./scripts/eslint-plugin/index.mjs";
+import n from "eslint-plugin-n";
 
 export default [
   {
@@ -33,13 +34,15 @@ export default [
     }
   },
   ...domenicConfig,
+  ...domenicStylistic,
   {
     plugins: {
       "jsdom-internal": jsdomInternal
     },
     rules: {
       // Overrides for jsdom
-      "array-element-newline": "off",
+      "@stylistic/array-element-newline": "off",
+      "no-await-in-loop": "off",
       "no-implied-eval": "off",
       "no-invalid-this": "off",
       "require-unicode-regexp": "off",
@@ -166,7 +169,7 @@ export default [
       }
     },
     rules: {
-      "padded-blocks": "off", // we like to add spaces around the main test block
+      "@stylistic/padded-blocks": "off", // we like to add spaces around the main test block
       "camelcase": "off", // setting options like allow_uncaught_exception requires this
       "no-implicit-globals": "off", // it doesn't much matter if we use top-level function declarations here
       "new-cap": [

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -208,7 +208,7 @@ class EventTargetImpl {
       const clearTargetsStruct = eventImpl._path[clearTargetsStructIndex];
 
       clearTargets =
-          (isNode(clearTargetsStruct.target) && isShadowRoot(nodeRoot(clearTargetsStruct.target))) ||
+        (isNode(clearTargetsStruct.target) && isShadowRoot(nodeRoot(clearTargetsStruct.target))) ||
           (isNode(clearTargetsStruct.relatedTarget) && isShadowRoot(nodeRoot(clearTargetsStruct.relatedTarget)));
 
       if (activationTarget !== null && activationTarget._legacyPreActivationBehavior) {

--- a/lib/jsdom/living/helpers/create-element.js
+++ b/lib/jsdom/living/helpers/create-element.js
@@ -182,7 +182,7 @@ function createElement(
   isValue = null,
   synchronousCE = false
 ) {
-  let result = null;
+  let result;
 
   const { _globalObject } = document;
   const definition = lookupCEDefinition(document, namespace, localName, isValue);

--- a/lib/jsdom/living/helpers/focusing.js
+++ b/lib/jsdom/living/helpers/focusing.js
@@ -26,7 +26,7 @@ exports.isFocusableAreaElement = elImpl => {
       return false;
     }
 
-    if (!Number.isNaN(parseInt(elImpl.getAttributeNS(null, "tabindex")))) {
+    if (!Number.isNaN(parseInt(elImpl.getAttributeNS(null, "tabindex"), 10))) {
       return true;
     }
 
@@ -64,7 +64,7 @@ exports.isFocusableAreaElement = elImpl => {
   }
 
   if (elImpl._namespaceURI === SVG_NS) {
-    if (!Number.isNaN(parseInt(elImpl.getAttributeNS(null, "tabindex"))) && isRenderedElement(elImpl)) {
+    if (!Number.isNaN(parseInt(elImpl.getAttributeNS(null, "tabindex"), 10)) && isRenderedElement(elImpl)) {
       return true;
     }
 

--- a/lib/jsdom/living/helpers/runtime-script-errors.js
+++ b/lib/jsdom/living/helpers/runtime-script-errors.js
@@ -54,8 +54,8 @@ module.exports = function reportException(window, error, filenameHint) {
   }
 
   const fileName = (pieces && pieces[2]) || filenameHint || window._document.URL;
-  const lineNumber = (pieces && parseInt(pieces[3])) || 0;
-  const columnNumber = (pieces && parseInt(pieces[4])) || 0;
+  const lineNumber = (pieces && parseInt(pieces[3], 10)) || 0;
+  const columnNumber = (pieces && parseInt(pieces[4], 10)) || 0;
 
   const windowImpl = idlUtils.implForWrapper(window);
 

--- a/lib/jsdom/living/helpers/strings.js
+++ b/lib/jsdom/living/helpers/strings.js
@@ -80,7 +80,7 @@ const parseInteger = exports.parseInteger = input => {
     return null;
   }
   // We don't allow hexadecimal numbers here.
-  // eslint-disable-next-line radix
+
   const value = parseInt(input, 10);
   if (Number.isNaN(value)) {
     return null;

--- a/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
@@ -7,7 +7,7 @@ const { Canvas } = require("../../utils");
 class HTMLCanvasElementImpl extends HTMLElementImpl {
   _attrModified(name, value, oldValue) {
     if (this._canvas && (name === "width" || name === "height")) {
-      this._canvas[name] = parseInt(value);
+      this._canvas[name] = parseInt(value, 10);
     }
 
     super._attrModified(name, value, oldValue);
@@ -94,7 +94,7 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
   }
 
   get width() {
-    const parsed = parseInt(this.getAttributeNS(null, "width"));
+    const parsed = parseInt(this.getAttributeNS(null, "width"), 10);
     return isNaN(parsed) || parsed < 0 || parsed > 2147483647 ? 300 : parsed;
   }
 
@@ -104,7 +104,7 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
   }
 
   get height() {
-    const parsed = parseInt(this.getAttributeNS(null, "height"));
+    const parsed = parseInt(this.getAttributeNS(null, "height"), 10);
     return isNaN(parsed) || parsed < 0 || parsed > 2147483647 ? 150 : parsed;
   }
 

--- a/lib/jsdom/living/nodes/HTMLOListElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOListElement-impl.js
@@ -4,7 +4,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
 class HTMLOListElementImpl extends HTMLElementImpl {
   get start() {
-    const value = parseInt(this.getAttributeNS(null, "start"));
+    const value = parseInt(this.getAttributeNS(null, "start"), 10);
 
     if (!isNaN(value)) {
       return value;

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -385,7 +385,7 @@ class NodeImpl extends EventTargetImpl {
     let node2 = this;
 
     let attr1 = null;
-    let attr2 = null;
+    let attr2;
 
     if (node1.nodeType === NODE_TYPE.ATTRIBUTE_NODE) {
       attr1 = node1;

--- a/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
+++ b/lib/jsdom/living/xhr/XMLHttpRequest-impl.js
@@ -161,8 +161,8 @@ function requestErrorSteps(xhr, event, exception) {
 function setResponseToNetworkError(xhr) {
   xhr._responseBytes =
     xhr._responseCache =
-    xhr._responseTextCache =
-    xhr._responseXMLCache = null;
+      xhr._responseTextCache =
+        xhr._responseXMLCache = null;
 
   xhr._responseHeaders = new HeaderList();
   xhr.status = 0;
@@ -284,6 +284,7 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
       case "json": {
         if (this.readyState !== READY_STATES.DONE || !responseBytes) {
           res = null;
+          break;
         }
 
         try {
@@ -336,11 +337,10 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
 
     const contentType = finalMIMEType(this);
     let isHTML = false;
-    let isXML = false;
     const parsed = MIMEType.parse(contentType);
     if (parsed) {
       isHTML = parsed.isHTML();
-      isXML = parsed.isXML();
+      const isXML = parsed.isXML();
       if (!isXML && !isHTML) {
         return null;
       }
@@ -659,7 +659,7 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
         throw DOMException.create(this._globalObject, [this._error, "NetworkError"]);
       } else {
         const contentLength = this._responseHeaders.get("content-length") || "0";
-        const byteLength = parseInt(contentLength) || this._responseBytes.length;
+        const byteLength = parseInt(contentLength, 10) || this._responseBytes.length;
         const progressObj = { lengthComputable: false };
         if (byteLength !== 0) {
           progressObj.total = byteLength;
@@ -778,7 +778,7 @@ class XMLHttpRequestImpl extends XMLHttpRequestEventTargetImpl {
           // so lengthComputable must be false (method b from the XHR spec)
           const contentEncoding = headers.get("content-encoding");
           const contentLength = headers.get("content-length") || "0";
-          const bufferLength = parseInt(contentLength) || 0;
+          const bufferLength = parseInt(contentLength, 10) || 0;
           const progressObj = { lengthComputable: false, loaded: 0, total: 0 };
           if (bufferLength !== 0 && !contentEncoding) {
             progressObj.total = bufferLength;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,8 +32,9 @@
         "xml-name-validator": "^5.0.0"
       },
       "devDependencies": {
-        "@domenic/eslint-config": "^4.1.0",
-        "eslint": "^9.39.4",
+        "@domenic/eslint-config": "^5.0.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
+        "eslint": "^10.0.3",
         "eslint-plugin-html": "^8.1.4",
         "eslint-plugin-n": "^17.24.0",
         "globals": "^17.4.0",
@@ -245,13 +246,19 @@
       }
     },
     "node_modules/@domenic/eslint-config": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@domenic/eslint-config/-/eslint-config-4.1.0.tgz",
-      "integrity": "sha512-I9CLi2qmin09ZnmRIGYu1703pr4/TqMlSbromGgRWHlu78nk44O+Sx0I/OPRHkiTvuThYYSYw6UtJ9NdmNi2GA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@domenic/eslint-config/-/eslint-config-5.0.1.tgz",
+      "integrity": "sha512-q/7IOn/iLjxmTS2fUVJJCbxcvY+xRjWgw33a3MWoLg2zcz6p4DmcgD1Sxv9iamXPcjR6P8pOEJdnh9gkmQRO0w==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "eslint": "^9.7.0"
+        "@stylistic/eslint-plugin": "^5.10.0",
+        "eslint": "^10.0.3"
+      },
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -297,180 +304,68 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.1.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -571,6 +466,34 @@
         "node": ">=14"
       }
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -584,6 +507,20 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -708,16 +645,6 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
@@ -860,13 +787,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1116,33 +1036,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1152,8 +1069,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1161,7 +1077,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1267,17 +1183,19 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1296,35 +1214,35 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+    "node_modules/eslint/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
@@ -1696,23 +1614,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1901,13 +1802,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -2228,19 +2122,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -2442,16 +2323,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,9 @@
     }
   },
   "devDependencies": {
-    "@domenic/eslint-config": "^4.1.0",
-    "eslint": "^9.39.4",
+    "@domenic/eslint-config": "^5.0.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
+    "eslint": "^10.0.3",
     "eslint-plugin-html": "^8.1.4",
     "eslint-plugin-n": "^17.24.0",
     "globals": "^17.4.0",
@@ -94,6 +95,6 @@
   "main": "./lib/api.js",
   "type": "commonjs",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+    "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
   }
 }

--- a/test/assert-helpers.js
+++ b/test/assert-helpers.js
@@ -20,8 +20,7 @@ exports.assertThrowsDOMException = (fn, document, name) => {
     `expected #{this} to throw a window.DOMException with name '${name}' and code '${expectedCode}' but ` +
     (thrownError ?
       `#{act} was thrown with name '${thrownError.name}' and code '${thrownError.code}'` :
-      `nothing was thrown`)
-    ,
+      `nothing was thrown`),
     `expected #{this} to not throw a window.DOMException with name '${name}' and code '${expectedCode}'`
   );
 };

--- a/test/web-platform-tests/to-upstream/xhr/response-json-during-loading.html
+++ b/test/web-platform-tests/to-upstream/xhr/response-json-during-loading.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>XMLHttpRequest: response is null during LOADING for responseType json</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+async_test(t => {
+  const xhr = new XMLHttpRequest();
+  xhr.open("GET", "resources/json-with-bom.py");
+  xhr.responseType = "json";
+
+  let sawLoading = false;
+
+  xhr.onreadystatechange = t.step_func(() => {
+    if (xhr.readyState === XMLHttpRequest.LOADING) {
+      sawLoading = true;
+      assert_equals(xhr.response, null, "response must be null during LOADING for json responseType");
+    }
+
+    if (xhr.readyState === XMLHttpRequest.DONE) {
+      assert_true(sawLoading, "Should have seen LOADING state");
+      assert_not_equals(xhr.response, null, "response must not be null during DONE");
+      assert_equals(xhr.response.key, "value", "response must contain parsed JSON");
+      t.done();
+    }
+  });
+
+  xhr.onerror = t.unreached_func("XHR should not error");
+  xhr.send();
+}, "xhr.response must be null during LOADING state for responseType json");
+</script>

--- a/test/web-platform-tests/wpt-server.js
+++ b/test/web-platform-tests/wpt-server.js
@@ -59,7 +59,7 @@ async function pollForServer(url, lastLogTime = Date.now()) {
     await doHeadRequestWithNoCertChecking(url);
   } catch (err) {
     if (!subprocess) {
-      throw new Error("WPT server terminated");
+      throw new Error("WPT server terminated", { cause: err });
     }
 
     // Only log every 5 seconds to be less spammy.


### PR DESCRIPTION
Update `eslint` to v10, `@domenic/eslint-config` to v5.0.1, and add `@stylistic/eslint-plugin`. Fix all resulting lint errors.

One of the lint fixes (`no-useless-assignment`) uncovered a real bug: the `case "json"` branch in `XMLHttpRequest`'s `response` getter was missing a `break` after setting `res = null` for the non-DONE/no-bytes early return. Without it, the code fell through to `parseJSONFromBytes`, causing `xhr.response` to return parsed JSON during the LOADING state instead of `null`. Added a to-upstream WPT test that fails before and passes after the fix.


🤖 Generated with [Claude Code](https://claude.com/claude-code)