### PR TITLE
Replace manual attribute reflection with IDL reflection

### DIFF
--- a/lib/jsdom/living/helpers/shadow-dom.js
+++ b/lib/jsdom/living/helpers/shadow-dom.js
@@ -217,7 +217,7 @@ function findSlot(slotable, openFlag) {
   }
 
   for (const child of domSymbolTree.treeIterator(shadow)) {
-    if (isSlot(child) && child.name === slotable._slotableName) {
+    if (isSlot(child) && child._name === slotable._slotableName) {
       return child;
     }
   }

--- a/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
@@ -15,7 +15,8 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
 
   _getCanvas() {
     if (Canvas && !this._canvas) {
-      this._canvas = Canvas.createCanvas(this.width, this.height);
+      const wrapper = idlUtils.wrapperForImpl(this);
+      this._canvas = Canvas.createCanvas(wrapper.width, wrapper.height);
     }
     return this._canvas;
   }
@@ -91,26 +92,6 @@ class HTMLCanvasElementImpl extends HTMLElementImpl {
         "without installing the canvas npm package"
       );
     }
-  }
-
-  get width() {
-    const parsed = parseInt(this.getAttributeNS(null, "width"), 10);
-    return isNaN(parsed) || parsed < 0 || parsed > 2147483647 ? 300 : parsed;
-  }
-
-  set width(v) {
-    v = v > 2147483647 ? 300 : v;
-    this.setAttributeNS(null, "width", String(v));
-  }
-
-  get height() {
-    const parsed = parseInt(this.getAttributeNS(null, "height"), 10);
-    return isNaN(parsed) || parsed < 0 || parsed > 2147483647 ? 150 : parsed;
-  }
-
-  set height(v) {
-    v = v > 2147483647 ? 150 : v;
-    this.setAttributeNS(null, "height", String(v));
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLCanvasElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement.webidl
@@ -3,8 +3,8 @@ typedef (CanvasRenderingContext2D or WebGLRenderingContext) RenderingContext;
 [Exposed=Window,
  HTMLConstructor]
 interface HTMLCanvasElement : HTMLElement {
-  [CEReactions] attribute unsigned long width;
-  [CEReactions] attribute unsigned long height;
+  [CEReactions, Reflect, ReflectDefault=300] attribute unsigned long width;
+  [CEReactions, Reflect, ReflectDefault=150] attribute unsigned long height;
 
   RenderingContext? getContext(DOMString contextId, any... arguments);
 

--- a/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
@@ -80,18 +80,6 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
     }
   }
 
-  get defaultMuted() {
-    return this.getAttributeNS(null, "muted") !== null;
-  }
-
-  set defaultMuted(v) {
-    if (v) {
-      this.setAttributeNS(null, "muted", v);
-    } else {
-      this.removeAttributeNS(null, "muted");
-    }
-  }
-
   get volume() {
     return this._volume;
   }

--- a/lib/jsdom/living/nodes/HTMLOListElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOListElement-impl.js
@@ -2,20 +2,7 @@
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
-class HTMLOListElementImpl extends HTMLElementImpl {
-  get start() {
-    const value = parseInt(this.getAttributeNS(null, "start"), 10);
-
-    if (!isNaN(value)) {
-      return value;
-    }
-
-    return 1;
-  }
-  set start(value) {
-    this.setAttributeNS(null, "start", value);
-  }
-}
+class HTMLOListElementImpl extends HTMLElementImpl { }
 
 module.exports = {
   implementation: HTMLOListElementImpl

--- a/lib/jsdom/living/nodes/HTMLOListElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLOListElement.webidl
@@ -2,7 +2,7 @@
  HTMLConstructor]
 interface HTMLOListElement : HTMLElement {
   [CEReactions, Reflect] attribute boolean reversed;
-  [CEReactions] attribute long start;
+  [CEReactions, Reflect, ReflectDefault=1] attribute long start;
   [CEReactions, Reflect] attribute DOMString type;
 
   // also has obsolete members

--- a/lib/jsdom/living/nodes/HTMLSlotElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSlotElement-impl.js
@@ -14,7 +14,7 @@ class HTMLSlotElementImpl extends HTMLElementImpl {
   }
 
   // https://dom.spec.whatwg.org/#slot-name
-  get name() {
+  get _name() {
     return this.getAttributeNS(null, "name") || "";
   }
 

--- a/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
@@ -2,43 +2,10 @@
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
-const { asciiLowercase, parseNonNegativeInteger } = require("../helpers/strings");
+const { asciiLowercase } = require("../helpers/strings");
 const { closest } = require("../helpers/traversal");
 
-function reflectedAttributeClampedToRange(attrValue, min, max, defaultValue = 0) {
-  if (attrValue === null) {
-    return defaultValue;
-  }
-  const parsed = parseNonNegativeInteger(attrValue);
-  if (parsed === null) {
-    return defaultValue;
-  }
-  if (parsed < min) {
-    return min;
-  }
-  if (parsed > max) {
-    return max;
-  }
-  return parsed;
-}
-
 class HTMLTableCellElementImpl extends HTMLElementImpl {
-  get colSpan() {
-    return reflectedAttributeClampedToRange(this.getAttributeNS(null, "colspan"), 1, 1000, 1);
-  }
-
-  set colSpan(V) {
-    this.setAttributeNS(null, "colspan", String(V));
-  }
-
-  get rowSpan() {
-    return reflectedAttributeClampedToRange(this.getAttributeNS(null, "rowspan"), 0, 65534, 1);
-  }
-
-  set rowSpan(V) {
-    this.setAttributeNS(null, "rowspan", String(V));
-  }
-
   get cellIndex() {
     const tr = closest(this, "tr");
     if (tr === null) {


### PR DESCRIPTION
Use webidl2js's [Reflect] and [ReflectDefault] annotations instead of manual getters/setters, and remove dead code where [Reflect] was already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)