### PR TITLE
Optimize cache handling

### DIFF
--- a/benchmark/style/style-property.js
+++ b/benchmark/style/style-property.js
@@ -4,7 +4,8 @@ const documentBench = require("../document-bench");
 // Style benchmarks based on https://github.com/jsdom/jsdom/issues/3985
 
 const cssText =
-  "color: blue; background-color: white; padding: 10px; border: 1px solid black; animation: 3s linear 1s slide-in;";
+  "color: blue; background-color: white; padding: 10px; border: 1px solid black;" +
+  " width: calc(100vw - 20px); animation: 3s linear 1s slide-in;";
 
 module.exports = () => {
   const { document, bench } = documentBench();
@@ -24,6 +25,7 @@ module.exports = () => {
       div.style.backgroundColor = "white";
       div.style.padding = "10px";
       div.style.border = "1px solid black";
+      div.style.width = "calc(100vw - 20px)";
       div.style.animation = "3s linear 1s slide-in";
     }
   });

--- a/benchmark/style/style-property.js
+++ b/benchmark/style/style-property.js
@@ -4,8 +4,7 @@ const documentBench = require("../document-bench");
 // Style benchmarks based on https://github.com/jsdom/jsdom/issues/3985
 
 const cssText =
-  "color: blue; background-color: white; padding: 10px; border: 1px solid black;" +
-  " width: calc(100vw - 20px); animation: 3s linear 1s slide-in;";
+  "color: blue; background-color: white; padding: 10px; border: 1px solid black; animation: 3s linear 1s slide-in;";
 
 module.exports = () => {
   const { document, bench } = documentBench();
@@ -25,7 +24,6 @@ module.exports = () => {
       div.style.backgroundColor = "white";
       div.style.padding = "10px";
       div.style.border = "1px solid black";
-      div.style.width = "calc(100vw - 20px)";
       div.style.animation = "3s linear 1s slide-in";
     }
   });

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -4,7 +4,7 @@ const {
   resolve: resolveColor,
   utils: { cssCalc, resolveGradient, splitValue }
 } = require("@asamuzakjp/css-color");
-const { GenerationalCache } = require("@asamuzakjp/generational-cache");
+const { LRUCache } = require("lru-cache");
 const cssTree = require("./patched-csstree.js");
 const propertyDefinitions = require("../../../../generated/css-property-definitions");
 const { asciiLowercase } = require("../../helpers/strings");
@@ -39,8 +39,10 @@ const calcNameRegEx = new RegExp(`^${CALC_FUNC_NAMES}$`);
 const varRegEx = /^var\(/;
 const varContainedRegEx = /(?<=[*/\s(])var\(/;
 
-// Instance of the generational cache. Stores up to 1024 items.
-const genCache = new GenerationalCache(1024);
+// Instance of the LRU Cache. Stores up to 2048 items.
+const lruCache = new LRUCache({
+  max: 2048
+});
 
 function getPropertyDefinition(property) {
   if (propertyDefinitions.has(property)) {
@@ -114,7 +116,7 @@ function resolveCalc(val, opt = { format: "specifiedValue" }) {
     return val;
   }
   const cacheKey = `resolveCalc_${val}_${opt.format}`;
-  const cachedValue = genCache.get(cacheKey);
+  const cachedValue = lruCache.get(cacheKey);
   if (typeof cachedValue === "string") {
     return cachedValue;
   }
@@ -140,7 +142,7 @@ function resolveCalc(val, opt = { format: "specifiedValue" }) {
     }
   }
   const resolvedValue = values.join(" ");
-  genCache.set(cacheKey, resolvedValue);
+  lruCache.set(cacheKey, resolvedValue);
   return resolvedValue;
 }
 
@@ -340,7 +342,7 @@ function parsePropertyValue(prop, val, opt = {}) {
 
 function validatePropertyValue(prop, val, context = "value") {
   const cacheKey = `validatePropertyValue_${prop}_${val}_${context}`;
-  const cachedValue = genCache.get(cacheKey);
+  const cachedValue = lruCache.get(cacheKey);
   if (cachedValue !== undefined) {
     return cachedValue;
   }
@@ -368,7 +370,7 @@ function validatePropertyValue(prop, val, context = "value") {
       valid: false
     };
   }
-  genCache.set(cacheKey, result);
+  lruCache.set(cacheKey, result);
   return result;
 }
 

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -4,8 +4,8 @@ const {
   resolve: resolveColor,
   utils: { cssCalc, resolveGradient, splitValue }
 } = require("@asamuzakjp/css-color");
+const { GenerationalCache } = require("@asamuzakjp/generational-cache");
 const cssTree = require("./patched-csstree.js");
-const { LRUCache } = require("lru-cache");
 const propertyDefinitions = require("../../../../generated/css-property-definitions");
 const { asciiLowercase } = require("../../helpers/strings");
 const { systemColors } = require("./system-colors");
@@ -39,10 +39,8 @@ const calcNameRegEx = new RegExp(`^${CALC_FUNC_NAMES}$`);
 const varRegEx = /^var\(/;
 const varContainedRegEx = /(?<=[*/\s(])var\(/;
 
-// Instance of the LRU Cache. Stores up to 4096 items.
-const lruCache = new LRUCache({
-  max: 4096
-});
+// Instance of the generational cache. Stores up to 1024 items.
+const genCache = new GenerationalCache(1024);
 
 function getPropertyDefinition(property) {
   if (propertyDefinitions.has(property)) {
@@ -99,23 +97,8 @@ function isValidPropertyValue(prop, val) {
   if (val === "") {
     return true;
   }
-  const cacheKey = `isValidPropertyValue_${prop}_${val}`;
-  const cachedValue = lruCache.get(cacheKey);
-  if (typeof cachedValue === "boolean") {
-    return cachedValue;
-  }
-  let result;
-  try {
-    const ast = cssTree.parse(val, {
-      context: "value"
-    });
-    const { error, matched } = cssTree.lexer.matchProperty(prop, ast);
-    result = error === null && matched !== null;
-  } catch {
-    result = false;
-  }
-  lruCache.set(cacheKey, result);
-  return result;
+  const { valid } = validatePropertyValue(prop, val);
+  return valid;
 }
 
 /**
@@ -131,7 +114,7 @@ function resolveCalc(val, opt = { format: "specifiedValue" }) {
     return val;
   }
   const cacheKey = `resolveCalc_${val}_${opt.format}`;
-  const cachedValue = lruCache.get(cacheKey);
+  const cachedValue = genCache.get(cacheKey);
   if (typeof cachedValue === "string") {
     return cachedValue;
   }
@@ -157,7 +140,7 @@ function resolveCalc(val, opt = { format: "specifiedValue" }) {
     }
   }
   const resolvedValue = values.join(" ");
-  lruCache.set(cacheKey, resolvedValue);
+  genCache.set(cacheKey, resolvedValue);
   return resolvedValue;
 }
 
@@ -187,17 +170,9 @@ function parsePropertyValue(prop, val, opt = {}) {
     }
     val = calculatedValue;
   }
-  const cacheKey = `parsePropertyValue_${prop}_${val}_${caseSensitive}`;
-  const cachedValue = lruCache.get(cacheKey);
-  if (cachedValue === false) {
-    return undefined;
-  } else if (cachedValue !== undefined) {
-    return cachedValue;
-  }
-  let parsedValue;
   const lowerCasedValue = asciiLowercase(val);
   if (GLOBAL_KEYS.has(lowerCasedValue)) {
-    parsedValue = [
+    return [
       {
         type: AST_TYPES.GLOBAL_KEYWORD,
         name: lowerCasedValue
@@ -287,11 +262,114 @@ function parsePropertyValue(prop, val, opt = {}) {
       parsedValue = false;
     }
   }
-  lruCache.set(cacheKey, parsedValue);
-  if (parsedValue === false) {
+  const { ast, valid } = validatePropertyValue(prop, val);
+  if (!valid) {
     return undefined;
   }
-  return parsedValue;
+  const items = ast.children;
+  const itemCount = items.size;
+  const values = [];
+  for (const item of items) {
+    const { children, name, type, value, unit } = item;
+    switch (type) {
+      case AST_TYPES.DIMENSION: {
+        values.push({
+          type,
+          value,
+          unit: asciiLowercase(unit)
+        });
+        break;
+      }
+      case AST_TYPES.FUNCTION: {
+        const raw = itemCount === 1 ? val : cssTree.generate(item).replace(/\)(?!\)|\s|,)/g, ") ");
+        // Remove "${name}(" from the start and ")" from the end
+        const itemValue = raw.trim().slice(name.length + 1, -1);
+        if (name === "calc") {
+          if (children.size === 1) {
+            const child = children.first;
+            if (child.type === AST_TYPES.NUMBER) {
+              values.push({
+                type: AST_TYPES.CALC,
+                name,
+                isNumber: true,
+                value: `${parseFloat(child.value)}`
+              });
+            } else {
+              values.push({
+                type: AST_TYPES.CALC,
+                name,
+                isNumber: false,
+                value: asciiLowercase(itemValue)
+              });
+            }
+          } else {
+            values.push({
+              type: AST_TYPES.CALC,
+              name,
+              isNumber: false,
+              value: asciiLowercase(itemValue)
+            });
+          }
+        } else {
+          values.push({
+            type,
+            name,
+            value: caseSensitive ? itemValue : asciiLowercase(itemValue)
+          });
+        }
+        break;
+      }
+      case AST_TYPES.IDENTIFIER: {
+        if (caseSensitive) {
+          values.push(item);
+        } else {
+          values.push({
+            type,
+            name: asciiLowercase(name)
+          });
+        }
+        break;
+      }
+      default: {
+        values.push(item);
+      }
+    }
+  }
+  return values;
+}
+
+function validatePropertyValue(prop, val, context = "value") {
+  const cacheKey = `validatePropertyValue_${prop}_${val}_${context}`;
+  const cachedValue = genCache.get(cacheKey);
+  if (cachedValue !== undefined) {
+    return cachedValue;
+  }
+  let result;
+  try {
+    const ast = cssTree.parse(val, {
+      context
+    });
+    // For custom properties, any value is valid if it is parsed without errors.
+    if (prop.startsWith("--")) {
+      result = {
+        ast,
+        valid: true
+      };
+    } else {
+      const { error, matched } = cssTree.lexer.matchProperty(prop, ast);
+      result = {
+        ast,
+        valid: error === null && matched !== null
+      };
+    }
+  } catch {
+    result = {
+      ast: null,
+      valid: false
+    };
+  }
+  genCache.set(cacheKey, result);
+  return result;
 }
 
 function generateCSSFromAST(ast) {

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -180,89 +180,6 @@ function parsePropertyValue(prop, val, opt = {}) {
         name: lowerCasedValue
       }
     ];
-  } else {
-    try {
-      const ast = cssTree.parse(val, {
-        context: "value"
-      });
-      const { error, matched } = cssTree.lexer.matchProperty(prop, ast);
-      if (error || !matched) {
-        parsedValue = false;
-      } else {
-        const items = ast.children;
-        const itemCount = items.size;
-        const values = [];
-        for (const item of items) {
-          const { children, name, type, value, unit } = item;
-          switch (type) {
-            case AST_TYPES.DIMENSION: {
-              values.push({
-                type,
-                value,
-                unit: asciiLowercase(unit)
-              });
-              break;
-            }
-            case AST_TYPES.FUNCTION: {
-              const raw = itemCount === 1 ? val : generateCSSFromAST(item);
-              // Remove "${name}(" from the start and ")" from the end
-              const itemValue = raw.trim().slice(name.length + 1, -1);
-              if (calcNameRegEx.test(name)) {
-                if (children.size === 1) {
-                  const child = children.first;
-                  if (child.type === AST_TYPES.NUMBER) {
-                    values.push({
-                      type: AST_TYPES.CALC,
-                      name,
-                      isNumber: true,
-                      value: `${parseFloat(child.value)}`
-                    });
-                  } else {
-                    values.push({
-                      type: AST_TYPES.CALC,
-                      name,
-                      isNumber: false,
-                      value: asciiLowercase(itemValue)
-                    });
-                  }
-                } else {
-                  values.push({
-                    type: AST_TYPES.CALC,
-                    name,
-                    isNumber: false,
-                    value: asciiLowercase(itemValue)
-                  });
-                }
-              } else {
-                values.push({
-                  type,
-                  name,
-                  value: caseSensitive ? itemValue : asciiLowercase(itemValue)
-                });
-              }
-              break;
-            }
-            case AST_TYPES.IDENTIFIER: {
-              if (caseSensitive) {
-                values.push(item);
-              } else {
-                values.push({
-                  type,
-                  name: asciiLowercase(name)
-                });
-              }
-              break;
-            }
-            default: {
-              values.push(item);
-            }
-          }
-        }
-        parsedValue = values;
-      }
-    } catch {
-      parsedValue = false;
-    }
   }
   const { ast, valid } = validatePropertyValue(prop, val);
   if (!valid) {
@@ -286,7 +203,7 @@ function parsePropertyValue(prop, val, opt = {}) {
         const raw = itemCount === 1 ? val : cssTree.generate(item).replace(/\)(?!\)|\s|,)/g, ") ");
         // Remove "${name}(" from the start and ")" from the end
         const itemValue = raw.trim().slice(name.length + 1, -1);
-        if (name === "calc") {
+        if (calcNameRegEx.test(name)) {
           if (children.size === 1) {
             const child = children.first;
             if (child.type === AST_TYPES.NUMBER) {

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -39,9 +39,9 @@ const calcNameRegEx = new RegExp(`^${CALC_FUNC_NAMES}$`);
 const varRegEx = /^var\(/;
 const varContainedRegEx = /(?<=[*/\s(])var\(/;
 
-// Instance of the LRU Cache. Stores up to 2048 items.
+// Instance of the LRU Cache. Stores up to 4096 items.
 const lruCache = new LRUCache({
-  max: 2048
+  max: 4096
 });
 
 function getPropertyDefinition(property) {

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -99,7 +99,13 @@ function isValidPropertyValue(prop, val) {
   if (val === "") {
     return true;
   }
+  const cacheKey = `isValidPropertyValue_${prop}_${val}`;
+  const cachedValue = lruCache.get(cacheKey);
+  if (typeof cachedValue === "boolean") {
+    return cachedValue;
+  }
   const { valid } = validatePropertyValue(prop, val);
+  lruCache.set(cacheKey, valid);
   return valid;
 }
 
@@ -164,25 +170,28 @@ function parsePropertyValue(prop, val, opt = {}) {
   if (val === "" || hasVarFunc(val)) {
     return val;
   } else if (hasCalcFunc(val)) {
-    const calculatedValue = resolveCalc(val, {
-      format: "specifiedValue"
-    });
+    const calculatedValue = resolveCalc(val, { format: "specifiedValue" });
     if (typeof calculatedValue !== "string") {
       return undefined;
     }
     val = calculatedValue;
   }
+  const cacheKey = `parsePropertyValue_${prop}_${val}_${caseSensitive}`;
+  const cachedValue = lruCache.get(cacheKey);
+  if (cachedValue === false) {
+    return undefined;
+  } else if (cachedValue !== undefined) {
+    return cachedValue;
+  }
   const lowerCasedValue = asciiLowercase(val);
   if (GLOBAL_KEYS.has(lowerCasedValue)) {
-    return [
-      {
-        type: AST_TYPES.GLOBAL_KEYWORD,
-        name: lowerCasedValue
-      }
-    ];
+    const globalResult = [{ type: AST_TYPES.GLOBAL_KEYWORD, name: lowerCasedValue }];
+    lruCache.set(cacheKey, globalResult);
+    return globalResult;
   }
   const { ast, valid } = validatePropertyValue(prop, val);
   if (!valid) {
+    lruCache.set(cacheKey, false);
     return undefined;
   }
   const items = ast.children;
@@ -254,41 +263,22 @@ function parsePropertyValue(prop, val, opt = {}) {
       }
     }
   }
+  lruCache.set(cacheKey, values);
   return values;
 }
 
 function validatePropertyValue(prop, val, context = "value") {
-  const cacheKey = `validatePropertyValue_${prop}_${val}_${context}`;
-  const cachedValue = lruCache.get(cacheKey);
-  if (cachedValue !== undefined) {
-    return cachedValue;
-  }
-  let result;
   try {
-    const ast = cssTree.parse(val, {
-      context
-    });
+    const ast = cssTree.parse(val, { context });
     // For custom properties, any value is valid if it is parsed without errors.
     if (prop.startsWith("--")) {
-      result = {
-        ast,
-        valid: true
-      };
-    } else {
-      const { error, matched } = cssTree.lexer.matchProperty(prop, ast);
-      result = {
-        ast,
-        valid: error === null && matched !== null
-      };
+      return { ast, valid: true };
     }
+    const { error, matched } = cssTree.lexer.matchProperty(prop, ast);
+    return { ast, valid: error === null && matched !== null };
   } catch {
-    result = {
-      ast: null,
-      valid: false
-    };
+    return { ast: null, valid: false };
   }
-  lruCache.set(cacheKey, result);
-  return result;
 }
 
 function generateCSSFromAST(ast) {

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -200,7 +200,7 @@ function parsePropertyValue(prop, val, opt = {}) {
         break;
       }
       case AST_TYPES.FUNCTION: {
-        const raw = itemCount === 1 ? val : cssTree.generate(item).replace(/\)(?!\)|\s|,)/g, ") ");
+        const raw = itemCount === 1 ? val : generateCSSFromAST(item);
         // Remove "${name}(" from the start and ")" from the end
         const itemValue = raw.trim().slice(name.length + 1, -1);
         if (calcNameRegEx.test(name)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
-        "@asamuzakjp/generational-cache": "^1.0.1",
         "@bramus/specificity": "^2.4.2",
         "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
         "@exodus/bytes": "^1.15.0",
@@ -20,6 +19,7 @@
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.6",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
@@ -2008,6 +2008,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/mdn-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@bramus/specificity": "^2.4.2",
         "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
         "@exodus/bytes": "^1.15.0",
@@ -19,7 +20,6 @@
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
@@ -2008,15 +2008,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/mdn-data": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@asamuzakjp/css-color": "^5.1.11",
     "@asamuzakjp/dom-selector": "^7.1.1",
+    "@asamuzakjp/generational-cache": "^1.0.1",
     "@bramus/specificity": "^2.4.2",
     "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
     "@exodus/bytes": "^1.15.0",
@@ -33,7 +34,6 @@
     "decimal.js": "^10.6.0",
     "html-encoding-sniffer": "^6.0.0",
     "is-potential-custom-element-name": "^1.0.1",
-    "lru-cache": "^11.3.5",
     "parse5": "^8.0.1",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@asamuzakjp/css-color": "^5.1.11",
     "@asamuzakjp/dom-selector": "^7.1.1",
-    "@asamuzakjp/generational-cache": "^1.0.1",
     "@bramus/specificity": "^2.4.2",
     "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
     "@exodus/bytes": "^1.15.0",
@@ -34,6 +33,7 @@
     "decimal.js": "^10.6.0",
     "html-encoding-sniffer": "^6.0.0",
     "is-potential-custom-element-name": "^1.0.1",
+    "lru-cache": "^11.3.6",
     "parse5": "^8.0.1",
     "saxes": "^6.0.0",
     "symbol-tree": "^3.2.4",


### PR DESCRIPTION
This PR optimizes cache handling.

<!--
## Motivation & Context
The previous implementation used `lru-cache` with `max: 4096`. While effective, the strict access-order management (e.g., linked list operations) of an LRU cache introduces overhead. CSS parsing and value resolution (`calc()` and property validation) typically generate short-lived caches in bursts. A generational cache approach is algorithmically much better suited for this access pattern, as it discards old generations in bulk without per-item management overhead.

I conducted extensive benchmarking to find the optimal cache strategy. I compared the current state (`lru-cache`, max: 4096), an optimized LRU state (`lru-cache`, max: 2048), and the new generational cache (`generational-cache`, max: 1024).

The results showed that while simply reducing the LRU cache size to 2048 brought some improvements, switching to `@asamuzakjp/generational-cache` with `max: 1024` hits the absolute sweet spot: it delivers the best overall performance in the most CPU-intensive tasks while keeping only 1/4 of the original cached items in memory.

## Benchmark Results

Here is the comparison across the three states. (Higher ops/s is better)

### `style/get-computed-style`

| Task Name | Current (`lru-cache: 4096`) | Improvement (`lru-cache: 2048`) | Proposed (`generational: 1024`) |
| :--- | :--- | :--- | :--- |
| `flat (20 siblings)` | 9,292 ops/s | 9,540 ops/s | **10,194 ops/s** |
| `deep (10-level nesting)` | 195,729 ops/s | **205,346 ops/s** | 202,373 ops/s |
| `deep, all levels` | 20,132 ops/s | 18,920 ops/s | **21,604 ops/s** |

### Key Takeaways for the Proposed Change (`generational: 1024`):
1. **Best Peak Performance:** Outperforms the others in the most intensive `deep, all levels` task (+7.3% compared to Current) and the `flat` task (+9.7% compared to Current). While `lru-cache: 2048` slightly edges out in the single `deep` task, the overall balance favors the generational approach.
2. **Massively Reduced Memory Footprint:** The maximum number of cached items is reduced by 75% (from 4096 to 1024).
3. **Less GC Overhead:** The simplified data structure of a generational cache (two simple Maps instead of linked lists) reduces the burden on V8's Garbage Collector.

## Additional Note
If you prefer to stick with `lru-cache` (to avoid introducing a new dependency) and simply change the `max` value to `2048`, please let me know.
I am fine with updating the PR to that approach instead.
-->
