### PR TITLE
Lazily initialize DOMSelector

### DIFF
--- a/lib/jsdom/living/helpers/style-rules.js
+++ b/lib/jsdom/living/helpers/style-rules.js
@@ -255,7 +255,7 @@ function handlePropertyForInlineStyle(property, declaration, style) {
 
 function matches(selectorText, elementImpl) {
   try {
-    const domSelector = elementImpl._ownerDocument._domSelector;
+    const domSelector = elementImpl._ownerDocument._getDOMSelector();
     const { ast, match, pseudoElement } = domSelector.check(selectorText, elementImpl);
     // `pseudoElement` is a pseudo-element selector (e.g. `::before`).
     // However, we do not support getComputedStyle(element, pseudoElement), so `match` is set to `false`.

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -116,6 +116,8 @@ const eventInterfaceTable = {
 };
 
 class DocumentImpl extends NodeImpl {
+  #domSelector = null;
+
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
 
@@ -202,11 +204,6 @@ class DocumentImpl extends NodeImpl {
     // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#throw-on-dynamic-markup-insertion-counter
     this._throwOnDynamicMarkupInsertionCounter = 0;
 
-    // DOMSelector is lazy-initialized on first access to avoid ~0.5ms overhead
-    // per Document creation. This matters for DOMParser.parseFromString() which
-    // creates a throwaway Document on every call — e.g. DOMPurify.sanitize().
-    this.__domSelector = null;
-
     // Cache of computed element styles
     this._styleCache = new WeakMap();
 
@@ -215,18 +212,19 @@ class DocumentImpl extends NodeImpl {
     this._baseURLSerializedCache = null;
   }
 
-  get _domSelector() {
-    if (!this.__domSelector) {
-      this.__domSelector = new DOMSelector(this._globalObject, this._ownerDocument, {
+  // The `DOMSelector` instance is lazily created, as it is somewhat expensive to create and not always needed.
+  _getDOMSelector() {
+    if (!this.#domSelector) {
+      this.#domSelector = new DOMSelector(this._globalObject, this._ownerDocument, {
         domSymbolTree,
         idlUtils
       });
     }
-    return this.__domSelector;
+    return this.#domSelector;
   }
 
-  set _domSelector(val) {
-    this.__domSelector = val;
+  _clearDOMSelector() {
+    this.#domSelector?.clear();
   }
 
   _clearBaseURLCache() {

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -100,12 +100,7 @@ class ElementImpl extends NodeImpl {
     }
 
     // Clear domSelector cached results on attribute change.
-    // Access __domSelector directly to avoid triggering lazy initialization —
-    // throwaway Documents (e.g. from DOMParser) that never use querySelector
-    // should not pay the DOMSelector construction cost.
-    if (this._ownerDocument.__domSelector) {
-      this._ownerDocument.__domSelector.clear();
-    }
+    this._ownerDocument._clearDOMSelector();
 
     this._attrModifiedSlotableMixin(name, value, oldValue);
   }
@@ -535,12 +530,12 @@ class ElementImpl extends NodeImpl {
   }
 
   closest(selectors) {
-    const domSelector = this._ownerDocument._domSelector;
+    const domSelector = this._ownerDocument._getDOMSelector();
     return domSelector.closest(selectors, this);
   }
 
   matches(selectors) {
-    const domSelector = this._ownerDocument._domSelector;
+    const domSelector = this._ownerDocument._getDOMSelector();
     return domSelector.matches(selectors, this);
   }
 

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -63,7 +63,7 @@ class ParentNodeImpl {
     if (shouldAlwaysSelectNothing(this)) {
       return null;
     }
-    const domSelector = this._ownerDocument._domSelector;
+    const domSelector = this._ownerDocument._getDOMSelector();
     return domSelector.querySelector(selectors, this);
   }
 
@@ -74,7 +74,7 @@ class ParentNodeImpl {
     if (shouldAlwaysSelectNothing(this)) {
       return NodeList.createImpl(this._globalObject, [], { nodes: [] });
     }
-    const domSelector = this._ownerDocument._domSelector;
+    const domSelector = this._ownerDocument._getDOMSelector();
     const nodes = domSelector.querySelectorAll(selectors, this);
     return NodeList.createImpl(this._globalObject, [], { nodes });
   }


### PR DESCRIPTION
DOMSelector initialization costs ~0.5ms per Document due to the Finder constructor registering 9 event listeners and nwsapi compiling regexps. This is not needed for all documents, so only do so lazily.