### PR TITLE
Add background-position longhands

### DIFF
--- a/lib/jsdom/living/css/helpers/shorthand-properties.js
+++ b/lib/jsdom/living/css/helpers/shorthand-properties.js
@@ -1406,10 +1406,15 @@ function prepareProperties(properties) {
       let parsedValues = shorthandItem.parse(value);
       if (property === backgroundPosition.property) {
         const parsedBackgroundPosition = backgroundPosition.parseLonghands(value);
+        if (parsedBackgroundPosition && hasPrecedingBackground) {
+          parsedProperties.delete(backgroundPosition.propertyX);
+          parsedProperties.delete(backgroundPosition.propertyY);
+          parsedProperties.delete(backgroundPosition.property);
+        }
         parsedValues = parsedBackgroundPosition && {
-          [backgroundPosition.property]: parsedBackgroundPosition.value,
           [backgroundPosition.propertyX]: parsedBackgroundPosition.x,
-          [backgroundPosition.propertyY]: parsedBackgroundPosition.y
+          [backgroundPosition.propertyY]: parsedBackgroundPosition.y,
+          [backgroundPosition.property]: parsedBackgroundPosition.value
         };
       }
       let omitShorthandProperty = false;

--- a/lib/jsdom/living/css/helpers/shorthand-properties.js
+++ b/lib/jsdom/living/css/helpers/shorthand-properties.js
@@ -4,6 +4,7 @@ const propertyDefinitions = require("../../../../generated/css-property-definiti
 const { hasVarFunc, isGlobalKeyword, isValidPropertyValue, splitValue } = require("./css-values");
 const background = require("../properties/background");
 const backgroundColor = require("../properties/backgroundColor");
+const backgroundPosition = require("../properties/backgroundPosition");
 const border = require("../properties/border");
 const borderWidth = require("../properties/borderWidth");
 const borderStyle = require("../properties/borderStyle");
@@ -36,6 +37,7 @@ const TRBL_INDICES = {
 
 const shorthandProperties = new Map([
   [background.property, background],
+  [backgroundPosition.property, backgroundPosition],
   [
     border.property,
     {
@@ -225,6 +227,17 @@ function replaceBackgroundShorthand(property, properties) {
       bgValues[i][property] = values[i] !== undefined ? values[i] : values[0];
     }
   }
+  if (property === backgroundPosition.propertyX || property === backgroundPosition.propertyY) {
+    for (let i = 0; i < bgLength; i++) {
+      const bgValue = bgValues[i];
+      const x = bgValue[backgroundPosition.propertyX] ?? background.initialValues.get(backgroundPosition.propertyX);
+      const y = bgValue[backgroundPosition.propertyY] ?? background.initialValues.get(backgroundPosition.propertyY);
+      const position = backgroundPosition.serialize(x, y);
+      if (position) {
+        bgValue[backgroundPosition.property] = position;
+      }
+    }
+  }
   const backgrounds = [];
   for (const bgValue of bgValues) {
     const bg = [];
@@ -235,7 +248,10 @@ function replaceBackgroundShorthand(property, properties) {
       originValue === background.initialValues.get("background-origin") &&
       clipValue === background.initialValues.get("background-clip");
     let boxSet = false;
-    for (const longhand of background.initialValues.keys()) {
+    for (const longhand of background.shorthandFor.keys()) {
+      if (longhand === backgroundPosition.propertyX || longhand === backgroundPosition.propertyY) {
+        continue;
+      }
       const value = bgValue[longhand];
       if (!value) {
         continue;
@@ -1213,6 +1229,17 @@ function processShorthandProperties(shorthands) {
   const shorthandItems = new Map();
   for (const [property, item] of shorthands) {
     const shorthandItem = shorthandProperties.get(property);
+    if (property === backgroundPosition.property && item.size === shorthandItem.shorthandFor.size) {
+      const xItem = item.get(backgroundPosition.propertyX);
+      const yItem = item.get(backgroundPosition.propertyY);
+      if (xItem && yItem && xItem.priority === yItem.priority) {
+        const value = backgroundPosition.serialize(xItem.value, yItem.value);
+        if (value) {
+          shorthandItems.set(property, createPropertyItem(property, value, xItem.priority));
+        }
+      }
+      continue;
+    }
     if (item.size === shorthandItem.shorthandFor.size && shorthandItem.position) {
       const positionValues = [];
       let priority = "";
@@ -1376,7 +1403,15 @@ function prepareProperties(properties) {
       parsedProperties.set(property, item);
     } else if (shorthandProperties.has(property)) {
       const shorthandItem = shorthandProperties.get(property);
-      const parsedValues = shorthandItem.parse(value);
+      let parsedValues = shorthandItem.parse(value);
+      if (property === backgroundPosition.property) {
+        const parsedBackgroundPosition = backgroundPosition.parseLonghands(value);
+        parsedValues = parsedBackgroundPosition && {
+          [backgroundPosition.property]: parsedBackgroundPosition.value,
+          [backgroundPosition.propertyX]: parsedBackgroundPosition.x,
+          [backgroundPosition.propertyY]: parsedBackgroundPosition.y
+        };
+      }
       let omitShorthandProperty = false;
       if (Array.isArray(parsedValues)) {
         const [parsedValue] = parsedValues;

--- a/lib/jsdom/living/css/properties/background.js
+++ b/lib/jsdom/living/css/properties/background.js
@@ -3,6 +3,8 @@
 const parsers = require("../helpers/css-values");
 const backgroundImage = require("./backgroundImage");
 const backgroundPosition = require("./backgroundPosition");
+const backgroundPositionX = require("./backgroundPositionX");
+const backgroundPositionY = require("./backgroundPositionY");
 const backgroundSize = require("./backgroundSize");
 const backgroundRepeat = require("./backgroundRepeat");
 const backgroundOrigin = require("./backgroundOrigin");
@@ -15,6 +17,8 @@ const property = "background";
 const initialValues = new Map([
   [backgroundImage.property, "none"],
   [backgroundPosition.property, "0% 0%"],
+  [backgroundPositionX.property, "0%"],
+  [backgroundPositionY.property, "0%"],
   [backgroundSize.property, "auto"],
   [backgroundRepeat.property, "repeat"],
   [backgroundOrigin.property, "padding-box"],
@@ -26,6 +30,8 @@ const initialValues = new Map([
 const shorthandFor = new Map([
   [backgroundImage.property, backgroundImage],
   [backgroundPosition.property, backgroundPosition],
+  [backgroundPositionX.property, backgroundPositionX],
+  [backgroundPositionY.property, backgroundPositionY],
   [backgroundSize.property, backgroundSize],
   [backgroundRepeat.property, backgroundRepeat],
   [backgroundOrigin.property, backgroundOrigin],
@@ -33,6 +39,17 @@ const shorthandFor = new Map([
   [backgroundAttachment.property, backgroundAttachment],
   [backgroundColor.property, backgroundColor]
 ]);
+
+const serializationLonghands = [
+  backgroundImage.property,
+  backgroundPosition.property,
+  backgroundSize.property,
+  backgroundRepeat.property,
+  backgroundOrigin.property,
+  backgroundClip.property,
+  backgroundAttachment.property,
+  backgroundColor.property
+];
 
 const descriptor = {
   set(v) {
@@ -57,6 +74,8 @@ const descriptor = {
       const bgMap = new Map([
         [backgroundImage.property, []],
         [backgroundPosition.property, []],
+        [backgroundPositionX.property, []],
+        [backgroundPositionY.property, []],
         [backgroundSize.property, []],
         [backgroundRepeat.property, []],
         [backgroundOrigin.property, []],
@@ -78,6 +97,11 @@ const descriptor = {
           if (value) {
             const arr = bgMap.get(longhand);
             arr.push(value);
+          }
+        }
+        for (const longhand of serializationLonghands) {
+          const value = bgValue[longhand];
+          if (value) {
             if (longhand === backgroundOrigin.property) {
               if (!isDefaultBox) {
                 bg.push(originValue);
@@ -121,7 +145,7 @@ const descriptor = {
       return v;
     }
     if (parsers.isGlobalKeyword(v)) {
-      for (const [longhand] of shorthandFor) {
+      for (const longhand of serializationLonghands) {
         if (this.getPropertyValue(longhand) !== v) {
           return "";
         }
@@ -195,7 +219,7 @@ const descriptor = {
         originValue === initialValues.get(backgroundOrigin.property) &&
         clipValue === initialValues.get(backgroundClip.property);
       let boxSet = false;
-      for (const [longhand] of shorthandFor) {
+      for (const longhand of serializationLonghands) {
         let value;
         if (bgMap.has(longhand)) {
           const values = bgMap.get(longhand);
@@ -268,6 +292,8 @@ function parse(v) {
     let bg = {
       [backgroundImage.property]: initialValues.get(backgroundImage.property),
       [backgroundPosition.property]: initialValues.get(backgroundPosition.property),
+      [backgroundPositionX.property]: initialValues.get(backgroundPositionX.property),
+      [backgroundPositionY.property]: initialValues.get(backgroundPositionY.property),
       [backgroundSize.property]: initialValues.get(backgroundSize.property),
       [backgroundRepeat.property]: initialValues.get(backgroundRepeat.property),
       [backgroundOrigin.property]: initialValues.get(backgroundOrigin.property),
@@ -279,6 +305,8 @@ function parse(v) {
       bg = {
         [backgroundImage.property]: initialValues.get(backgroundImage.property),
         [backgroundPosition.property]: initialValues.get(backgroundPosition.property),
+        [backgroundPositionX.property]: initialValues.get(backgroundPositionX.property),
+        [backgroundPositionY.property]: initialValues.get(backgroundPositionY.property),
         [backgroundSize.property]: initialValues.get(backgroundSize.property),
         [backgroundRepeat.property]: initialValues.get(backgroundRepeat.property),
         [backgroundOrigin.property]: initialValues.get(backgroundOrigin.property),
@@ -330,10 +358,13 @@ function parse(v) {
               break;
             }
             case backgroundPosition.property: {
-              const parsedValue = value.parse(part);
-              if (parsedValue) {
-                bgPosition.push(parsedValue);
+              if (value.parse(part)) {
+                bgPosition.push(part);
               }
+              break;
+            }
+            case backgroundPositionX.property:
+            case backgroundPositionY.property: {
               break;
             }
             case backgroundRepeat.property: {
@@ -395,6 +426,10 @@ function parse(v) {
               case backgroundPosition.property: {
                 break;
               }
+              case backgroundPositionX.property:
+              case backgroundPositionY.property: {
+                break;
+              }
               case backgroundRepeat.property: {
                 const parsedValue = value.parse(part);
                 if (parsedValue) {
@@ -424,10 +459,11 @@ function parse(v) {
       }
     }
     if (bgPosition.length) {
-      const { parse: parser } = shorthandFor.get(backgroundPosition.property);
-      const value = parser(bgPosition.join(" "));
+      const value = backgroundPosition.parseLonghands(bgPosition.join(" "));
       if (value) {
-        bg[backgroundPosition.property] = value;
+        bg[backgroundPosition.property] = value.value;
+        bg[backgroundPositionX.property] = value.x;
+        bg[backgroundPositionY.property] = value.y;
       }
     }
     if (bgSize.length) {

--- a/lib/jsdom/living/css/properties/backgroundPosition.js
+++ b/lib/jsdom/living/css/properties/backgroundPosition.js
@@ -6,25 +6,39 @@ const parsers = require("../helpers/css-values");
 const { AST_TYPES } = parsers;
 
 const property = "background-position";
-const shorthand = "background";
-const keyX = ["left", "right"];
-const keyY = ["top", "bottom"];
+const propertyX = "background-position-x";
+const propertyY = "background-position-y";
+const background = "background";
+const keyX = ["left", "right", "x-start", "x-end"];
+const keyY = ["top", "bottom", "y-start", "y-end"];
 const keywordsX = ["center", ...keyX];
 const keywordsY = ["center", ...keyY];
 const keywords = ["center", ...keyX, ...keyY];
+
+const shorthandFor = new Map([
+  [propertyX, { property: propertyX, position: "x" }],
+  [propertyY, { property: propertyY, position: "y" }]
+]);
 
 const descriptor = {
   set(v) {
     v = v.trim();
     if (parsers.hasVarFunc(v)) {
-      this._setProperty(shorthand, "");
+      this._setProperty(background, "");
+      this._setProperty(propertyX, "");
+      this._setProperty(propertyY, "");
       this._setProperty(property, v);
     } else {
-      const val = parse(v);
-      if (typeof val === "string") {
+      const val = parseLonghands(v);
+      if (val) {
         const priority =
-          !this._priorities.get(shorthand) && this._priorities.has(property) ? this._priorities.get(property) : "";
-        this._setProperty(property, val, priority);
+          !this._priorities.get(background) && this._priorities.has(property) ?
+            this._priorities.get(property) :
+            "";
+        this._setProperty(background, "");
+        this._setProperty(propertyX, val.x, priority);
+        this._setProperty(propertyY, val.y, priority);
+        this._setProperty(property, val.value, priority);
       }
     }
   },
@@ -35,6 +49,199 @@ const descriptor = {
   configurable: true
 };
 
+function toValue(part) {
+  if (part.type === AST_TYPES.IDENTIFIER || part.type === AST_TYPES.GLOBAL_KEYWORD) {
+    return part.name;
+  }
+  return parsers.resolveNumericValue([part], { type: "length" });
+}
+
+function isX(value) {
+  return keywordsX.includes(value);
+}
+
+function isY(value) {
+  return keywordsY.includes(value);
+}
+
+function isKeyX(value) {
+  return keyX.includes(value);
+}
+
+function isKeyY(value) {
+  return keyY.includes(value);
+}
+
+function isKeyword(value) {
+  return keywords.includes(value);
+}
+
+function isOffset(value) {
+  return Boolean(value) && !isKeyword(value);
+}
+
+function parseLayer(value) {
+  if (!Array.isArray(value) || !value.length || value.length > 4) {
+    return undefined;
+  }
+
+  const parts = value.map(toValue);
+  if (parts.some(part => !part)) {
+    return undefined;
+  }
+
+  let x = "";
+  let y = "";
+  let shorthandValue = "";
+
+  switch (parts.length) {
+    case 1: {
+      const [val] = parts;
+      if (parsers.isGlobalKeyword(val)) {
+        x = val;
+        y = val;
+      } else if (val === "center") {
+        x = val;
+        y = val;
+      } else if (isKeyY(val)) {
+        x = "center";
+        y = val;
+      } else {
+        x = val;
+        y = "center";
+      }
+      break;
+    }
+
+    case 2: {
+      const [val1, val2] = parts;
+      if (isX(val1) && isY(val2)) {
+        x = val1;
+        y = val2;
+      } else if (isY(val1) && isX(val2)) {
+        x = val2;
+        y = val1;
+      } else if (isKeyX(val1) && isOffset(val2)) {
+        x = `${val1} ${val2}`;
+        y = "center";
+        shorthandValue = `${val1} ${val2}`;
+      } else if (val1 === "center" && isOffset(val2)) {
+        x = val1;
+        y = val2;
+      } else if (isKeyY(val1) && isOffset(val2)) {
+        x = "center";
+        y = `${val1} ${val2}`;
+      } else if (isOffset(val1) && isKeyY(val2)) {
+        x = val1;
+        y = val2;
+      } else if (isOffset(val1) && val2 === "center") {
+        x = val1;
+        y = val2;
+      } else if (isOffset(val1) && isOffset(val2)) {
+        x = val1;
+        y = val2;
+      }
+      break;
+    }
+
+    case 3: {
+      const [val1, val2, val3] = parts;
+      if (val1 === "center" && isKeyX(val2) && isOffset(val3)) {
+        x = `${val2} ${val3}`;
+        y = val1;
+      } else if (val1 === "center" && isKeyY(val2) && isOffset(val3)) {
+        x = val1;
+        y = `${val2} ${val3}`;
+      } else if (isKeyX(val1) && isOffset(val2) && isY(val3)) {
+        x = `${val1} ${val2}`;
+        y = val3;
+      } else if (isKeyX(val1) && isKeyY(val2) && isOffset(val3)) {
+        x = val1;
+        y = `${val2} ${val3}`;
+      } else if (isKeyY(val1) && isOffset(val2) && isX(val3)) {
+        x = val3;
+        y = `${val1} ${val2}`;
+      } else if (isKeyY(val1) && isKeyX(val2) && isOffset(val3)) {
+        x = `${val2} ${val3}`;
+        y = val1;
+      }
+      break;
+    }
+
+    case 4: {
+      const [val1, val2, val3, val4] = parts;
+      if (isKeyX(val1) && isOffset(val2) && isKeyY(val3) && isOffset(val4)) {
+        x = `${val1} ${val2}`;
+        y = `${val3} ${val4}`;
+      } else if (isKeyY(val1) && isOffset(val2) && isKeyX(val3) && isOffset(val4)) {
+        x = `${val3} ${val4}`;
+        y = `${val1} ${val2}`;
+      }
+      break;
+    }
+
+    default:
+  }
+
+  if (!x || !y) {
+    return undefined;
+  }
+
+  return {
+    value: shorthandValue || serializeLayer(x, y),
+    x,
+    y
+  };
+}
+
+/**
+ * Parses the background-position property value into shorthand and longhand values.
+ *
+ * @param {string} v - The value to parse.
+ * @returns {object|undefined} The parsed values or undefined if invalid.
+ */
+function parseLonghands(v) {
+  if (v === "") {
+    return {
+      value: v,
+      x: v,
+      y: v
+    };
+  }
+  const values = parsers.splitValue(v, {
+    delimiter: ","
+  });
+  const parsedValues = [];
+  const xValues = [];
+  const yValues = [];
+  for (const val of values) {
+    const value = parsers.parsePropertyValue(property, val);
+    if (Array.isArray(value) && value.length) {
+      const parsed = parseLayer(value);
+      if (!parsed) {
+        return undefined;
+      }
+      parsedValues.push(parsed.value);
+      xValues.push(parsed.x);
+      yValues.push(parsed.y);
+    } else if (typeof value === "string") {
+      parsedValues.push(value);
+      xValues.push(value);
+      yValues.push(value);
+    } else {
+      return undefined;
+    }
+  }
+  if (parsedValues.length) {
+    return {
+      value: parsedValues.join(", "),
+      x: xValues.join(", "),
+      y: yValues.join(", ")
+    };
+  }
+  return undefined;
+}
+
 /**
  * Parses the background-position property value.
  *
@@ -42,6 +249,11 @@ const descriptor = {
  * @returns {string|undefined} The parsed value or undefined if invalid.
  */
 function parse(v) {
+  const parsed = parseLonghands(v);
+  return parsed?.value;
+}
+
+function parseLonghand(propertyName, v) {
   if (v === "") {
     return v;
   }
@@ -50,146 +262,35 @@ function parse(v) {
   });
   const parsedValues = [];
   for (const val of values) {
-    const value = parsers.parsePropertyValue(property, val);
+    const value = parsers.parsePropertyValue(propertyName, val);
     if (Array.isArray(value) && value.length) {
-      const [part1, part2, part3, part4] = value;
-      let parsedValue = "";
-      switch (value.length) {
-        case 1: {
-          if (part1.type === AST_TYPES.GLOBAL_KEYWORD) {
-            parsedValue = part1.name;
-          } else {
-            const val1 =
-              part1.type === AST_TYPES.IDENTIFIER ?
-                part1.name :
-                parsers.resolveNumericValue([part1], { type: "length" });
-            if (val1) {
-              if (val1 === "center") {
-                parsedValue = `${val1} ${val1}`;
-              } else if (val1 === "top" || val1 === "bottom") {
-                parsedValue = `center ${val1}`;
-              } else {
-                parsedValue = `${val1} center`;
-              }
-            }
-          }
-          break;
-        }
-        case 2: {
-          const val1 =
-            part1.type === AST_TYPES.IDENTIFIER ? part1.name : parsers.resolveNumericValue([part1], { type: "length" });
-          const val2 =
-            part2.type === AST_TYPES.IDENTIFIER ? part2.name : parsers.resolveNumericValue([part2], { type: "length" });
-          if (val1 && val2) {
-            if (keywordsX.includes(val1) && keywordsY.includes(val2)) {
-              parsedValue = `${val1} ${val2}`;
-            } else if (keywordsY.includes(val1) && keywordsX.includes(val2)) {
-              parsedValue = `${val2} ${val1}`;
-            } else if (keywordsX.includes(val1)) {
-              if (val2 === "center" || !keywordsX.includes(val2)) {
-                parsedValue = `${val1} ${val2}`;
-              }
-            } else if (keywordsY.includes(val2)) {
-              if (!keywordsY.includes(val1)) {
-                parsedValue = `${val1} ${val2}`;
-              }
-            } else if (!keywordsY.includes(val1) && !keywordsX.includes(val2)) {
-              parsedValue = `${val1} ${val2}`;
-            }
-          }
-          break;
-        }
-        case 3: {
-          const val1 = part1.type === AST_TYPES.IDENTIFIER && part1.name;
-          const val2 =
-            part2.type === AST_TYPES.IDENTIFIER ? part2.name : parsers.resolveNumericValue([part2], { type: "length" });
-          const val3 =
-            part3.type === AST_TYPES.IDENTIFIER ? part3.name : parsers.resolveNumericValue([part3], { type: "length" });
-          if (val1 && val2 && val3) {
-            let posX = "";
-            let offX = "";
-            let posY = "";
-            let offY = "";
-            if (keywordsX.includes(val1)) {
-              if (keyY.includes(val2)) {
-                if (!keywords.includes(val3)) {
-                  posX = val1;
-                  posY = val2;
-                  offY = val3;
-                }
-              } else if (keyY.includes(val3)) {
-                if (!keywords.includes(val2)) {
-                  posX = val1;
-                  offX = val2;
-                  posY = val3;
-                }
-              }
-            } else if (keywordsY.includes(val1)) {
-              if (keyX.includes(val2)) {
-                if (!keywords.includes(val3)) {
-                  posX = val2;
-                  offX = val3;
-                  posY = val1;
-                }
-              } else if (keyX.includes(val3)) {
-                if (!keywords.includes(val2)) {
-                  posX = val3;
-                  posY = val1;
-                  offY = val2;
-                }
-              }
-            }
-            if (posX && posY) {
-              if (offX) {
-                parsedValue = `${posX} ${offX} ${posY}`;
-              } else if (offY) {
-                parsedValue = `${posX} ${posY} ${offY}`;
-              }
-            }
-          }
-          break;
-        }
-        case 4: {
-          const val1 = part1.type === AST_TYPES.IDENTIFIER && part1.name;
-          const val2 = parsers.resolveNumericValue([part2], { type: "length" });
-          const val3 = part3.type === AST_TYPES.IDENTIFIER && part3.name;
-          const val4 = parsers.resolveNumericValue([part4], { type: "length" });
-          if (val1 && val2 && val3 && val4) {
-            let posX = "";
-            let offX = "";
-            let posY = "";
-            let offY = "";
-            if (keywordsX.includes(val1) && keyY.includes(val3)) {
-              posX = val1;
-              offX = val2;
-              posY = val3;
-              offY = val4;
-            } else if (keyX.includes(val1) && keywordsY.includes(val3)) {
-              posX = val1;
-              offX = val2;
-              posY = val3;
-              offY = val4;
-            } else if (keyY.includes(val1) && keywordsX.includes(val3)) {
-              posX = val3;
-              offX = val4;
-              posY = val1;
-              offY = val2;
-            }
-            if (posX && offX && posY && offY) {
-              parsedValue = `${posX} ${offX} ${posY} ${offY}`;
-            }
-          }
-          break;
-        }
-        default:
+      if (value.length > 2) {
+        return undefined;
       }
-      if (parsedValue) {
+      const [part1, part2] = value;
+      if (part1.type === AST_TYPES.GLOBAL_KEYWORD && value.length === 1) {
+        parsedValues.push(part1.name);
+      } else if (part1.type === AST_TYPES.IDENTIFIER && value.length === 1) {
+        parsedValues.push(part1.name);
+      } else if (value.length === 1) {
+        const parsedValue = parsers.resolveNumericValue([part1], { type: "length" });
+        if (!parsedValue) {
+          return undefined;
+        }
         parsedValues.push(parsedValue);
+      } else if (part1.type === AST_TYPES.IDENTIFIER) {
+        const offset = parsers.resolveNumericValue([part2], { type: "length" });
+        if (!offset) {
+          return undefined;
+        }
+        parsedValues.push(`${part1.name} ${offset}`);
       } else {
         return undefined;
       }
     } else if (typeof value === "string") {
       parsedValues.push(value);
+    } else {
+      return undefined;
     }
   }
   if (parsedValues.length) {
@@ -198,8 +299,70 @@ function parse(v) {
   return undefined;
 }
 
+function serializeLayer(x, y) {
+  if (parsers.isGlobalKeyword(x) || parsers.isGlobalKeyword(y)) {
+    return x === y ? x : "";
+  }
+  if (x === "center" && y === "center") {
+    return "center center";
+  }
+  return `${x} ${y}`;
+}
+
+function serialize(x, y) {
+  const xValues = parsers.splitValue(x, {
+    delimiter: ","
+  });
+  const yValues = parsers.splitValue(y, {
+    delimiter: ","
+  });
+  const length = Math.max(xValues.length, yValues.length);
+  const values = [];
+  for (let i = 0; i < length; i++) {
+    const xValue = xValues[i] !== undefined ? xValues[i] : xValues[0];
+    const yValue = yValues[i] !== undefined ? yValues[i] : yValues[0];
+    const value = serializeLayer(xValue, yValue);
+    if (!value) {
+      return undefined;
+    }
+    values.push(value);
+  }
+  return values.join(", ");
+}
+
+function setLonghand(style, longhand, value, priority) {
+  const otherLonghand = longhand === propertyX ? propertyY : propertyX;
+  style._setProperty(background, "");
+  style._setProperty(property, "");
+  style._setProperty(longhand, value, priority);
+
+  const otherValue = style.getPropertyValue(otherLonghand);
+  if (!value || !otherValue || parsers.hasVarFunc(value) || parsers.hasVarFunc(otherValue)) {
+    return;
+  }
+
+  const otherPriority = style.getPropertyPriority(otherLonghand);
+  if (priority !== otherPriority) {
+    return;
+  }
+
+  const x = longhand === propertyX ? value : otherValue;
+  const y = longhand === propertyY ? value : otherValue;
+  const shorthandValue = serialize(x, y);
+  if (shorthandValue) {
+    style._setProperty(property, shorthandValue, priority);
+  }
+}
+
 module.exports = {
   descriptor,
   parse,
-  property
+  parseLonghand,
+  parseLonghands,
+  property,
+  propertyX,
+  propertyY,
+  serialize,
+  setLonghand,
+  shorthandFor
 };

--- a/lib/jsdom/living/css/properties/backgroundPositionX.js
+++ b/lib/jsdom/living/css/properties/backgroundPositionX.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const parsers = require("../helpers/css-values");
+const backgroundPosition = require("./backgroundPosition");
+
+const property = backgroundPosition.propertyX;
+const shorthand = backgroundPosition.property;
+
+const descriptor = {
+  set(v) {
+    v = v.trim();
+    if (parsers.hasVarFunc(v)) {
+      this._setProperty("background", "");
+      this._setProperty(shorthand, "");
+      this._setProperty(property, v);
+    } else {
+      const val = parse(v);
+      if (typeof val === "string") {
+        const priority =
+          !this._priorities.get(shorthand) && this._priorities.has(property) ? this._priorities.get(property) : "";
+        backgroundPosition.setLonghand(this, property, val, priority);
+      }
+    }
+  },
+  get() {
+    return this.getPropertyValue(property);
+  },
+  enumerable: true,
+  configurable: true
+};
+
+/**
+ * Parses the background-position-x property value.
+ *
+ * @param {string} v - The value to parse.
+ * @returns {string|undefined} The parsed value or undefined if invalid.
+ */
+function parse(v) {
+  return backgroundPosition.parseLonghand(property, v);
+}
+
+module.exports = {
+  descriptor,
+  parse,
+  property
+};

--- a/lib/jsdom/living/css/properties/backgroundPositionY.js
+++ b/lib/jsdom/living/css/properties/backgroundPositionY.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const parsers = require("../helpers/css-values");
+const backgroundPosition = require("./backgroundPosition");
+
+const property = backgroundPosition.propertyY;
+const shorthand = backgroundPosition.property;
+
+const descriptor = {
+  set(v) {
+    v = v.trim();
+    if (parsers.hasVarFunc(v)) {
+      this._setProperty("background", "");
+      this._setProperty(shorthand, "");
+      this._setProperty(property, v);
+    } else {
+      const val = parse(v);
+      if (typeof val === "string") {
+        const priority =
+          !this._priorities.get(shorthand) && this._priorities.has(property) ? this._priorities.get(property) : "";
+        backgroundPosition.setLonghand(this, property, val, priority);
+      }
+    }
+  },
+  get() {
+    return this.getPropertyValue(property);
+  },
+  enumerable: true,
+  configurable: true
+};
+
+/**
+ * Parses the background-position-y property value.
+ *
+ * @param {string} v - The value to parse.
+ * @returns {string|undefined} The parsed value or undefined if invalid.
+ */
+function parse(v) {
+  return backgroundPosition.parseLonghand(property, v);
+}
+
+module.exports = {
+  descriptor,
+  parse,
+  property
+};

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -98,10 +98,6 @@ parsing/background-image-valid.html:
   "e.style['background-image'] = \"cross-fade(red 1%, cross-fade(red 2%, green))\" should set the property value": [fail, Not implemented]
 parsing/background-origin-computed.html: [fail, Need to fix getComputedStyle]
 parsing/background-position-computed.html: [fail, Need to fix getComputedStyle]
-parsing/background-position-valid.html:
-  "e.style['background-position'] = \"center right 7%\" should set the property value": [fail, Unknown]
-  "e.style['background-position'] = \"left 10px center\" should set the property value": [fail, Unknown]
-  "e.style['background-position'] = \"top 15px center\" should set the property value": [fail, Unknown]
 parsing/background-position-x-computed.html: [fail, Not implemented]
 parsing/background-position-x-valid.html:
   "e.style['background-position-x'] = \"calc(10px - 0.5em)\" should set the property value": [fail, Unknown]
@@ -119,7 +115,6 @@ parsing/background-valid.html:
   "e.style['background'] = \"url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box, rgb(5, 6, 7) url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box\" should set the property value": [fail, Unknown]
   "e.style['background'] = \"none\" should set background-color": [fail, Need getComputedStyle fix]
   "e.style['background'] = \"none\" should not set unrelated longhands": [fail, Unknown]
-  "e.style['background'] = \"url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box, rgb(5, 6, 7) url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box\" should set background-position": [fail, Unknown]
   "e.style['background'] = \"url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box, rgb(5, 6, 7) url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box\" should not set unrelated longhands": [fail, Unknown]
 parsing/border-image-outset-computed.html: [fail, Need to fix getComputedStyle]
 parsing/border-image-repeat-valid.html:

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -114,8 +114,6 @@ parsing/background-size-computed.html: [fail, Need to fix getComputedStyle]
 parsing/background-valid.html:
   "e.style['background'] = \"url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box, rgb(5, 6, 7) url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box\" should set the property value": [fail, Unknown]
   "e.style['background'] = \"none\" should set background-color": [fail, Need getComputedStyle fix]
-  "e.style['background'] = \"none\" should not set unrelated longhands": [fail, Unknown]
-  "e.style['background'] = \"url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box, rgb(5, 6, 7) url(\\\"https://example.com/\\\") 1px 2px / 3px 4px space round local padding-box content-box\" should not set unrelated longhands": [fail, Unknown]
 parsing/border-image-outset-computed.html: [fail, Need to fix getComputedStyle]
 parsing/border-image-repeat-valid.html:
   "e.style['border-image-repeat'] = \"space space\" should set the property value": [fail, Not implemented]

--- a/test/web-platform-tests/to-upstream/css/cssom/style-background-position-longhands.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-background-position-longhands.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<title>background-position longhands</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#background-position-longhands">
+
+<div id="test"></div>
+
+<script>
+"use strict";
+
+const div = document.getElementById("test");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.cssText = "";
+  });
+
+  div.style.backgroundPosition = "left 10px top 20px";
+
+  assert_equals(div.style.backgroundPosition, "left 10px top 20px", "shorthand");
+  assert_equals(div.style.backgroundPositionX, "left 10px", "x longhand");
+  assert_equals(div.style.backgroundPositionY, "top 20px", "y longhand");
+}, "background-position sets background-position-x and background-position-y");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.cssText = "";
+  });
+
+  div.style.backgroundPositionX = "right 10px";
+  div.style.backgroundPositionY = "bottom 20px";
+
+  assert_equals(div.style.backgroundPosition, "right 10px bottom 20px", "shorthand");
+  assert_equals(div.style.backgroundPositionX, "right 10px", "x longhand");
+  assert_equals(div.style.backgroundPositionY, "bottom 20px", "y longhand");
+}, "background-position-x and background-position-y set background-position");
+
+test(t => {
+  t.add_cleanup(() => {
+    div.style.cssText = "";
+  });
+
+  div.style.background = "url(example.png) 10px 20px / 30px 40px no-repeat";
+
+  assert_equals(div.style.backgroundPosition, "10px 20px", "position shorthand");
+  assert_equals(div.style.backgroundPositionX, "10px", "x longhand");
+  assert_equals(div.style.backgroundPositionY, "20px", "y longhand");
+}, "background sets background-position-x and background-position-y");
+</script>


### PR DESCRIPTION
Implements `background-position-x` and `background-position-y` as CSSOM properties, and updates `background-position`/`background` shorthand synchronization around those longhands.

Closes #4130.

Tested locally:

- `npm run lint`
- `PATH=/tmp:$PATH npm run test:wpt -- --grep serialize-values.html`
- `PATH=/tmp:$PATH npm run test:wpt -- --grep parsing/background-position-x-valid.html`
- `PATH=/tmp:$PATH npm run test:wpt -- --grep parsing/background-position-y-valid.html`
- `PATH=/tmp:$PATH npm run test:wpt -- --grep parsing/background-position-valid.html`
- `PATH=/tmp:$PATH npm run test:wpt -- --grep parsing/background-valid.html`
- `PATH=/tmp:$PATH npm run test:tuwpt -- --grep style-background-position-longhands.html`
- `PATH=/tmp:$PATH npm run test:tuwpt -- --grep style-background-shorthand-overwrite.html`

Also ran full `PATH=/tmp:$PATH npm test` locally. The CSS/background-related tests passed; the full run ended with one unrelated WPT failure in `html/semantics/scripting-1/the-script-element/execution-timing/111.html`, which passed when rerun in isolation.