### PR TITLE
Exclude border-radius from border shorthand handler

### DIFF
--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -392,7 +392,7 @@ class CSSStyleDeclarationImpl {
         return this.#resolvePositionShorthand(property);
       }
       default: {
-        if (property.startsWith("border")) {
+        if (property.startsWith("border") && !property.endsWith("radius")) {
           return this.#resolveBorderShorthands(property);
         }
         return value;

--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -391,10 +391,17 @@ class CSSStyleDeclarationImpl {
       case "padding": {
         return this.#resolvePositionShorthand(property);
       }
+      case "border":
+      case "border-top":
+      case "border-right":
+      case "border-bottom":
+      case "border-left":
+      case "border-width":
+      case "border-style":
+      case "border-color": {
+        return this.#resolveBorderShorthands(property);
+      }
       default: {
-        if (property.startsWith("border") && !property.endsWith("radius")) {
-          return this.#resolveBorderShorthands(property);
-        }
         return value;
       }
     }

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,4 +1,4 @@
-css/css-borders/border-radious-shorthand.html:
+css/css-borders/border-radius-shorthand.html:
   "longhand from shorthand": [fail, border-radius and its longhands are not implemented]
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]
 css/css-conditional/container-queries-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3597]

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,3 +1,5 @@
+css/css-borders/border-radious-shorthand.html:
+  "longhand from shorthand": [fail, border-radius and its longhands are not implemented]
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]
 css/css-conditional/container-queries-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3597]
 css/css-display/display-initial.html:

--- a/test/web-platform-tests/to-upstream/css/css-borders/border-radious-shorthand.html
+++ b/test/web-platform-tests/to-upstream/css/css-borders/border-radious-shorthand.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>border-radious shorthand</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- Regression test for https://github.com/jsdom/jsdom/issues/4153 -->
+
+<style>
+#div {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+}
+</style>
+
+<div id="div"></div>
+
+<script>
+"use strict";
+
+test(() => {
+  const div = document.getElementById("div");
+  const cs = window.getComputedStyle(div);
+  assert_equals(cs.borderRadius, "12px", "shorthand");
+  assert_equals(cs.getPropertyValue("border-radius"), "12px", "get value");
+}, "shorthand");
+
+test(() => {
+  const div = document.getElementById("div");
+  const cs = window.getComputedStyle(div);
+  assert_equals(cs.borderRadius, "12px", "shorthand");
+  assert_equals(cs.borderTopLeftRadius, "12px", "longhand");
+}, "longhand from shorthand");
+
+test(() => {
+  const div = document.getElementById("div");
+  div.style.borderRadius = "14px";
+  const cs = window.getComputedStyle(div);
+  assert_equals(cs.borderRadius, "14px", "shorthand");
+  assert_equals(cs.getPropertyValue("border-radius"), "14px", "get value");
+}, "inline style");
+</script>

--- a/test/web-platform-tests/to-upstream/css/css-borders/border-radius-shorthand.html
+++ b/test/web-platform-tests/to-upstream/css/css-borders/border-radius-shorthand.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>border-radious shorthand</title>
+<title>border-radius shorthand</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
Partially addresses the regression of `border-radius` in the first half of #4153.
Note that it does not fix `border-radius` longhands.