### PR TITLE
Add benchmark comparison script

### DIFF
--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+"use strict";
+/* eslint-disable no-console */
+
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+const { parseArgs } = require("node:util");
+const {
+  renderSuiteResults,
+  compareSuites,
+  renderComparisonTable,
+  renderComparisonList
+} = require("./lib");
+
+const { values, positionals } = parseArgs({
+  options: {
+    suite: { type: "string", multiple: true, short: "s" },
+    format: { type: "string", short: "f", default: "terminal" },
+    output: { type: "string", short: "o", default: "table" }
+  },
+  allowPositionals: true,
+  strict: false
+});
+
+if (positionals.length !== 2) {
+  console.error(
+    "Usage: npm run benchmark:compare -- <ref1> <ref2> " +
+      "[--suite <name>]... [--format=terminal|markdown] [--output=table|list]"
+  );
+  process.exit(1);
+}
+const [ref1, ref2] = positionals;
+
+if (values.format !== "terminal" && values.format !== "markdown") {
+  console.error(`Unknown --format: ${values.format}. Expected "terminal" or "markdown".`);
+  process.exit(1);
+}
+if (values.output !== "table" && values.output !== "list") {
+  console.error(`Unknown --output: ${values.output}. Expected "table" or "list".`);
+  process.exit(1);
+}
+
+function git(...args) {
+  const r = spawnSync("git", args, { encoding: "utf-8" });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed:\n${r.stderr}`);
+  }
+  return r.stdout.trim();
+}
+
+function ensureCleanTree() {
+  const status = git("status", "--porcelain");
+  if (status !== "") {
+    console.error("Working tree is not clean. Commit or stash your changes before running benchmark:compare.");
+    console.error(status);
+    process.exit(1);
+  }
+}
+
+function currentRefName() {
+  // If we're on a branch, return its name; otherwise return the detached HEAD SHA.
+  const branch = git("rev-parse", "--abbrev-ref", "HEAD");
+  if (branch === "HEAD") {
+    return git("rev-parse", "HEAD");
+  }
+  return branch;
+}
+
+function checkout(ref) {
+  console.error(`\n--- Checking out ${ref} ---`);
+  git("checkout", ref);
+}
+
+function npmInstall() {
+  console.error("--- Running npm install ---");
+  const r = spawnSync("npm", ["install"], { stdio: ["ignore", "inherit", "inherit"] });
+  if (r.status !== 0) {
+    throw new Error(`npm install failed (exit ${r.status})`);
+  }
+}
+
+function runSuites(suiteFilters) {
+  console.error("--- Running benchmarks ---");
+  const args = [path.join(__dirname, "run-suites-json.js")];
+  if (suiteFilters) {
+    for (const s of suiteFilters) {
+      args.push("--suite", s);
+    }
+  }
+  const r = spawnSync(process.execPath, args, { encoding: "utf-8", stdio: ["ignore", "pipe", "inherit"] });
+  if (r.status !== 0) {
+    throw new Error(`benchmark subprocess failed (exit ${r.status})`);
+  }
+  return r.stdout
+    .split("\n")
+    .filter(line => line.trim() !== "")
+    .map(line => JSON.parse(line));
+}
+
+function runForRef(ref, suiteFilters) {
+  checkout(ref);
+  npmInstall();
+  return runSuites(suiteFilters);
+}
+
+ensureCleanTree();
+const originalRef = currentRefName();
+console.error(`Original ref: ${originalRef}`);
+
+let ref1Results, ref2Results;
+try {
+  ref1Results = runForRef(ref1, values.suite);
+  ref2Results = runForRef(ref2, values.suite);
+} finally {
+  try {
+    checkout(originalRef);
+    npmInstall();
+  } catch (err) {
+    console.error("\n!!! Failed to restore original ref. You are likely on a different branch.");
+    console.error(`Run 'git checkout ${originalRef} && npm install' manually.`);
+    console.error(err);
+  }
+}
+
+// Render per-suite raw results, then a combined summary at the end.
+const ref1BySuite = new Map(ref1Results.map(r => [r.suite, r]));
+const ref2BySuite = new Map(ref2Results.map(r => [r.suite, r]));
+const allSuites = [...new Set([...ref1BySuite.keys(), ...ref2BySuite.keys()])];
+
+for (const suite of allSuites) {
+  console.log(`\n# ${suite}\n`);
+  if (ref1BySuite.has(suite)) {
+    console.log(`## ${ref1}\n`);
+    console.log(renderSuiteResults(values.format, ref1BySuite.get(suite)));
+  }
+  if (ref2BySuite.has(suite)) {
+    console.log(`\n## ${ref2}\n`);
+    console.log(renderSuiteResults(values.format, ref2BySuite.get(suite)));
+  }
+}
+
+console.log(`\n# Summary (${ref2} throughput / ${ref1} throughput; >1 means ${ref2} faster)\n`);
+
+if (values.output === "list") {
+  for (const suite of allSuites) {
+    const r1 = ref1BySuite.get(suite) ?? { tasks: [] };
+    const r2 = ref2BySuite.get(suite) ?? { tasks: [] };
+    console.log(`## ${suite}\n`);
+    console.log(renderComparisonList(ref1, ref2, compareSuites(r1, r2)));
+    console.log("");
+  }
+} else {
+  for (const suite of allSuites) {
+    const r1 = ref1BySuite.get(suite) ?? { tasks: [] };
+    const r2 = ref2BySuite.get(suite) ?? { tasks: [] };
+    console.log(`## ${suite}\n`);
+    console.log(renderComparisonTable(values.format, ref1, ref2, compareSuites(r1, r2)));
+    console.log("");
+  }
+}

--- a/benchmark/lib.js
+++ b/benchmark/lib.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { formatNumber } = require("tinybench");
+
+const benchmarkDir = __dirname;
+
+function discoverSuites() {
+  const suites = [];
+  for (const category of fs.readdirSync(benchmarkDir, { withFileTypes: true })) {
+    if (!category.isDirectory()) {
+      continue;
+    }
+    for (const file of fs.readdirSync(path.join(benchmarkDir, category.name), { withFileTypes: true })) {
+      if (file.isFile() && file.name.endsWith(".js")) {
+        suites.push(`${category.name}/${path.basename(file.name, ".js")}`);
+      }
+    }
+  }
+  suites.sort();
+  return suites;
+}
+
+function filterSuites(suites, filters) {
+  if (!filters || filters.length === 0) {
+    return suites;
+  }
+  return suites.filter(s => filters.some(f => s.startsWith(f)));
+}
+
+async function runSuite(suiteName) {
+  const factory = require(path.join(benchmarkDir, suiteName));
+  const bench = factory();
+  await bench.run();
+  return {
+    suite: suiteName,
+    // bench.table() returns rows pre-formatted by tinybench (one record per task,
+    // matching tinybench's own console output); used as-is for rendering.
+    table: bench.table(),
+    // Raw results retained so the comparison step can compute throughput ratios.
+    tasks: bench.tasks.map(t => ({ name: t.name, result: t.result }))
+  };
+}
+
+function renderTerminalTable(headers, rows) {
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => String(r[i]).length)));
+  const top = `┌${widths.map(w => "─".repeat(w + 2)).join("┬")}┐`;
+  const sep = `├${widths.map(w => "─".repeat(w + 2)).join("┼")}┤`;
+  const bot = `└${widths.map(w => "─".repeat(w + 2)).join("┴")}┘`;
+  function fmtRow(cells) {
+    return `│${cells.map((c, i) => ` ${String(c).padEnd(widths[i])} `).join("│")}│`;
+  }
+  const lines = [top, fmtRow(headers), sep, ...rows.map(fmtRow), bot];
+  return lines.join("\n");
+}
+
+function escapeMarkdownCell(value) {
+  return String(value).replace(/\|/g, "\\|");
+}
+
+function renderMarkdownTable(headers, rows) {
+  const lines = [
+    `| ${headers.map(escapeMarkdownCell).join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...rows.map(r => `| ${r.map(escapeMarkdownCell).join(" | ")} |`)
+  ];
+  return lines.join("\n");
+}
+
+function renderTable(format, headers, rows) {
+  return format === "markdown" ? renderMarkdownTable(headers, rows) : renderTerminalTable(headers, rows);
+}
+
+function renderSuiteResults(format, suiteResult) {
+  const headers = Object.keys(suiteResult.table[0]);
+  const rows = suiteResult.table.map(record => headers.map(h => record[h]));
+  return renderTable(format, headers, rows);
+}
+
+function formatRatio(ratio) {
+  if (!Number.isFinite(ratio)) {
+    return "n/a";
+  }
+  return `${ratio.toFixed(2)}×`;
+}
+
+function compareSuites(ref1Result, ref2Result) {
+  const tasksByName = new Map(ref1Result.tasks.map(t => [t.name, { ref1: t }]));
+  for (const t of ref2Result.tasks) {
+    const entry = tasksByName.get(t.name) ?? {};
+    entry.ref2 = t;
+    tasksByName.set(t.name, entry);
+  }
+  const rows = [];
+  for (const [name, { ref1, ref2 }] of tasksByName) {
+    const ratio = ref1 && ref2 ? ref2.result.throughput.p50 / ref1.result.throughput.p50 : NaN;
+    rows.push({ name, ref1, ref2, ratio });
+  }
+  return rows;
+}
+
+function renderComparisonTable(format, ref1Label, ref2Label, comparisonRows) {
+  const headers = [
+    "Task name",
+    `${ref1Label} (ops/s)`,
+    `${ref2Label} (ops/s)`,
+    `${ref2Label} / ${ref1Label}`
+  ];
+  const rows = comparisonRows.map(({ name, ref1, ref2, ratio }) => [
+    name,
+    ref1 ? formatNumber(ref1.result.throughput.p50, 5, 2) : "—",
+    ref2 ? formatNumber(ref2.result.throughput.p50, 5, 2) : "—",
+    formatRatio(ratio)
+  ]);
+  return renderTable(format, headers, rows);
+}
+
+function renderComparisonList(ref1Label, ref2Label, comparisonRows) {
+  return comparisonRows
+    .map(({ name, ratio }) => `- '${name}': ${ref2Label} is ${formatRatio(ratio)} ${ref1Label}`)
+    .join("\n");
+}
+
+module.exports = {
+  discoverSuites,
+  filterSuites,
+  runSuite,
+  renderSuiteResults,
+  compareSuites,
+  renderComparisonTable,
+  renderComparisonList
+};

--- a/benchmark/run-suites-json.js
+++ b/benchmark/run-suites-json.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+"use strict";
+/* eslint-disable no-console */
+
+// Internal entry point used by `benchmark/compare.js`. Runs the requested suites
+// and writes one JSON object per suite to stdout (one per line). All progress
+// messages go to stderr so stdout stays parseable.
+
+const { parseArgs } = require("node:util");
+const { discoverSuites, filterSuites, runSuite } = require("./lib");
+
+const { values } = parseArgs({
+  options: {
+    suite: { type: "string", multiple: true, short: "s" }
+  },
+  strict: false
+});
+
+const suitesToRun = filterSuites(discoverSuites(), values.suite);
+
+(async () => {
+  for (const suiteName of suitesToRun) {
+    process.stderr.write(`  running ${suiteName}\n`);
+    const result = await runSuite(suiteName);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  }
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/benchmark/runner.js
+++ b/benchmark/runner.js
@@ -2,23 +2,8 @@
 "use strict";
 /* eslint-disable no-console */
 
-const fs = require("node:fs");
-const path = require("node:path");
 const { parseArgs } = require("node:util");
-
-const benchmarkDir = __dirname;
-const suites = [];
-for (const category of fs.readdirSync(benchmarkDir, { withFileTypes: true })) {
-  if (!category.isDirectory()) {
-    continue;
-  }
-  for (const file of fs.readdirSync(path.join(benchmarkDir, category.name), { withFileTypes: true })) {
-    if (file.isFile() && file.name.endsWith(".js")) {
-      suites.push(`${category.name}/${path.basename(file.name, ".js")}`);
-    }
-  }
-}
-suites.sort();
+const { discoverSuites, filterSuites, runSuite, renderSuiteResults } = require("./lib");
 
 const { values } = parseArgs({
   options: {
@@ -26,28 +11,34 @@ const { values } = parseArgs({
       type: "string",
       multiple: true,
       short: "s"
+    },
+    format: {
+      type: "string",
+      short: "f",
+      default: "terminal"
     }
   },
   strict: false
 });
 
-let suitesToRun = suites;
-if (values.suite) {
-  suitesToRun = suites.filter(s => values.suite.some(f => s.startsWith(f)));
+if (values.format !== "terminal" && values.format !== "markdown") {
+  console.error(`Unknown format: ${values.format}. Expected "terminal" or "markdown".`);
+  process.exit(1);
+}
 
-  if (suitesToRun.length === 0) {
-    console.error(`No suites matched: ${values.suite.join(", ")}`);
-    console.error(`Available suites: ${suites.join(", ")}`);
-    process.exitCode = 1;
-  }
+const suites = discoverSuites();
+const suitesToRun = filterSuites(suites, values.suite);
+
+if (values.suite && suitesToRun.length === 0) {
+  console.error(`No suites matched: ${values.suite.join(", ")}`);
+  console.error(`Available suites: ${suites.join(", ")}`);
+  process.exit(1);
 }
 
 (async () => {
-  for (const suite of suitesToRun) {
-    const bench = require(`./${suite}`)();
-
-    console.log(`\n# ${suite}\n`);
-    await bench.run();
-    console.table(bench.table());
+  for (const suiteName of suitesToRun) {
+    const result = await runSuite(suiteName);
+    console.log(`\n# ${suiteName}\n`);
+    console.log(renderSuiteResults(values.format, result));
   }
 })();

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "wpt:init": "git submodule update --init --recursive",
     "wpt:reset": "rm -rf ./test/web-platform-tests/tests && npm run wpt:init",
     "wpt:update": "git submodule update --init --recursive --remote && cd test/web-platform-tests/tests && python wpt.py manifest --path ../wpt-manifest.json",
-    "benchmark": "node ./benchmark/runner"
+    "benchmark": "node ./benchmark/runner",
+    "benchmark:compare": "node ./benchmark/compare"
   },
   "wireit": {
     "prepare": {


### PR DESCRIPTION
## Summary

- Adds `npm run benchmark:compare -- <ref1> <ref2> [--suite <name>]... [--format=terminal|markdown] [--output=table|list]`, which checks out each ref, runs `npm install`, runs the requested benchmark suites in a fresh subprocess, restores the original ref, and prints both raw per-ref tables and a comparison summary.
- Comparison ratio is `ref2 throughput / ref1 throughput` (median ops/s), so >1 = ref2 faster, <1 = ref2 slower.
- Two output formats (terminal box-drawing characters / markdown) and two summary layouts (table / list), as requested in the issue.
- Refactors `benchmark/runner.js` to share suite-discovery/runner code via a new `benchmark/lib.js` (no behavior change for `npm run benchmark`, plus a bonus optional `--format=markdown`).
- Per-suite tables come from `bench.table()` (tinybench) so number formatting matches what `console.table(bench.table())` produced before; the comparison column uses tinybench's exported `formatNumber`.

Refuses to run on a dirty working tree, and assumes the harness exists in both refs (so this script is only useful for comparing refs created at or after this commit).

Closes #4157

## Test plan

- [ ] `npm run benchmark` still produces the same output as before.
- [ ] `npm run benchmark -- --format=markdown` produces a markdown-formatted table.
- [ ] `npm run benchmark:compare -- <ref1> <ref2> --suite style/get-computed-style` produces both raw tables and a summary, in terminal format by default.
- [ ] `--format=markdown` and `--output=list` flags work as expected.
- [ ] Working tree is restored to the original ref after the run, even on subprocess failure.
- [ ] Refuses to run when the working tree is dirty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)