### PR TITLE
Suppress informational WPT output when using the min reporter

### DIFF
--- a/test/web-platform-tests/utils.js
+++ b/test/web-platform-tests/utils.js
@@ -40,6 +40,19 @@ exports.doHeadRequestWithNoCertChecking = url => {
   });
 };
 
+exports.isQuietReporter = () => {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if ((args[i] === "--reporter" || args[i] === "-R") && args[i + 1] === "min") {
+      return true;
+    }
+    if (args[i] === "--reporter=min" || args[i] === "-Rmin") {
+      return true;
+    }
+  }
+  return false;
+};
+
 exports.spawnSyncFiltered = (command, args, options = {}) => {
   // We need to capture the output to filter it, so override any stdio settings
   const modifiedOptions = { ...options, stdio: "pipe" };
@@ -52,7 +65,8 @@ exports.spawnSyncFiltered = (command, args, options = {}) => {
         .filter(line => {
           return !line.includes("[notice] A new release of pip is available") &&
                  !line.includes("[notice] To update, run: python") &&
-                 !line.includes("is outside repository at");
+                 !line.includes("is outside repository at") &&
+                 !line.includes("INFO:manifest:");
         })
         .join("\n");
 

--- a/test/web-platform-tests/wpt-manifest-utils.js
+++ b/test/web-platform-tests/wpt-manifest-utils.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
+const { isQuietReporter, spawnSyncFiltered } = require("./utils.js");
 
 const EXPECTED_MANIFEST_VERSION = 9;
 
@@ -60,7 +61,9 @@ exports.readManifest = filename => {
 // Regenerates a WPT manifest for the given tests root directory and manifest output path,
 // then reads and returns the parsed manifest.
 exports.regenerateManifest = (testsRoot, manifestFilename) => {
-  const result = spawnSync(
+  const quiet = isQuietReporter();
+  const spawnFn = quiet ? spawnSyncFiltered : spawnSync;
+  const result = spawnFn(
     "python",
     [
       "./wpt.py", "manifest",

--- a/test/web-platform-tests/wpt-server.js
+++ b/test/web-platform-tests/wpt-server.js
@@ -4,7 +4,7 @@ const dns = require("node:dns").promises;
 const path = require("node:path");
 const childProcess = require("node:child_process");
 const delay = require("node:timers/promises").setTimeout;
-const { killSubprocess, doHeadRequestWithNoCertChecking } = require("./utils.js");
+const { killSubprocess, doHeadRequestWithNoCertChecking, isQuietReporter } = require("./utils.js");
 
 const wptDir = path.resolve(__dirname, "tests");
 
@@ -39,8 +39,9 @@ exports.start = async ({ toUpstream = false } = {}) => {
     stdio: ["inherit", "pipe", "pipe"]
   });
 
-  subprocess.stdout.filter(nonSpammyWPTLog).pipe(process.stdout);
-  subprocess.stderr.filter(nonSpammyWPTLog).pipe(process.stderr);
+  const logFilter = isQuietReporter() ? quietWPTLog : nonSpammyWPTLog;
+  subprocess.stdout.filter(logFilter).pipe(process.stdout);
+  subprocess.stderr.filter(logFilter).pipe(process.stderr);
   subprocess.stderr.on("data", terminateWPTOnKeyError);
   subprocess.on("error", terminateSubprocessOnError);
 
@@ -97,6 +98,20 @@ function nonSpammyWPTLog(buffer) {
   // Probing / on the ws and wss ports will cause a fallback, and log some messages about it.
   // Those are expected and are uninteresting.
   if (/wss? on port \d+\] INFO - (No handler|Fallback to|"HEAD \/ HTTP)/.test(string)) {
+    return false;
+  }
+
+  return true;
+}
+
+function quietWPTLog(buffer) {
+  if (!nonSpammyWPTLog(buffer)) {
+    return false;
+  }
+
+  const string = buffer.toString("utf-8");
+
+  if (string.includes("INFO - Starting")) {
     return false;
   }
 


### PR DESCRIPTION
Filter out WPT server startup messages and manifest regeneration INFO lines when running with `--reporter min`, keeping output minimal for automated use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)