### PR TITLE
Support ratio type

### DIFF
--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -27,6 +27,7 @@ const AST_TYPES = Object.freeze({
   IDENTIFIER: "Identifier",
   NUMBER: "Number",
   PERCENTAGE: "Percentage",
+  RATIO: "Ratio",
   STRING: "String",
   URL: "Url"
 });
@@ -439,6 +440,24 @@ function serializePercentage(val, opt = {}) {
 }
 
 /**
+ * Serializes a <ratio> value.
+ *
+ * @param {Array<object>} val - The AST value.
+ * @returns {string|undefined} The serialized ratio.
+ */
+function serializeRatio(val) {
+  const res = parseNumericValue(
+    val,
+    { max: Number.INFINITY, min: 0 },
+    type => type === AST_TYPES.NUMBER
+  );
+  if (!res) {
+    return undefined;
+  }
+  return `${res.num} / 1`;
+}
+
+/**
  * Serializes a <url> value.
  *
  * @param {Array<object>} val - The AST value.
@@ -810,6 +829,7 @@ exports.serializeGradient = serializeGradient;
 exports.serializeLength = serializeLength;
 exports.serializeNumber = serializeNumber;
 exports.serializePercentage = serializePercentage;
+exports.serializeRatio = serializeRatio;
 exports.serializeString = serializeString;
 exports.serializeURL = serializeURL;
 exports.splitValue = splitValue;

--- a/lib/jsdom/living/css/helpers/generic-property-descriptor.js
+++ b/lib/jsdom/living/css/helpers/generic-property-descriptor.js
@@ -38,7 +38,8 @@ function createGenericPropertyDescriptor(property, { caseSensitive, dimensionTyp
               dimension: dimensionType,
               length: lengthType,
               number: numberType,
-              percentage: percentageType
+              percentage: percentageType,
+              ratio: ratioType
             } = dimensionTypes;
             const { color: colorType, image: imageType, paint: paintType } = functionTypes;
             const [{ name, type, value: itemValue }] = parsedValue;
@@ -76,6 +77,8 @@ function createGenericPropertyDescriptor(property, { caseSensitive, dimensionTyp
                   val = parsers.serializeLength(parsedValue, lengthType);
                 } else if (percentageType) {
                   val = parsers.serializePercentage(parsedValue, percentageType);
+                } else if (ratioType) {
+                  val = parsers.serializeRatio(parsedValue, ratioType);
                 }
                 this._setProperty(property, val, priority);
                 break;

--- a/scripts/generate-css-style-properties.js
+++ b/scripts/generate-css-style-properties.js
@@ -170,6 +170,10 @@ ${attributes.join("\n")}
             type = "percentage";
             break;
           }
+          case "ratio": {
+            type = "ratio";
+            break;
+          }
           default: {
             type = "dimension";
           }

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -4,6 +4,8 @@ css/css-display/display-initial.html:
   "Revert value of display": [fail, Revert keyword is not supported]
   "Revert-layer value of display": [fail, Revert-layer keyword is not supported]
 css/css-nesting/nested-media-in-layer.html: [fail, https://github.com/jsdom/jsdom/issues/3997]
+css/css-sizing/aspect-ratio.html:
+  "auto number": [fail, aspect-ratio is not fully implemented]
 css/css-values/calc-parentheses.html: [fail, calc() values not resolved to computed values; https://github.com/jsdom/jsdom/issues/3538]
 css/cssom/getComputedStyle-live.html: [fail, https://github.com/jsdom/jsdom/issues/3562]
 css/cssom/getComputedStyle-shadow-host.html: [fail, https://github.com/jsdom/jsdom/issues/3661]

--- a/test/web-platform-tests/to-upstream/css/css-sizing/aspect-ratio.html
+++ b/test/web-platform-tests/to-upstream/css/css-sizing/aspect-ratio.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>aspect-ratio values</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#ratio-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- Regression test for https://github.com/jsdom/jsdom/issues/4150 -->
+
+<script>
+"use strict";
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "3 / 2");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "3 / 2");
+}, "number / number");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "1.5");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "1.5 / 1");
+}, "number");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "auto");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "auto");
+}, "auto");
+
+test(() => {
+  const img = document.createElement("img");
+  img.style.setProperty("aspect-ratio", "auto 3 / 2");
+  assert_equals(img.style.getPropertyValue("aspect-ratio"), "auto 3 / 2");
+}, "auto number / number");
+
+test(() => {
+  const img = document.createElement("img");
+  img.style.setProperty("aspect-ratio", "auto 1.5");
+  assert_equals(img.style.getPropertyValue("aspect-ratio"), "auto 1.5 / 1");
+}, "auto number");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "0 / 2");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "0 / 2");
+}, "zero / number");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "3 / 0");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "3 / 0");
+}, "number / zero");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "0");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "0 / 1");
+}, "zero");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "-3 / 2");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "");
+}, "invalid; negative / number");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "3 / -2");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "");
+}, "invalid; number / negative");
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.setProperty("aspect-ratio", "-3");
+  assert_equals(div.style.getPropertyValue("aspect-ratio"), "");
+}, "invalid; negative");
+</script>


### PR DESCRIPTION
Fix #4150 

Note: This PR adds support for the generic `<ratio>` CSS data type, but does not fully implement `aspect-ratio`.
