### PR TITLE
Add Blob.stream

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -141,6 +141,8 @@ export default [
         promise_test: "readonly",
         promise_rejects: "readonly",
         promise_rejects_dom: "readonly",
+        promise_rejects_js: "readonly",
+        promise_rejects_exactly: "readonly",
         generate_tests: "readonly",
         setup: "readonly",
         done: "readonly",

--- a/lib/jsdom/living/file-api/Blob-impl.js
+++ b/lib/jsdom/living/file-api/Blob-impl.js
@@ -1,5 +1,4 @@
 "use strict";
-const { ReadableStream } = require("node:stream/web");
 const { utf8Encode, utf8Decode } = require("../helpers/encoding");
 const Blob = require("../../../generated/idl/Blob");
 const { isArrayBuffer } = require("../../../generated/idl/utils");
@@ -90,7 +89,7 @@ exports.implementation = class BlobImpl {
   stream() {
     const globalObject = this._globalObject;
     const bytes = this._bytes;
-    return new ReadableStream({
+    return new globalObject.ReadableStream({
       type: "bytes",
       start(controller) {
         if (bytes.length > 0) {

--- a/lib/jsdom/living/file-api/Blob-impl.js
+++ b/lib/jsdom/living/file-api/Blob-impl.js
@@ -1,4 +1,5 @@
 "use strict";
+const { ReadableStream } = require("node:stream/web");
 const { utf8Encode, utf8Decode } = require("../helpers/encoding");
 const Blob = require("../../../generated/idl/Blob");
 const { isArrayBuffer } = require("../../../generated/idl/utils");
@@ -84,6 +85,21 @@ exports.implementation = class BlobImpl {
 
   text() {
     return this._globalObject.Promise.resolve(utf8Decode(this._bytes));
+  }
+
+  stream() {
+    const globalObject = this._globalObject;
+    const bytes = this._bytes;
+    return new ReadableStream({
+      type: "bytes",
+      start(controller) {
+        if (bytes.length > 0) {
+          const ab = copyToArrayBufferInTargetRealm(bytes.buffer, globalObject);
+          controller.enqueue(new globalObject.Uint8Array(ab));
+        }
+        controller.close();
+      }
+    });
   }
 
   slice(start, end, contentType) {

--- a/lib/jsdom/living/file-api/Blob.webidl
+++ b/lib/jsdom/living/file-api/Blob.webidl
@@ -16,6 +16,7 @@ interface Blob {
   [NewObject] Promise<USVString> text();
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
   [NewObject] Promise<Uint8Array> bytes();
+  [NewObject] ReadableStream stream();
 };
 
 enum EndingType { "transparent", "native" };

--- a/lib/jsdom/living/interfaces.js
+++ b/lib/jsdom/living/interfaces.js
@@ -241,7 +241,14 @@ const generatedInterfaces = {
   DOMRect: require("../../generated/idl/DOMRect"),
 
   TextDecoder: require("../../generated/idl/TextDecoder"),
-  TextEncoder: require("../../generated/idl/TextEncoder")
+  TextEncoder: require("../../generated/idl/TextEncoder"),
+
+  ReadableStream: require("../../generated/idl/ReadableStream"),
+  ReadableStreamDefaultReader: require("../../generated/idl/ReadableStreamDefaultReader"),
+  ReadableStreamBYOBReader: require("../../generated/idl/ReadableStreamBYOBReader"),
+  ReadableStreamDefaultController: require("../../generated/idl/ReadableStreamDefaultController"),
+  ReadableByteStreamController: require("../../generated/idl/ReadableByteStreamController"),
+  ReadableStreamBYOBRequest: require("../../generated/idl/ReadableStreamBYOBRequest")
 };
 
 function install(window, name, interfaceConstructor) {

--- a/lib/jsdom/living/streams/ReadableByteStreamController-impl.js
+++ b/lib/jsdom/living/streams/ReadableByteStreamController-impl.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const {
+  readableByteStreamControllerCanCloseOrEnqueue,
+  readableByteStreamControllerGetDesiredSize,
+  readableByteStreamControllerClose,
+  readableByteStreamControllerEnqueue,
+  readableByteStreamControllerError,
+  readableByteStreamControllerGetBYOBRequest
+} = require("./internals");
+
+function isViewByteLengthZero(view) {
+  return view.byteLength === 0;
+}
+
+function isBufferDetached(buffer) {
+  return typeof buffer.detached === "boolean" ? buffer.detached : buffer.byteLength === 0;
+}
+
+exports.implementation = class ReadableByteStreamControllerImpl {
+  constructor(globalObject) {
+    this._globalObject = globalObject;
+  }
+
+  get byobRequest() {
+    return readableByteStreamControllerGetBYOBRequest(this);
+  }
+
+  get desiredSize() {
+    return readableByteStreamControllerGetDesiredSize(this);
+  }
+
+  close() {
+    if (this._closeRequested) {
+      throw new this._globalObject.TypeError("close has already been requested.");
+    }
+    if (this._stream._state !== "readable") {
+      throw new this._globalObject.TypeError("Stream is not readable.");
+    }
+    readableByteStreamControllerClose(this);
+  }
+
+  enqueue(chunk) {
+    if (isViewByteLengthZero(chunk)) {
+      throw new this._globalObject.TypeError("chunk.byteLength must not be 0.");
+    }
+    if (chunk.buffer.byteLength === 0) {
+      throw new this._globalObject.TypeError("chunk.buffer.byteLength must not be 0.");
+    }
+    if (isBufferDetached(chunk.buffer)) {
+      throw new this._globalObject.TypeError("chunk's buffer has been detached.");
+    }
+    if (!readableByteStreamControllerCanCloseOrEnqueue(this)) {
+      throw new this._globalObject.TypeError("Cannot enqueue to stream in current state.");
+    }
+    readableByteStreamControllerEnqueue(this, chunk);
+  }
+
+  error(e) {
+    readableByteStreamControllerError(this, e);
+  }
+};

--- a/lib/jsdom/living/streams/ReadableByteStreamController.webidl
+++ b/lib/jsdom/living/streams/ReadableByteStreamController.webidl
@@ -1,0 +1,9 @@
+[Exposed=(Window,Worker)]
+interface ReadableByteStreamController {
+  readonly attribute ReadableStreamBYOBRequest? byobRequest;
+  readonly attribute unrestricted double? desiredSize;
+
+  undefined close();
+  undefined enqueue(ArrayBufferView chunk);
+  undefined error(optional any e);
+};

--- a/lib/jsdom/living/streams/ReadableStream-impl.js
+++ b/lib/jsdom/living/streams/ReadableStream-impl.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const idlUtils = require("../../../generated/idl/utils");
+const ReadableStreamDefaultReader = require("../../../generated/idl/ReadableStreamDefaultReader");
+const ReadableStreamBYOBReader = require("../../../generated/idl/ReadableStreamBYOBReader");
+const {
+  initializeReadableStream,
+  isReadableStreamLocked,
+  readableStreamCancel,
+  extractHighWaterMark,
+  extractSizeAlgorithm,
+  convertUnderlyingDefaultOrByteSource,
+  setUpReadableStreamDefaultControllerFromUnderlyingSource,
+  setUpReadableByteStreamControllerFromUnderlyingSource,
+  readableStreamTee
+} = require("./internals");
+
+exports.implementation = class ReadableStreamImpl {
+  constructor(globalObject, [underlyingSource, strategy]) {
+    this._globalObject = globalObject;
+    initializeReadableStream(this);
+
+    const underlyingSourceDict = convertUnderlyingDefaultOrByteSource(underlyingSource);
+    const strat = strategy || {};
+
+    if (underlyingSourceDict.type === "bytes") {
+      if (strat.size !== undefined) {
+        throw new RangeError("byte streams must not have a size function.");
+      }
+      const highWaterMark = extractHighWaterMark(strat, 0);
+      setUpReadableByteStreamControllerFromUnderlyingSource(
+        this,
+        underlyingSource,
+        underlyingSourceDict,
+        highWaterMark,
+        globalObject
+      );
+    } else {
+      const sizeAlgorithm = extractSizeAlgorithm(strat);
+      const highWaterMark = extractHighWaterMark(strat, 1);
+      setUpReadableStreamDefaultControllerFromUnderlyingSource(
+        this,
+        underlyingSource,
+        underlyingSourceDict,
+        highWaterMark,
+        sizeAlgorithm,
+        globalObject
+      );
+    }
+  }
+
+  get locked() {
+    return isReadableStreamLocked(this);
+  }
+
+  cancel(reason) {
+    if (isReadableStreamLocked(this)) {
+      return this._globalObject.Promise.reject(
+        new this._globalObject.TypeError("Cannot cancel a stream that already has a reader.")
+      );
+    }
+    return readableStreamCancel(this, reason);
+  }
+
+  getReader(options) {
+    if (options && options.mode === "byob") {
+      return ReadableStreamBYOBReader.createImpl(this._globalObject, [idlUtils.wrapperForImpl(this)], {});
+    }
+    return ReadableStreamDefaultReader.createImpl(this._globalObject, [idlUtils.wrapperForImpl(this)], {});
+  }
+
+  tee() {
+    if (isReadableStreamLocked(this)) {
+      throw new this._globalObject.TypeError("Cannot tee a stream that already has a reader.");
+    }
+    return readableStreamTee(this).map(branchImpl => idlUtils.wrapperForImpl(branchImpl));
+  }
+};

--- a/lib/jsdom/living/streams/ReadableStream.webidl
+++ b/lib/jsdom/living/streams/ReadableStream.webidl
@@ -1,0 +1,25 @@
+[Exposed=(Window,Worker)]
+interface ReadableStream {
+  constructor(optional object underlyingSource, optional QueuingStrategy strategy = {});
+
+  readonly attribute boolean locked;
+
+  Promise<undefined> cancel(optional any reason);
+  ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
+  sequence<ReadableStream> tee();
+};
+
+typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStreamReader;
+
+enum ReadableStreamReaderMode { "byob" };
+
+dictionary ReadableStreamGetReaderOptions {
+  ReadableStreamReaderMode mode;
+};
+
+dictionary QueuingStrategy {
+  unrestricted double highWaterMark;
+  QueuingStrategySize size;
+};
+
+callback QueuingStrategySize = unrestricted double (any chunk);

--- a/lib/jsdom/living/streams/ReadableStreamBYOBReader-impl.js
+++ b/lib/jsdom/living/streams/ReadableStreamBYOBReader-impl.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const ReadableStream = require("../../../generated/idl/ReadableStream");
+const {
+  newPromiseCapability,
+  isReadableStreamLocked,
+  readableStreamReaderGenericInitialize,
+  readableStreamReaderGenericCancel,
+  readableStreamBYOBReaderRelease,
+  readableStreamBYOBReaderRead,
+  READER
+} = require("./internals");
+
+function isViewByteLengthZero(view) {
+  return view.byteLength === 0;
+}
+
+function isBufferDetached(buffer) {
+  return typeof buffer.detached === "boolean" ? buffer.detached : buffer.byteLength === 0;
+}
+
+exports.implementation = class ReadableStreamBYOBReaderImpl {
+  constructor(globalObject, [streamWrapper]) {
+    this._globalObject = globalObject;
+    this._readerType = READER.BYOB;
+    this._readIntoRequests = [];
+    this._readRequests = []; // unused, but harmless
+
+    const streamImpl = ReadableStream.convert(globalObject, streamWrapper);
+    if (streamImpl._controller._pendingPullIntos === undefined) {
+      throw new globalObject.TypeError("Cannot acquire a BYOB reader on a non-byte stream.");
+    }
+    if (isReadableStreamLocked(streamImpl)) {
+      throw new globalObject.TypeError("Stream is already locked to a reader.");
+    }
+    readableStreamReaderGenericInitialize(this, streamImpl, globalObject);
+  }
+
+  get closed() {
+    return this._closedPromise.promise;
+  }
+
+  cancel(reason) {
+    if (this._stream === undefined) {
+      return this._globalObject.Promise.reject(
+        new this._globalObject.TypeError("Reader is no longer associated with a stream.")
+      );
+    }
+    return readableStreamReaderGenericCancel(this, reason);
+  }
+
+  read(view, options) {
+    const globalObject = this._globalObject;
+    if (isViewByteLengthZero(view)) {
+      return globalObject.Promise.reject(new globalObject.TypeError("view.byteLength must not be 0."));
+    }
+    if (view.buffer.byteLength === 0) {
+      return globalObject.Promise.reject(new globalObject.TypeError("view.buffer.byteLength must not be 0."));
+    }
+    if (isBufferDetached(view.buffer)) {
+      return globalObject.Promise.reject(new globalObject.TypeError("view's buffer has been detached."));
+    }
+    const min = options && options.min !== undefined ? Number(options.min) : 1;
+    if (min === 0) {
+      return globalObject.Promise.reject(new globalObject.TypeError("options.min must not be 0."));
+    }
+    if (!Number.isInteger(min) || min < 1) {
+      return globalObject.Promise.reject(new globalObject.TypeError("options.min must be a positive integer."));
+    }
+    if (view.constructor !== DataView) {
+      const elementCount = view.byteLength / view.BYTES_PER_ELEMENT;
+      if (min > elementCount) {
+        return globalObject.Promise.reject(new globalObject.RangeError("options.min exceeds view element count."));
+      }
+    } else if (min > view.byteLength) {
+      return globalObject.Promise.reject(new globalObject.RangeError("options.min exceeds view byte length."));
+    }
+    if (this._stream === undefined) {
+      return globalObject.Promise.reject(new globalObject.TypeError("Reader is no longer associated with a stream."));
+    }
+    const capability = newPromiseCapability(globalObject);
+    const readIntoRequest = {
+      chunkSteps: chunk => capability.resolve({ value: chunk, done: false }),
+      closeSteps: chunk => capability.resolve({ value: chunk, done: true }),
+      errorSteps: e => capability.reject(e)
+    };
+    readableStreamBYOBReaderRead(this, view, min, readIntoRequest);
+    return capability.promise;
+  }
+
+  releaseLock() {
+    if (this._stream === undefined) {
+      return;
+    }
+    readableStreamBYOBReaderRelease(this);
+  }
+};

--- a/lib/jsdom/living/streams/ReadableStreamBYOBReader.webidl
+++ b/lib/jsdom/living/streams/ReadableStreamBYOBReader.webidl
@@ -1,0 +1,12 @@
+[Exposed=(Window,Worker)]
+interface ReadableStreamBYOBReader {
+  constructor(ReadableStream stream);
+
+  Promise<ReadableStreamReadResult> read(ArrayBufferView view, optional ReadableStreamBYOBReaderReadOptions options = {});
+  undefined releaseLock();
+};
+ReadableStreamBYOBReader includes ReadableStreamGenericReader;
+
+dictionary ReadableStreamBYOBReaderReadOptions {
+  [EnforceRange] unsigned long long min = 1;
+};

--- a/lib/jsdom/living/streams/ReadableStreamBYOBRequest-impl.js
+++ b/lib/jsdom/living/streams/ReadableStreamBYOBRequest-impl.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const {
+  readableByteStreamControllerRespond,
+  readableByteStreamControllerRespondWithNewView
+} = require("./internals");
+
+function isBufferDetached(buffer) {
+  return typeof buffer.detached === "boolean" ? buffer.detached : false;
+}
+
+exports.implementation = class ReadableStreamBYOBRequestImpl {
+  constructor(globalObject) {
+    this._globalObject = globalObject;
+    this._controller = undefined;
+    this._view = null;
+  }
+
+  get view() {
+    return this._view;
+  }
+
+  respond(bytesWritten) {
+    if (this._controller === undefined) {
+      throw new this._globalObject.TypeError("Request is no longer associated with a controller.");
+    }
+    if (isBufferDetached(this._view.buffer)) {
+      throw new this._globalObject.TypeError("view's buffer has been detached.");
+    }
+    readableByteStreamControllerRespond(this._controller, bytesWritten);
+  }
+
+  respondWithNewView(view) {
+    if (this._controller === undefined) {
+      throw new this._globalObject.TypeError("Request is no longer associated with a controller.");
+    }
+    if (isBufferDetached(view.buffer)) {
+      throw new this._globalObject.TypeError("view's buffer has been detached.");
+    }
+    readableByteStreamControllerRespondWithNewView(this._controller, view);
+  }
+};

--- a/lib/jsdom/living/streams/ReadableStreamBYOBRequest.webidl
+++ b/lib/jsdom/living/streams/ReadableStreamBYOBRequest.webidl
@@ -1,0 +1,7 @@
+[Exposed=(Window,Worker)]
+interface ReadableStreamBYOBRequest {
+  readonly attribute ArrayBufferView? view;
+
+  undefined respond([EnforceRange] unsigned long long bytesWritten);
+  undefined respondWithNewView(ArrayBufferView view);
+};

--- a/lib/jsdom/living/streams/ReadableStreamDefaultController-impl.js
+++ b/lib/jsdom/living/streams/ReadableStreamDefaultController-impl.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const {
+  readableStreamDefaultControllerCanCloseOrEnqueue,
+  readableStreamDefaultControllerGetDesiredSize,
+  readableStreamDefaultControllerClose,
+  readableStreamDefaultControllerEnqueue,
+  readableStreamDefaultControllerError
+} = require("./internals");
+
+exports.implementation = class ReadableStreamDefaultControllerImpl {
+  constructor(globalObject) {
+    this._globalObject = globalObject;
+  }
+
+  get desiredSize() {
+    return readableStreamDefaultControllerGetDesiredSize(this);
+  }
+
+  close() {
+    if (!readableStreamDefaultControllerCanCloseOrEnqueue(this)) {
+      throw new this._globalObject.TypeError("Cannot close stream in current state.");
+    }
+    readableStreamDefaultControllerClose(this);
+  }
+
+  enqueue(chunk) {
+    if (!readableStreamDefaultControllerCanCloseOrEnqueue(this)) {
+      throw new this._globalObject.TypeError("Cannot enqueue to stream in current state.");
+    }
+    readableStreamDefaultControllerEnqueue(this, chunk);
+  }
+
+  error(e) {
+    readableStreamDefaultControllerError(this, e);
+  }
+};

--- a/lib/jsdom/living/streams/ReadableStreamDefaultController.webidl
+++ b/lib/jsdom/living/streams/ReadableStreamDefaultController.webidl
@@ -1,0 +1,8 @@
+[Exposed=(Window,Worker)]
+interface ReadableStreamDefaultController {
+  readonly attribute unrestricted double? desiredSize;
+
+  undefined close();
+  undefined enqueue(optional any chunk);
+  undefined error(optional any e);
+};

--- a/lib/jsdom/living/streams/ReadableStreamDefaultReader-impl.js
+++ b/lib/jsdom/living/streams/ReadableStreamDefaultReader-impl.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const ReadableStream = require("../../../generated/idl/ReadableStream");
+const {
+  newPromiseCapability,
+  isReadableStreamLocked,
+  readableStreamReaderGenericInitialize,
+  readableStreamReaderGenericCancel,
+  readableStreamDefaultReaderRelease,
+  readableStreamDefaultReaderRead,
+  READER
+} = require("./internals");
+
+exports.implementation = class ReadableStreamDefaultReaderImpl {
+  constructor(globalObject, [streamWrapper]) {
+    this._globalObject = globalObject;
+    this._readerType = READER.DEFAULT;
+    this._readRequests = [];
+    this._readIntoRequests = []; // unused, but harmless
+
+    const streamImpl = ReadableStream.convert(globalObject, streamWrapper);
+    if (isReadableStreamLocked(streamImpl)) {
+      throw new globalObject.TypeError("Stream is already locked to a reader.");
+    }
+    readableStreamReaderGenericInitialize(this, streamImpl, globalObject);
+  }
+
+  get closed() {
+    return this._closedPromise.promise;
+  }
+
+  cancel(reason) {
+    if (this._stream === undefined) {
+      return this._globalObject.Promise.reject(
+        new this._globalObject.TypeError("Reader is no longer associated with a stream.")
+      );
+    }
+    return readableStreamReaderGenericCancel(this, reason);
+  }
+
+  read() {
+    if (this._stream === undefined) {
+      return this._globalObject.Promise.reject(
+        new this._globalObject.TypeError("Reader is no longer associated with a stream.")
+      );
+    }
+    const capability = newPromiseCapability(this._globalObject);
+    const readRequest = {
+      chunkSteps: chunk => capability.resolve({ value: chunk, done: false }),
+      closeSteps: () => capability.resolve({ value: undefined, done: true }),
+      errorSteps: e => capability.reject(e)
+    };
+    readableStreamDefaultReaderRead(this, readRequest);
+    return capability.promise;
+  }
+
+  releaseLock() {
+    if (this._stream === undefined) {
+      return;
+    }
+    readableStreamDefaultReaderRelease(this);
+  }
+};

--- a/lib/jsdom/living/streams/ReadableStreamDefaultReader.webidl
+++ b/lib/jsdom/living/streams/ReadableStreamDefaultReader.webidl
@@ -1,0 +1,19 @@
+[Exposed=(Window,Worker)]
+interface ReadableStreamDefaultReader {
+  constructor(ReadableStream stream);
+
+  Promise<ReadableStreamReadResult> read();
+  undefined releaseLock();
+};
+ReadableStreamDefaultReader includes ReadableStreamGenericReader;
+
+dictionary ReadableStreamReadResult {
+  any value;
+  boolean done;
+};
+
+interface mixin ReadableStreamGenericReader {
+  readonly attribute Promise<undefined> closed;
+
+  Promise<undefined> cancel(optional any reason);
+};

--- a/lib/jsdom/living/streams/internals.js
+++ b/lib/jsdom/living/streams/internals.js
@@ -1,0 +1,1612 @@
+"use strict";
+
+// Implementation of the WHATWG Streams Standard "readable streams" section.
+// See https://streams.spec.whatwg.org/#rs-abstract-ops and related sections.
+// The slot/state names below follow the spec's `[[name]]` slots, lower-cased.
+
+const STATE = Object.freeze({
+  READABLE: "readable",
+  CLOSED: "closed",
+  ERRORED: "errored"
+});
+
+const READER = Object.freeze({
+  DEFAULT: "default",
+  BYOB: "byob"
+});
+
+// --- Promise helpers --------------------------------------------------------
+
+function newPromiseCapability(globalObject) {
+  let resolve,
+    reject;
+  const promise = new globalObject.Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function resolvedPromise(globalObject, value) {
+  return globalObject.Promise.resolve(value);
+}
+
+function rejectedPromise(globalObject, reason) {
+  return globalObject.Promise.reject(reason);
+}
+
+// Mark a promise as handled so unhandled-rejection diagnostics ignore it.
+// We attach an empty rejection handler.
+function markPromiseHandled(promise) {
+  promise.then(undefined, () => {});
+}
+
+// --- Queue-with-sizes -------------------------------------------------------
+
+function dequeueValue(container) {
+  const valueWithSize = container._queue.shift();
+  container._queueTotalSize -= valueWithSize.size;
+  if (container._queueTotalSize < 0) {
+    container._queueTotalSize = 0;
+  }
+  return valueWithSize.value;
+}
+
+function enqueueValueWithSize(container, value, size) {
+  if (!Number.isFinite(size) || size < 0) {
+    throw new RangeError("Size must be a finite, non-negative number.");
+  }
+  container._queue.push({ value, size });
+  container._queueTotalSize += size;
+}
+
+function resetQueue(container) {
+  container._queue = [];
+  container._queueTotalSize = 0;
+}
+
+// --- Strategy helpers -------------------------------------------------------
+
+function extractHighWaterMark(strategy, defaultHWM) {
+  if (strategy.highWaterMark === undefined) {
+    return defaultHWM;
+  }
+  const hwm = Number(strategy.highWaterMark);
+  if (Number.isNaN(hwm) || hwm < 0) {
+    throw new RangeError("highWaterMark must be a non-negative number.");
+  }
+  return hwm;
+}
+
+function extractSizeAlgorithm(strategy) {
+  if (strategy.size === undefined) {
+    return () => 1;
+  }
+  return chunk => strategy.size(chunk);
+}
+
+// --- Stream state -----------------------------------------------------------
+
+function initializeReadableStream(stream) {
+  stream._state = STATE.READABLE;
+  stream._reader = undefined;
+  stream._storedError = undefined;
+  stream._disturbed = false;
+  stream._controller = undefined;
+}
+
+function isReadableStreamLocked(stream) {
+  return stream._reader !== undefined;
+}
+
+function readableStreamGetNumReadRequests(stream) {
+  return stream._reader._readRequests.length;
+}
+
+function readableStreamGetNumReadIntoRequests(stream) {
+  return stream._reader._readIntoRequests.length;
+}
+
+function readableStreamHasDefaultReader(stream) {
+  const reader = stream._reader;
+  return reader !== undefined && reader._readerType === READER.DEFAULT;
+}
+
+function readableStreamHasBYOBReader(stream) {
+  const reader = stream._reader;
+  return reader !== undefined && reader._readerType === READER.BYOB;
+}
+
+function readableStreamFulfillReadRequest(stream, chunk, done) {
+  const readRequest = stream._reader._readRequests.shift();
+  if (done) {
+    readRequest.closeSteps();
+  } else {
+    readRequest.chunkSteps(chunk);
+  }
+}
+
+function readableStreamFulfillReadIntoRequest(stream, chunk, done) {
+  const readIntoRequest = stream._reader._readIntoRequests.shift();
+  if (done) {
+    readIntoRequest.closeSteps(chunk);
+  } else {
+    readIntoRequest.chunkSteps(chunk);
+  }
+}
+
+function readableStreamAddReadRequest(stream, readRequest) {
+  stream._reader._readRequests.push(readRequest);
+}
+
+function readableStreamAddReadIntoRequest(stream, readIntoRequest) {
+  stream._reader._readIntoRequests.push(readIntoRequest);
+}
+
+function readableStreamClose(stream) {
+  stream._state = STATE.CLOSED;
+  const reader = stream._reader;
+  if (reader === undefined) {
+    return;
+  }
+  reader._closedPromise.resolve(undefined);
+  if (reader._readerType === READER.DEFAULT) {
+    for (const readRequest of reader._readRequests) {
+      readRequest.closeSteps();
+    }
+    reader._readRequests = [];
+  }
+}
+
+function readableStreamError(stream, error) {
+  stream._state = STATE.ERRORED;
+  stream._storedError = error;
+  const reader = stream._reader;
+  if (reader === undefined) {
+    return;
+  }
+  reader._closedPromise.reject(error);
+  markPromiseHandled(reader._closedPromise.promise);
+  if (reader._readerType === READER.DEFAULT) {
+    for (const readRequest of reader._readRequests) {
+      readRequest.errorSteps(error);
+    }
+    reader._readRequests = [];
+  } else {
+    for (const readIntoRequest of reader._readIntoRequests) {
+      readIntoRequest.errorSteps(error);
+    }
+    reader._readIntoRequests = [];
+  }
+}
+
+function readableStreamCancel(stream, reason) {
+  const globalObject = stream._globalObject;
+  stream._disturbed = true;
+  if (stream._state === STATE.CLOSED) {
+    return resolvedPromise(globalObject, undefined);
+  }
+  if (stream._state === STATE.ERRORED) {
+    return rejectedPromise(globalObject, stream._storedError);
+  }
+  readableStreamClose(stream);
+  const reader = stream._reader;
+  if (reader !== undefined && reader._readerType === READER.BYOB) {
+    for (const readIntoRequest of reader._readIntoRequests) {
+      readIntoRequest.closeSteps(undefined);
+    }
+    reader._readIntoRequests = [];
+  }
+  const sourceCancelPromise = stream._controller._cancelSteps(reason);
+  return sourceCancelPromise.then(() => undefined);
+}
+
+// --- Generic reader ---------------------------------------------------------
+
+function readableStreamReaderGenericInitialize(reader, stream, globalObject) {
+  reader._globalObject = globalObject;
+  reader._stream = stream;
+  stream._reader = reader;
+  if (stream._state === STATE.READABLE) {
+    reader._closedPromise = newPromiseCapability(globalObject);
+  } else if (stream._state === STATE.CLOSED) {
+    reader._closedPromise = newPromiseCapability(globalObject);
+    reader._closedPromise.resolve(undefined);
+  } else {
+    reader._closedPromise = newPromiseCapability(globalObject);
+    reader._closedPromise.reject(stream._storedError);
+    markPromiseHandled(reader._closedPromise.promise);
+  }
+}
+
+function readableStreamReaderGenericCancel(reader, reason) {
+  const stream = reader._stream;
+  return readableStreamCancel(stream, reason);
+}
+
+function readableStreamReaderGenericRelease(reader) {
+  const globalObject = reader._globalObject;
+  const stream = reader._stream;
+  const releasedError = new globalObject.TypeError("Reader was released.");
+  if (stream._state === STATE.READABLE) {
+    reader._closedPromise.reject(releasedError);
+  } else {
+    reader._closedPromise = newPromiseCapability(globalObject);
+    reader._closedPromise.reject(releasedError);
+  }
+  markPromiseHandled(reader._closedPromise.promise);
+  stream._controller._releaseSteps();
+  stream._reader = undefined;
+  reader._stream = undefined;
+}
+
+function readableStreamDefaultReaderRelease(reader) {
+  readableStreamReaderGenericRelease(reader);
+  const globalObject = reader._globalObject;
+  const releasedError = new globalObject.TypeError("Reader was released.");
+  for (const readRequest of reader._readRequests) {
+    readRequest.errorSteps(releasedError);
+  }
+  reader._readRequests = [];
+}
+
+function readableStreamBYOBReaderRelease(reader) {
+  readableStreamReaderGenericRelease(reader);
+  const globalObject = reader._globalObject;
+  const releasedError = new globalObject.TypeError("Reader was released.");
+  for (const readIntoRequest of reader._readIntoRequests) {
+    readIntoRequest.errorSteps(releasedError);
+  }
+  reader._readIntoRequests = [];
+}
+
+// --- Default reader read ---------------------------------------------------
+
+function readableStreamDefaultReaderRead(reader, readRequest) {
+  const stream = reader._stream;
+  stream._disturbed = true;
+  if (stream._state === STATE.CLOSED) {
+    readRequest.closeSteps();
+  } else if (stream._state === STATE.ERRORED) {
+    readRequest.errorSteps(stream._storedError);
+  } else {
+    stream._controller._pullSteps(readRequest);
+  }
+}
+
+// --- BYOB reader read ------------------------------------------------------
+
+function readableStreamBYOBReaderRead(reader, view, min, readIntoRequest) {
+  const stream = reader._stream;
+  stream._disturbed = true;
+  if (stream._state === STATE.ERRORED) {
+    readIntoRequest.errorSteps(stream._storedError);
+  } else {
+    readableByteStreamControllerPullInto(stream._controller, view, min, readIntoRequest);
+  }
+}
+
+// --- Default controller ---------------------------------------------------
+
+function readableStreamDefaultControllerShouldCallPull(controller) {
+  const stream = controller._stream;
+  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
+    return false;
+  }
+  if (!controller._started) {
+    return false;
+  }
+  if (isReadableStreamLocked(stream) && readableStreamGetNumReadRequests(stream) > 0) {
+    return true;
+  }
+  const desiredSize = readableStreamDefaultControllerGetDesiredSize(controller);
+  return desiredSize > 0;
+}
+
+function readableStreamDefaultControllerCanCloseOrEnqueue(controller) {
+  return !controller._closeRequested && controller._stream._state === STATE.READABLE;
+}
+
+function readableStreamDefaultControllerGetDesiredSize(controller) {
+  const state = controller._stream._state;
+  if (state === STATE.ERRORED) {
+    return null;
+  }
+  if (state === STATE.CLOSED) {
+    return 0;
+  }
+  return controller._strategyHWM - controller._queueTotalSize;
+}
+
+function readableStreamDefaultControllerCallPullIfNeeded(controller) {
+  if (!readableStreamDefaultControllerShouldCallPull(controller)) {
+    return;
+  }
+  if (controller._pulling) {
+    controller._pullAgain = true;
+    return;
+  }
+  controller._pulling = true;
+  const pullPromise = controller._pullAlgorithm();
+  pullPromise.then(
+    () => {
+      controller._pulling = false;
+      if (controller._pullAgain) {
+        controller._pullAgain = false;
+        readableStreamDefaultControllerCallPullIfNeeded(controller);
+      }
+    },
+    err => {
+      readableStreamDefaultControllerError(controller, err);
+    }
+  );
+}
+
+function readableStreamDefaultControllerClearAlgorithms(controller) {
+  controller._pullAlgorithm = undefined;
+  controller._cancelAlgorithm = undefined;
+  controller._strategySizeAlgorithm = undefined;
+}
+
+function readableStreamDefaultControllerClose(controller) {
+  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
+    return;
+  }
+  controller._closeRequested = true;
+  if (controller._queue.length === 0) {
+    readableStreamDefaultControllerClearAlgorithms(controller);
+    readableStreamClose(controller._stream);
+  }
+}
+
+function readableStreamDefaultControllerEnqueue(controller, chunk) {
+  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
+    return;
+  }
+  const stream = controller._stream;
+  if (isReadableStreamLocked(stream) && readableStreamGetNumReadRequests(stream) > 0) {
+    readableStreamFulfillReadRequest(stream, chunk, false);
+  } else {
+    let chunkSize;
+    try {
+      chunkSize = controller._strategySizeAlgorithm(chunk);
+    } catch (e) {
+      readableStreamDefaultControllerError(controller, e);
+      throw e;
+    }
+    try {
+      enqueueValueWithSize(controller, chunk, chunkSize);
+    } catch (e) {
+      readableStreamDefaultControllerError(controller, e);
+      throw e;
+    }
+  }
+  readableStreamDefaultControllerCallPullIfNeeded(controller);
+}
+
+function readableStreamDefaultControllerError(controller, e) {
+  const stream = controller._stream;
+  if (stream._state !== STATE.READABLE) {
+    return;
+  }
+  resetQueue(controller);
+  readableStreamDefaultControllerClearAlgorithms(controller);
+  readableStreamError(stream, e);
+}
+
+// _pullSteps for default controller
+function defaultControllerPullSteps(controller, readRequest) {
+  const stream = controller._stream;
+  if (controller._queue.length > 0) {
+    const chunk = dequeueValue(controller);
+    if (controller._closeRequested && controller._queue.length === 0) {
+      readableStreamDefaultControllerClearAlgorithms(controller);
+      readableStreamClose(stream);
+    } else {
+      readableStreamDefaultControllerCallPullIfNeeded(controller);
+    }
+    readRequest.chunkSteps(chunk);
+  } else {
+    readableStreamAddReadRequest(stream, readRequest);
+    readableStreamDefaultControllerCallPullIfNeeded(controller);
+  }
+}
+
+function defaultControllerCancelSteps(controller, reason) {
+  resetQueue(controller);
+  const result = controller._cancelAlgorithm(reason);
+  readableStreamDefaultControllerClearAlgorithms(controller);
+  return result;
+}
+
+function defaultControllerReleaseSteps() {
+  // no-op for default controller
+}
+
+function setUpReadableStreamDefaultController(
+  stream,
+  controller,
+  startAlgorithm,
+  pullAlgorithm,
+  cancelAlgorithm,
+  highWaterMark,
+  sizeAlgorithm
+) {
+  controller._stream = stream;
+  resetQueue(controller);
+  controller._started = false;
+  controller._closeRequested = false;
+  controller._pullAgain = false;
+  controller._pulling = false;
+  controller._strategySizeAlgorithm = sizeAlgorithm;
+  controller._strategyHWM = highWaterMark;
+  controller._pullAlgorithm = pullAlgorithm;
+  controller._cancelAlgorithm = cancelAlgorithm;
+  controller._pullSteps = readRequest => defaultControllerPullSteps(controller, readRequest);
+  controller._cancelSteps = reason => defaultControllerCancelSteps(controller, reason);
+  controller._releaseSteps = defaultControllerReleaseSteps;
+
+  stream._controller = controller;
+  const startResult = startAlgorithm();
+  Promise.resolve(startResult).then(
+    () => {
+      controller._started = true;
+      readableStreamDefaultControllerCallPullIfNeeded(controller);
+    },
+    r => {
+      readableStreamDefaultControllerError(controller, r);
+    }
+  );
+}
+
+function setUpReadableStreamDefaultControllerFromUnderlyingSource(
+  stream,
+  underlyingSource,
+  underlyingSourceDict,
+  highWaterMark,
+  sizeAlgorithm,
+  globalObject
+) {
+  const ReadableStreamDefaultController = require("../../../generated/idl/ReadableStreamDefaultController");
+  const controller = ReadableStreamDefaultController.createImpl(globalObject, [], {});
+
+  function startAlgorithm() {
+    if (underlyingSourceDict.start === undefined) {
+      return undefined;
+    }
+    return underlyingSourceDict.start.call(underlyingSource, getControllerWrapper(controller));
+  }
+  function pullAlgorithm() {
+    if (underlyingSourceDict.pull === undefined) {
+      return resolvedPromise(globalObject, undefined);
+    }
+    try {
+      return Promise.resolve(underlyingSourceDict.pull.call(underlyingSource, getControllerWrapper(controller)));
+    } catch (e) {
+      return rejectedPromise(globalObject, e);
+    }
+  }
+  function cancelAlgorithm(reason) {
+    if (underlyingSourceDict.cancel === undefined) {
+      return resolvedPromise(globalObject, undefined);
+    }
+    try {
+      return Promise.resolve(underlyingSourceDict.cancel.call(underlyingSource, reason));
+    } catch (e) {
+      return rejectedPromise(globalObject, e);
+    }
+  }
+  setUpReadableStreamDefaultController(
+    stream,
+    controller,
+    startAlgorithm,
+    pullAlgorithm,
+    cancelAlgorithm,
+    highWaterMark,
+    sizeAlgorithm
+  );
+}
+
+// --- Byte stream controller ------------------------------------------------
+
+function readableByteStreamControllerCanCloseOrEnqueue(controller) {
+  return !controller._closeRequested && controller._stream._state === STATE.READABLE;
+}
+
+function readableByteStreamControllerGetDesiredSize(controller) {
+  const state = controller._stream._state;
+  if (state === STATE.ERRORED) {
+    return null;
+  }
+  if (state === STATE.CLOSED) {
+    return 0;
+  }
+  return controller._strategyHWM - controller._queueTotalSize;
+}
+
+function readableByteStreamControllerInvalidateBYOBRequest(controller) {
+  if (controller._byobRequest === null) {
+    return;
+  }
+  controller._byobRequest._controller = undefined;
+  controller._byobRequest._view = null;
+  controller._byobRequest = null;
+}
+
+function readableByteStreamControllerClearPendingPullIntos(controller) {
+  readableByteStreamControllerInvalidateBYOBRequest(controller);
+  controller._pendingPullIntos = [];
+}
+
+function readableByteStreamControllerClearAlgorithms(controller) {
+  controller._pullAlgorithm = undefined;
+  controller._cancelAlgorithm = undefined;
+}
+
+function readableByteStreamControllerError(controller, e) {
+  const stream = controller._stream;
+  if (stream._state !== STATE.READABLE) {
+    return;
+  }
+  readableByteStreamControllerClearPendingPullIntos(controller);
+  resetQueue(controller);
+  readableByteStreamControllerClearAlgorithms(controller);
+  readableStreamError(stream, e);
+}
+
+function readableByteStreamControllerClose(controller) {
+  const stream = controller._stream;
+  if (controller._closeRequested || stream._state !== STATE.READABLE) {
+    return;
+  }
+  if (controller._queueTotalSize > 0) {
+    controller._closeRequested = true;
+    return;
+  }
+  if (controller._pendingPullIntos.length > 0) {
+    const firstPendingPullInto = controller._pendingPullIntos[0];
+    if (firstPendingPullInto.bytesFilled % firstPendingPullInto.elementSize !== 0) {
+      const e = new TypeError("Insufficient bytes to fill elements in the given buffer.");
+      readableByteStreamControllerError(controller, e);
+      throw e;
+    }
+  }
+  readableByteStreamControllerClearAlgorithms(controller);
+  readableStreamClose(stream);
+}
+
+function readableByteStreamControllerHandleQueueDrain(controller) {
+  if (controller._queueTotalSize === 0 && controller._closeRequested) {
+    readableByteStreamControllerClearAlgorithms(controller);
+    readableStreamClose(controller._stream);
+  } else {
+    readableByteStreamControllerCallPullIfNeeded(controller);
+  }
+}
+
+function readableByteStreamControllerShouldCallPull(controller) {
+  const stream = controller._stream;
+  if (stream._state !== STATE.READABLE) {
+    return false;
+  }
+  if (controller._closeRequested) {
+    return false;
+  }
+  if (!controller._started) {
+    return false;
+  }
+  if (readableStreamHasDefaultReader(stream) && readableStreamGetNumReadRequests(stream) > 0) {
+    return true;
+  }
+  if (readableStreamHasBYOBReader(stream) && readableStreamGetNumReadIntoRequests(stream) > 0) {
+    return true;
+  }
+  const desiredSize = readableByteStreamControllerGetDesiredSize(controller);
+  return desiredSize > 0;
+}
+
+function readableByteStreamControllerCallPullIfNeeded(controller) {
+  if (!readableByteStreamControllerShouldCallPull(controller)) {
+    return;
+  }
+  if (controller._pulling) {
+    controller._pullAgain = true;
+    return;
+  }
+  controller._pulling = true;
+  controller._pullAlgorithm().then(
+    () => {
+      controller._pulling = false;
+      if (controller._pullAgain) {
+        controller._pullAgain = false;
+        readableByteStreamControllerCallPullIfNeeded(controller);
+      }
+    },
+    e => {
+      readableByteStreamControllerError(controller, e);
+    }
+  );
+}
+
+function transferArrayBuffer(buffer) {
+  if (typeof buffer.transfer === "function") {
+    return buffer.transfer();
+  }
+  // Fallback: copy
+  const copy = new ArrayBuffer(buffer.byteLength);
+  new Uint8Array(copy).set(new Uint8Array(buffer));
+  return copy;
+}
+
+function readableByteStreamControllerEnqueue(controller, chunk) {
+  const stream = controller._stream;
+  if (controller._closeRequested || stream._state !== STATE.READABLE) {
+    return;
+  }
+  const { buffer } = chunk;
+  const { byteOffset } = chunk;
+  const { byteLength } = chunk;
+  if (buffer.byteLength === 0 && typeof buffer.detached === "boolean" ? buffer.detached : false) {
+    throw new TypeError("ArrayBuffer is detached.");
+  }
+  const transferredBuffer = transferArrayBuffer(buffer);
+
+  if (controller._pendingPullIntos.length > 0) {
+    const firstPendingPullInto = controller._pendingPullIntos[0];
+    if (
+      firstPendingPullInto.buffer.byteLength === 0 &&
+      typeof firstPendingPullInto.buffer.detached === "boolean" &&
+      firstPendingPullInto.buffer.detached
+    ) {
+      throw new TypeError("BYOB pull-into descriptor's buffer is detached.");
+    }
+    readableByteStreamControllerInvalidateBYOBRequest(controller);
+    firstPendingPullInto.buffer = transferArrayBuffer(firstPendingPullInto.buffer);
+    if (firstPendingPullInto.readerType === "none") {
+      readableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, firstPendingPullInto);
+    }
+  }
+
+  if (readableStreamHasDefaultReader(stream)) {
+    readableByteStreamControllerProcessReadRequestsUsingQueue(controller);
+    if (readableStreamGetNumReadRequests(stream) === 0) {
+      readableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
+    } else {
+      if (controller._pendingPullIntos.length > 0) {
+        readableByteStreamControllerShiftPendingPullInto(controller);
+      }
+      const transferredView = new Uint8Array(transferredBuffer, byteOffset, byteLength);
+      readableStreamFulfillReadRequest(stream, transferredView, false);
+    }
+  } else if (readableStreamHasBYOBReader(stream)) {
+    readableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
+    readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
+  } else {
+    readableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
+  }
+  readableByteStreamControllerCallPullIfNeeded(controller);
+}
+
+function readableByteStreamControllerEnqueueChunkToQueue(controller, buffer, byteOffset, byteLength) {
+  controller._queue.push({ buffer, byteOffset, byteLength });
+  controller._queueTotalSize += byteLength;
+}
+
+function readableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, pullIntoDescriptor) {
+  if (pullIntoDescriptor.bytesFilled > 0) {
+    readableByteStreamControllerEnqueueClonedChunkToQueue(
+      controller,
+      pullIntoDescriptor.buffer,
+      pullIntoDescriptor.byteOffset,
+      pullIntoDescriptor.bytesFilled
+    );
+  }
+  readableByteStreamControllerShiftPendingPullInto(controller);
+}
+
+function readableByteStreamControllerEnqueueClonedChunkToQueue(controller, buffer, byteOffset, byteLength) {
+  const cloneResult = buffer.slice(byteOffset, byteOffset + byteLength);
+  controller._queue.push({ buffer: cloneResult, byteOffset: 0, byteLength });
+  controller._queueTotalSize += byteLength;
+}
+
+function readableByteStreamControllerProcessReadRequestsUsingQueue(controller) {
+  const reader = controller._stream._reader;
+  while (reader._readRequests.length > 0) {
+    if (controller._queueTotalSize === 0) {
+      return;
+    }
+    const readRequest = reader._readRequests.shift();
+    readableByteStreamControllerFillReadRequestFromQueue(controller, readRequest);
+  }
+}
+
+function readableByteStreamControllerFillReadRequestFromQueue(controller, readRequest) {
+  const entry = controller._queue.shift();
+  controller._queueTotalSize -= entry.byteLength;
+  readableByteStreamControllerHandleQueueDrain(controller);
+  const view = new Uint8Array(entry.buffer, entry.byteOffset, entry.byteLength);
+  readRequest.chunkSteps(view);
+}
+
+function readableByteStreamControllerShiftPendingPullInto(controller) {
+  readableByteStreamControllerInvalidateBYOBRequest(controller);
+  return controller._pendingPullIntos.shift();
+}
+
+function readableByteStreamControllerCommitPullIntoDescriptor(stream, pullIntoDescriptor) {
+  let done = false;
+  if (stream._state === STATE.CLOSED) {
+    done = true;
+  }
+  const filledView = readableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescriptor);
+  if (pullIntoDescriptor.readerType === "default") {
+    readableStreamFulfillReadRequest(stream, filledView, done);
+  } else {
+    readableStreamFulfillReadIntoRequest(stream, filledView, done);
+  }
+}
+
+function readableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescriptor) {
+  const { bytesFilled } = pullIntoDescriptor;
+  const { elementSize } = pullIntoDescriptor;
+  const Ctor = pullIntoDescriptor.viewConstructor;
+  return new Ctor(pullIntoDescriptor.buffer, pullIntoDescriptor.byteOffset, bytesFilled / elementSize);
+}
+
+function readableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor) {
+  const maxBytesToCopy = Math.min(
+    controller._queueTotalSize,
+    pullIntoDescriptor.byteLength - pullIntoDescriptor.bytesFilled
+  );
+  const maxBytesFilled = pullIntoDescriptor.bytesFilled + maxBytesToCopy;
+  const remainder = maxBytesFilled % pullIntoDescriptor.elementSize;
+  let totalBytesToCopyRemaining = maxBytesToCopy;
+  let ready = false;
+  if (maxBytesFilled >= pullIntoDescriptor.minimumFill) {
+    totalBytesToCopyRemaining = maxBytesToCopy - remainder;
+    ready = true;
+  }
+  const queue = controller._queue;
+  while (totalBytesToCopyRemaining > 0) {
+    const headOfQueue = queue[0];
+    const bytesToCopy = Math.min(totalBytesToCopyRemaining, headOfQueue.byteLength);
+    const destStart = pullIntoDescriptor.byteOffset + pullIntoDescriptor.bytesFilled;
+    const destBuffer = new Uint8Array(pullIntoDescriptor.buffer);
+    const sourceView = new Uint8Array(headOfQueue.buffer, headOfQueue.byteOffset, bytesToCopy);
+    destBuffer.set(sourceView, destStart);
+    if (headOfQueue.byteLength === bytesToCopy) {
+      queue.shift();
+    } else {
+      headOfQueue.byteOffset += bytesToCopy;
+      headOfQueue.byteLength -= bytesToCopy;
+    }
+    controller._queueTotalSize -= bytesToCopy;
+    pullIntoDescriptor.bytesFilled += bytesToCopy;
+    totalBytesToCopyRemaining -= bytesToCopy;
+  }
+  return ready;
+}
+
+function readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller) {
+  while (controller._pendingPullIntos.length > 0) {
+    if (controller._queueTotalSize === 0) {
+      return;
+    }
+    const pullIntoDescriptor = controller._pendingPullIntos[0];
+    if (readableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor)) {
+      readableByteStreamControllerShiftPendingPullInto(controller);
+      readableByteStreamControllerCommitPullIntoDescriptor(controller._stream, pullIntoDescriptor);
+    }
+  }
+}
+
+function readableByteStreamControllerPullInto(controller, view, min, readIntoRequest) {
+  const stream = controller._stream;
+  let elementSize,
+    ViewConstructor,
+    buffer;
+  if (view.constructor === DataView) {
+    elementSize = 1;
+    ViewConstructor = DataView;
+  } else {
+    elementSize = view.BYTES_PER_ELEMENT;
+    ViewConstructor = view.constructor;
+  }
+  const minimumFill = min * elementSize;
+  // Capture view's dimensions before transferring its buffer (after transfer, the view becomes detached and
+  // byteLength/byteOffset both read as 0).
+  const originalByteOffset = view.byteOffset;
+  const originalByteLength = view.byteLength;
+  try {
+    buffer = transferArrayBuffer(view.buffer);
+  } catch (e) {
+    readIntoRequest.errorSteps(e);
+    return;
+  }
+  const pullIntoDescriptor = {
+    buffer,
+    bufferByteLength: buffer.byteLength,
+    byteOffset: originalByteOffset,
+    byteLength: originalByteLength,
+    bytesFilled: 0,
+    minimumFill,
+    elementSize,
+    viewConstructor: ViewConstructor,
+    readerType: "byob"
+  };
+  if (controller._pendingPullIntos.length > 0) {
+    controller._pendingPullIntos.push(pullIntoDescriptor);
+    readableStreamAddReadIntoRequest(stream, readIntoRequest);
+    return;
+  }
+  if (stream._state === STATE.CLOSED) {
+    const emptyView = new ViewConstructor(pullIntoDescriptor.buffer, pullIntoDescriptor.byteOffset, 0);
+    readIntoRequest.closeSteps(emptyView);
+    return;
+  }
+  if (controller._queueTotalSize > 0) {
+    if (readableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor)) {
+      const filledView = readableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescriptor);
+      readableByteStreamControllerHandleQueueDrain(controller);
+      readIntoRequest.chunkSteps(filledView);
+      return;
+    }
+    if (controller._closeRequested) {
+      const e = new TypeError("Insufficient bytes to fill elements in the given buffer.");
+      readableByteStreamControllerError(controller, e);
+      readIntoRequest.errorSteps(e);
+      return;
+    }
+  }
+  controller._pendingPullIntos.push(pullIntoDescriptor);
+  readableStreamAddReadIntoRequest(stream, readIntoRequest);
+  readableByteStreamControllerCallPullIfNeeded(controller);
+}
+
+function readableByteStreamControllerRespondInternal(controller, bytesWritten) {
+  const firstDescriptor = controller._pendingPullIntos[0];
+  const state = controller._stream._state;
+  if (state === STATE.CLOSED) {
+    if (bytesWritten !== 0) {
+      throw new TypeError("bytesWritten must be 0 for a closed stream.");
+    }
+    readableByteStreamControllerRespondInClosedState(controller, firstDescriptor);
+  } else {
+    readableByteStreamControllerRespondInReadableState(controller, bytesWritten, firstDescriptor);
+  }
+  readableByteStreamControllerCallPullIfNeeded(controller);
+}
+
+function readableByteStreamControllerRespondInClosedState(controller, firstDescriptor) {
+  firstDescriptor.buffer = transferArrayBuffer(firstDescriptor.buffer);
+  const stream = controller._stream;
+  if (readableStreamHasBYOBReader(stream)) {
+    while (readableStreamGetNumReadIntoRequests(stream) > 0) {
+      const pullIntoDescriptor = readableByteStreamControllerShiftPendingPullInto(controller);
+      readableByteStreamControllerCommitPullIntoDescriptor(stream, pullIntoDescriptor);
+    }
+  }
+}
+
+function readableByteStreamControllerRespondInReadableState(controller, bytesWritten, pullIntoDescriptor) {
+  if (pullIntoDescriptor.bytesFilled + bytesWritten > pullIntoDescriptor.byteLength) {
+    throw new RangeError("bytesWritten exceeds the byte length of the view.");
+  }
+  readableByteStreamControllerFillHeadPullIntoDescriptor(controller, bytesWritten, pullIntoDescriptor);
+  if (pullIntoDescriptor.bytesFilled < pullIntoDescriptor.minimumFill) {
+    return;
+  }
+  readableByteStreamControllerShiftPendingPullInto(controller);
+  const remainderSize = pullIntoDescriptor.bytesFilled % pullIntoDescriptor.elementSize;
+  if (remainderSize > 0) {
+    const end = pullIntoDescriptor.byteOffset + pullIntoDescriptor.bytesFilled;
+    readableByteStreamControllerEnqueueClonedChunkToQueue(
+      controller,
+      pullIntoDescriptor.buffer,
+      end - remainderSize,
+      remainderSize
+    );
+  }
+  pullIntoDescriptor.bytesFilled -= remainderSize;
+  readableByteStreamControllerCommitPullIntoDescriptor(controller._stream, pullIntoDescriptor);
+  readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
+}
+
+function readableByteStreamControllerFillHeadPullIntoDescriptor(controller, size, pullIntoDescriptor) {
+  readableByteStreamControllerInvalidateBYOBRequest(controller);
+  pullIntoDescriptor.bytesFilled += size;
+}
+
+function readableByteStreamControllerRespond(controller, bytesWritten) {
+  const firstDescriptor = controller._pendingPullIntos[0];
+  const state = controller._stream._state;
+  if (state === STATE.CLOSED) {
+    if (bytesWritten !== 0) {
+      throw new TypeError("bytesWritten must be 0 for a closed stream.");
+    }
+  } else if (bytesWritten === 0) {
+    throw new TypeError("bytesWritten must not be 0 for a readable stream.");
+  } else if (firstDescriptor.bytesFilled + bytesWritten > firstDescriptor.byteLength) {
+    throw new RangeError("bytesWritten exceeds the byte length of the view.");
+  }
+  firstDescriptor.buffer = transferArrayBuffer(firstDescriptor.buffer);
+  readableByteStreamControllerRespondInternal(controller, bytesWritten);
+}
+
+function readableByteStreamControllerRespondWithNewView(controller, view) {
+  const firstDescriptor = controller._pendingPullIntos[0];
+  const state = controller._stream._state;
+  if (state === STATE.CLOSED) {
+    if (view.byteLength !== 0) {
+      throw new TypeError("view must have a byte length of 0 for a closed stream.");
+    }
+  } else if (view.byteLength === 0) {
+    throw new TypeError("view must not have a byte length of 0 for a readable stream.");
+  }
+  if (firstDescriptor.byteOffset + firstDescriptor.bytesFilled !== view.byteOffset) {
+    throw new RangeError("view's byteOffset does not match the pull-into descriptor.");
+  }
+  if (firstDescriptor.bufferByteLength !== view.buffer.byteLength) {
+    throw new RangeError("view's buffer byteLength does not match the pull-into descriptor.");
+  }
+  if (firstDescriptor.bytesFilled + view.byteLength > firstDescriptor.byteLength) {
+    throw new RangeError("view.byteLength exceeds the byte length of the descriptor.");
+  }
+  const viewByteLength = view.byteLength;
+  firstDescriptor.buffer = transferArrayBuffer(view.buffer);
+  readableByteStreamControllerRespondInternal(controller, viewByteLength);
+}
+
+function readableByteStreamControllerGetBYOBRequest(controller) {
+  const ReadableStreamBYOBRequest = require("../../../generated/idl/ReadableStreamBYOBRequest");
+  if (controller._byobRequest === null && controller._pendingPullIntos.length > 0) {
+    const firstDescriptor = controller._pendingPullIntos[0];
+    const view = new Uint8Array(
+      firstDescriptor.buffer,
+      firstDescriptor.byteOffset + firstDescriptor.bytesFilled,
+      firstDescriptor.byteLength - firstDescriptor.bytesFilled
+    );
+    const byobRequest = ReadableStreamBYOBRequest.createImpl(controller._stream._globalObject, [], {});
+    byobRequest._controller = controller;
+    byobRequest._view = view;
+    controller._byobRequest = byobRequest;
+  }
+  return controller._byobRequest;
+}
+
+function byteControllerPullSteps(controller, readRequest) {
+  const stream = controller._stream;
+  if (controller._queueTotalSize > 0) {
+    readableByteStreamControllerFillReadRequestFromQueue(controller, readRequest);
+    return;
+  }
+  const autoAllocateChunkSize = controller._autoAllocateChunkSize;
+  if (autoAllocateChunkSize !== undefined) {
+    let buffer;
+    try {
+      buffer = new ArrayBuffer(autoAllocateChunkSize);
+    } catch (e) {
+      readRequest.errorSteps(e);
+      return;
+    }
+    const pullIntoDescriptor = {
+      buffer,
+      bufferByteLength: autoAllocateChunkSize,
+      byteOffset: 0,
+      byteLength: autoAllocateChunkSize,
+      bytesFilled: 0,
+      minimumFill: 1,
+      elementSize: 1,
+      viewConstructor: Uint8Array,
+      readerType: "default"
+    };
+    controller._pendingPullIntos.push(pullIntoDescriptor);
+  }
+  readableStreamAddReadRequest(stream, readRequest);
+  readableByteStreamControllerCallPullIfNeeded(controller);
+}
+
+function byteControllerCancelSteps(controller, reason) {
+  readableByteStreamControllerClearPendingPullIntos(controller);
+  resetQueue(controller);
+  const result = controller._cancelAlgorithm(reason);
+  readableByteStreamControllerClearAlgorithms(controller);
+  return result;
+}
+
+function byteControllerReleaseSteps(controller) {
+  if (controller._pendingPullIntos.length > 0) {
+    const firstPendingPullInto = controller._pendingPullIntos[0];
+    firstPendingPullInto.readerType = "none";
+    controller._pendingPullIntos = [firstPendingPullInto];
+  }
+}
+
+function setUpReadableByteStreamController(
+  stream,
+  controller,
+  startAlgorithm,
+  pullAlgorithm,
+  cancelAlgorithm,
+  highWaterMark,
+  autoAllocateChunkSize
+) {
+  controller._stream = stream;
+  controller._pullAgain = false;
+  controller._pulling = false;
+  controller._byobRequest = null;
+  controller._pendingPullIntos = [];
+  resetQueue(controller);
+  controller._closeRequested = false;
+  controller._started = false;
+  controller._strategyHWM = highWaterMark;
+  controller._pullAlgorithm = pullAlgorithm;
+  controller._cancelAlgorithm = cancelAlgorithm;
+  controller._autoAllocateChunkSize = autoAllocateChunkSize;
+  controller._pullSteps = readRequest => byteControllerPullSteps(controller, readRequest);
+  controller._cancelSteps = reason => byteControllerCancelSteps(controller, reason);
+  controller._releaseSteps = () => byteControllerReleaseSteps(controller);
+  stream._controller = controller;
+  const startResult = startAlgorithm();
+  Promise.resolve(startResult).then(
+    () => {
+      controller._started = true;
+      readableByteStreamControllerCallPullIfNeeded(controller);
+    },
+    r => {
+      readableByteStreamControllerError(controller, r);
+    }
+  );
+}
+
+function setUpReadableByteStreamControllerFromUnderlyingSource(
+  stream,
+  underlyingSource,
+  underlyingSourceDict,
+  highWaterMark,
+  globalObject
+) {
+  const ReadableByteStreamController = require("../../../generated/idl/ReadableByteStreamController");
+  const controller = ReadableByteStreamController.createImpl(globalObject, [], {});
+
+  function startAlgorithm() {
+    if (underlyingSourceDict.start === undefined) {
+      return undefined;
+    }
+    return underlyingSourceDict.start.call(underlyingSource, getControllerWrapper(controller));
+  }
+  function pullAlgorithm() {
+    if (underlyingSourceDict.pull === undefined) {
+      return resolvedPromise(globalObject, undefined);
+    }
+    try {
+      return Promise.resolve(underlyingSourceDict.pull.call(underlyingSource, getControllerWrapper(controller)));
+    } catch (e) {
+      return rejectedPromise(globalObject, e);
+    }
+  }
+  function cancelAlgorithm(reason) {
+    if (underlyingSourceDict.cancel === undefined) {
+      return resolvedPromise(globalObject, undefined);
+    }
+    try {
+      return Promise.resolve(underlyingSourceDict.cancel.call(underlyingSource, reason));
+    } catch (e) {
+      return rejectedPromise(globalObject, e);
+    }
+  }
+  const { autoAllocateChunkSize } = underlyingSourceDict;
+  if (autoAllocateChunkSize === 0) {
+    throw new TypeError("autoAllocateChunkSize must not be 0.");
+  }
+  setUpReadableByteStreamController(
+    stream,
+    controller,
+    startAlgorithm,
+    pullAlgorithm,
+    cancelAlgorithm,
+    highWaterMark,
+    autoAllocateChunkSize
+  );
+}
+
+// Underlying source dict normalization
+function convertUnderlyingDefaultOrByteSource(underlyingSource) {
+  if (underlyingSource === undefined || underlyingSource === null) {
+    return {};
+  }
+  const dict = {};
+  if ("start" in underlyingSource) {
+    const { start } = underlyingSource;
+    if (typeof start !== "function") {
+      throw new TypeError("underlyingSource.start must be a function.");
+    }
+    dict.start = start;
+  }
+  if ("pull" in underlyingSource) {
+    const { pull } = underlyingSource;
+    if (typeof pull !== "function") {
+      throw new TypeError("underlyingSource.pull must be a function.");
+    }
+    dict.pull = pull;
+  }
+  if ("cancel" in underlyingSource) {
+    const { cancel } = underlyingSource;
+    if (typeof cancel !== "function") {
+      throw new TypeError("underlyingSource.cancel must be a function.");
+    }
+    dict.cancel = cancel;
+  }
+  if ("type" in underlyingSource && underlyingSource.type !== undefined) {
+    const type = String(underlyingSource.type);
+    if (type !== "bytes") {
+      throw new TypeError(`underlyingSource.type must be "bytes" if specified.`);
+    }
+    dict.type = "bytes";
+  }
+  if ("autoAllocateChunkSize" in underlyingSource && underlyingSource.autoAllocateChunkSize !== undefined) {
+    const value = Number(underlyingSource.autoAllocateChunkSize);
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new TypeError("autoAllocateChunkSize must be a positive integer.");
+    }
+    dict.autoAllocateChunkSize = value;
+  }
+  return dict;
+}
+
+function getControllerWrapper(controllerImpl) {
+  const utils = require("../../../generated/idl/utils");
+  const wrapper = utils.wrapperForImpl(controllerImpl);
+  return wrapper === undefined ? controllerImpl : wrapper;
+}
+
+// --- Internal stream/reader creation (used by tee) -------------------------
+
+function createReadableStream(
+  globalObject,
+  startAlgorithm,
+  pullAlgorithm,
+  cancelAlgorithm,
+  highWaterMark,
+  sizeAlgorithm
+) {
+  const ReadableStream = require("../../../generated/idl/ReadableStream");
+  const ReadableStreamDefaultController = require("../../../generated/idl/ReadableStreamDefaultController");
+  const streamImpl = ReadableStream.createImpl(globalObject, [
+    {
+      start: () => {},
+      pull: () => {},
+      cancel: () => {}
+    }, {}
+  ], {});
+  // Wipe out the controller wired up by the public constructor, then re-wire with our internal algorithms.
+  streamImpl._controller = undefined;
+  const controller = ReadableStreamDefaultController.createImpl(globalObject, [], {});
+  setUpReadableStreamDefaultController(
+    streamImpl,
+    controller,
+    startAlgorithm,
+    pullAlgorithm,
+    cancelAlgorithm,
+    highWaterMark === undefined ? 1 : highWaterMark,
+    sizeAlgorithm === undefined ? () => 1 : sizeAlgorithm
+  );
+  return streamImpl;
+}
+
+function createReadableByteStream(globalObject, startAlgorithm, pullAlgorithm, cancelAlgorithm) {
+  const ReadableStream = require("../../../generated/idl/ReadableStream");
+  const ReadableByteStreamController = require("../../../generated/idl/ReadableByteStreamController");
+  const streamImpl = ReadableStream.createImpl(globalObject, [
+    {
+      type: "bytes",
+      start: () => {},
+      pull: () => {},
+      cancel: () => {}
+    }, {}
+  ], {});
+  streamImpl._controller = undefined;
+  const controller = ReadableByteStreamController.createImpl(globalObject, [], {});
+  setUpReadableByteStreamController(
+    streamImpl,
+    controller,
+    startAlgorithm,
+    pullAlgorithm,
+    cancelAlgorithm,
+    0,
+    undefined
+  );
+  return streamImpl;
+}
+
+function acquireReadableStreamDefaultReader(stream) {
+  const ReadableStreamDefaultReader = require("../../../generated/idl/ReadableStreamDefaultReader");
+  const utils = require("../../../generated/idl/utils");
+  const streamWrapper = utils.wrapperForImpl(stream);
+  return ReadableStreamDefaultReader.createImpl(stream._globalObject, [streamWrapper], {});
+}
+
+function acquireReadableStreamBYOBReader(stream) {
+  const ReadableStreamBYOBReader = require("../../../generated/idl/ReadableStreamBYOBReader");
+  const utils = require("../../../generated/idl/utils");
+  const streamWrapper = utils.wrapperForImpl(stream);
+  return ReadableStreamBYOBReader.createImpl(stream._globalObject, [streamWrapper], {});
+}
+
+function cloneAsUint8Array(chunk) {
+  const copy = new ArrayBuffer(chunk.byteLength);
+  new Uint8Array(copy).set(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+  return new Uint8Array(copy);
+}
+
+// --- tee --------------------------------------------------------------------
+
+function readableStreamTee(stream) {
+  if (stream._controller._pendingPullIntos !== undefined) {
+    return readableByteStreamTee(stream);
+  }
+  return readableStreamDefaultTee(stream);
+}
+
+function readableStreamDefaultTee(stream) {
+  const globalObject = stream._globalObject;
+  const reader = acquireReadableStreamDefaultReader(stream);
+
+  let reading = false;
+  let readAgain = false;
+  let canceled1 = false;
+  let canceled2 = false;
+  let reason1,
+    reason2,
+    branch1,
+    branch2;
+
+  const cancelCapability = newPromiseCapability(globalObject);
+
+  function pullAlgorithm() {
+    if (reading) {
+      readAgain = true;
+      return resolvedPromise(globalObject, undefined);
+    }
+    reading = true;
+    const readRequest = {
+      chunkSteps(chunk) {
+        queueMicrotask(() => {
+          readAgain = false;
+          if (!canceled1) {
+            readableStreamDefaultControllerEnqueue(branch1._controller, chunk);
+          }
+          if (!canceled2) {
+            readableStreamDefaultControllerEnqueue(branch2._controller, chunk);
+          }
+          reading = false;
+          if (readAgain) {
+            pullAlgorithm();
+          }
+        });
+      },
+      closeSteps() {
+        reading = false;
+        if (!canceled1) {
+          readableStreamDefaultControllerClose(branch1._controller);
+        }
+        if (!canceled2) {
+          readableStreamDefaultControllerClose(branch2._controller);
+        }
+        if (!canceled1 || !canceled2) {
+          cancelCapability.resolve(undefined);
+        }
+      },
+      errorSteps() {
+        reading = false;
+      }
+    };
+    readableStreamDefaultReaderRead(reader, readRequest);
+    return resolvedPromise(globalObject, undefined);
+  }
+
+  function cancel1Algorithm(reason) {
+    canceled1 = true;
+    reason1 = reason;
+    if (canceled2) {
+      const cancelResult = readableStreamCancel(stream, [reason1, reason2]);
+      cancelResult.then(() => cancelCapability.resolve(undefined), e => cancelCapability.reject(e));
+    }
+    return cancelCapability.promise;
+  }
+
+  function cancel2Algorithm(reason) {
+    canceled2 = true;
+    reason2 = reason;
+    if (canceled1) {
+      const cancelResult = readableStreamCancel(stream, [reason1, reason2]);
+      cancelResult.then(() => cancelCapability.resolve(undefined), e => cancelCapability.reject(e));
+    }
+    return cancelCapability.promise;
+  }
+
+  function startAlgorithm() {}
+
+  branch1 = createReadableStream(globalObject, startAlgorithm, pullAlgorithm, cancel1Algorithm);
+  branch2 = createReadableStream(globalObject, startAlgorithm, pullAlgorithm, cancel2Algorithm);
+
+  reader._closedPromise.promise.then(undefined, r => {
+    readableStreamDefaultControllerError(branch1._controller, r);
+    readableStreamDefaultControllerError(branch2._controller, r);
+    if (!canceled1 || !canceled2) {
+      cancelCapability.resolve(undefined);
+    }
+  });
+  markPromiseHandled(cancelCapability.promise);
+
+  return [branch1, branch2];
+}
+
+function readableByteStreamTee(stream) {
+  const globalObject = stream._globalObject;
+  let reader = acquireReadableStreamDefaultReader(stream);
+
+  let reading = false;
+  let readAgainForBranch1 = false;
+  let readAgainForBranch2 = false;
+  let canceled1 = false;
+  let canceled2 = false;
+  let reason1,
+    reason2,
+    branch1,
+    branch2;
+
+  const cancelCapability = newPromiseCapability(globalObject);
+
+  function forwardReaderError(thisReader) {
+    thisReader._closedPromise.promise.then(undefined, r => {
+      if (thisReader !== reader) {
+        return;
+      }
+      readableByteStreamControllerError(branch1._controller, r);
+      readableByteStreamControllerError(branch2._controller, r);
+      if (!canceled1 || !canceled2) {
+        cancelCapability.resolve(undefined);
+      }
+    });
+  }
+
+  function pullWithDefaultReader() {
+    if (reader._readerType === READER.BYOB) {
+      readableStreamReaderGenericRelease(reader);
+      reader = acquireReadableStreamDefaultReader(stream);
+      forwardReaderError(reader);
+    }
+    const readRequest = {
+      chunkSteps(chunk) {
+        queueMicrotask(() => {
+          readAgainForBranch1 = false;
+          readAgainForBranch2 = false;
+          const chunk1 = chunk;
+          let chunk2 = chunk;
+          if (!canceled1 && !canceled2) {
+            try {
+              chunk2 = cloneAsUint8Array(chunk);
+            } catch (cloneE) {
+              readableByteStreamControllerError(branch1._controller, cloneE);
+              readableByteStreamControllerError(branch2._controller, cloneE);
+              const cancelResult = readableStreamCancel(stream, cloneE);
+              cancelResult.then(() => cancelCapability.resolve(undefined), e => cancelCapability.reject(e));
+              return;
+            }
+          }
+          if (!canceled1) {
+            readableByteStreamControllerEnqueue(branch1._controller, chunk1);
+          }
+          if (!canceled2) {
+            readableByteStreamControllerEnqueue(branch2._controller, chunk2);
+          }
+          reading = false;
+          if (readAgainForBranch1) {
+            pull1Algorithm();
+          } else if (readAgainForBranch2) {
+            pull2Algorithm();
+          }
+        });
+      },
+      closeSteps() {
+        reading = false;
+        if (!canceled1) {
+          readableByteStreamControllerClose(branch1._controller);
+        }
+        if (!canceled2) {
+          readableByteStreamControllerClose(branch2._controller);
+        }
+        if (branch1._controller._pendingPullIntos.length > 0) {
+          readableByteStreamControllerRespond(branch1._controller, 0);
+        }
+        if (branch2._controller._pendingPullIntos.length > 0) {
+          readableByteStreamControllerRespond(branch2._controller, 0);
+        }
+        if (!canceled1 || !canceled2) {
+          cancelCapability.resolve(undefined);
+        }
+      },
+      errorSteps() {
+        reading = false;
+      }
+    };
+    readableStreamDefaultReaderRead(reader, readRequest);
+  }
+
+  function pullWithBYOBReader(view, forBranch2) {
+    if (reader._readerType === READER.DEFAULT) {
+      readableStreamReaderGenericRelease(reader);
+      reader = acquireReadableStreamBYOBReader(stream);
+      forwardReaderError(reader);
+    }
+    const byobBranch = forBranch2 ? branch2 : branch1;
+    const otherBranch = forBranch2 ? branch1 : branch2;
+    const readIntoRequest = {
+      chunkSteps(chunk) {
+        queueMicrotask(() => {
+          readAgainForBranch1 = false;
+          readAgainForBranch2 = false;
+          const byobCanceled = forBranch2 ? canceled2 : canceled1;
+          const otherCanceled = forBranch2 ? canceled1 : canceled2;
+          if (!otherCanceled) {
+            let clonedChunk;
+            try {
+              clonedChunk = cloneAsUint8Array(chunk);
+            } catch (cloneE) {
+              readableByteStreamControllerError(byobBranch._controller, cloneE);
+              readableByteStreamControllerError(otherBranch._controller, cloneE);
+              const cancelResult = readableStreamCancel(stream, cloneE);
+              cancelResult.then(() => cancelCapability.resolve(undefined), e => cancelCapability.reject(e));
+              return;
+            }
+            if (!byobCanceled) {
+              readableByteStreamControllerRespondWithNewView(byobBranch._controller, chunk);
+            }
+            readableByteStreamControllerEnqueue(otherBranch._controller, clonedChunk);
+          } else if (!byobCanceled) {
+            readableByteStreamControllerRespondWithNewView(byobBranch._controller, chunk);
+          }
+          reading = false;
+          if (readAgainForBranch1) {
+            pull1Algorithm();
+          } else if (readAgainForBranch2) {
+            pull2Algorithm();
+          }
+        });
+      },
+      closeSteps(chunk) {
+        reading = false;
+        const byobCanceled = forBranch2 ? canceled2 : canceled1;
+        const otherCanceled = forBranch2 ? canceled1 : canceled2;
+        if (!byobCanceled) {
+          readableByteStreamControllerClose(byobBranch._controller);
+        }
+        if (!otherCanceled) {
+          readableByteStreamControllerClose(otherBranch._controller);
+        }
+        if (chunk !== undefined) {
+          if (!byobCanceled) {
+            readableByteStreamControllerRespondWithNewView(byobBranch._controller, chunk);
+          }
+          if (!otherCanceled && otherBranch._controller._pendingPullIntos.length > 0) {
+            readableByteStreamControllerRespond(otherBranch._controller, 0);
+          }
+        }
+        if (!byobCanceled || !otherCanceled) {
+          cancelCapability.resolve(undefined);
+        }
+      },
+      errorSteps() {
+        reading = false;
+      }
+    };
+    readableStreamBYOBReaderRead(reader, view, 1, readIntoRequest);
+  }
+
+  function pull1Algorithm() {
+    if (reading) {
+      readAgainForBranch1 = true;
+      return resolvedPromise(globalObject, undefined);
+    }
+    reading = true;
+    const byobRequest = readableByteStreamControllerGetBYOBRequest(branch1._controller);
+    if (byobRequest === null) {
+      pullWithDefaultReader();
+    } else {
+      pullWithBYOBReader(byobRequest._view, false);
+    }
+    return resolvedPromise(globalObject, undefined);
+  }
+
+  function pull2Algorithm() {
+    if (reading) {
+      readAgainForBranch2 = true;
+      return resolvedPromise(globalObject, undefined);
+    }
+    reading = true;
+    const byobRequest = readableByteStreamControllerGetBYOBRequest(branch2._controller);
+    if (byobRequest === null) {
+      pullWithDefaultReader();
+    } else {
+      pullWithBYOBReader(byobRequest._view, true);
+    }
+    return resolvedPromise(globalObject, undefined);
+  }
+
+  function cancel1Algorithm(reason) {
+    canceled1 = true;
+    reason1 = reason;
+    if (canceled2) {
+      const cancelResult = readableStreamCancel(stream, [reason1, reason2]);
+      cancelResult.then(() => cancelCapability.resolve(undefined), e => cancelCapability.reject(e));
+    }
+    return cancelCapability.promise;
+  }
+
+  function cancel2Algorithm(reason) {
+    canceled2 = true;
+    reason2 = reason;
+    if (canceled1) {
+      const cancelResult = readableStreamCancel(stream, [reason1, reason2]);
+      cancelResult.then(() => cancelCapability.resolve(undefined), e => cancelCapability.reject(e));
+    }
+    return cancelCapability.promise;
+  }
+
+  function startAlgorithm() {}
+
+  branch1 = createReadableByteStream(globalObject, startAlgorithm, pull1Algorithm, cancel1Algorithm);
+  branch2 = createReadableByteStream(globalObject, startAlgorithm, pull2Algorithm, cancel2Algorithm);
+  forwardReaderError(reader);
+  markPromiseHandled(cancelCapability.promise);
+
+  return [branch1, branch2];
+}
+
+module.exports = {
+  STATE,
+  READER,
+  newPromiseCapability,
+  resolvedPromise,
+  rejectedPromise,
+  markPromiseHandled,
+
+  extractHighWaterMark,
+  extractSizeAlgorithm,
+  convertUnderlyingDefaultOrByteSource,
+
+  initializeReadableStream,
+  isReadableStreamLocked,
+  readableStreamCancel,
+  readableStreamClose,
+  readableStreamError,
+
+  readableStreamReaderGenericInitialize,
+  readableStreamReaderGenericCancel,
+  readableStreamReaderGenericRelease,
+  readableStreamDefaultReaderRelease,
+  readableStreamBYOBReaderRelease,
+  readableStreamDefaultReaderRead,
+  readableStreamBYOBReaderRead,
+
+  readableStreamDefaultControllerCanCloseOrEnqueue,
+  readableStreamDefaultControllerGetDesiredSize,
+  readableStreamDefaultControllerClose,
+  readableStreamDefaultControllerEnqueue,
+  readableStreamDefaultControllerError,
+  setUpReadableStreamDefaultControllerFromUnderlyingSource,
+
+  readableByteStreamControllerCanCloseOrEnqueue,
+  readableByteStreamControllerGetDesiredSize,
+  readableByteStreamControllerClose,
+  readableByteStreamControllerEnqueue,
+  readableByteStreamControllerError,
+  readableByteStreamControllerRespond,
+  readableByteStreamControllerRespondWithNewView,
+  readableByteStreamControllerGetBYOBRequest,
+  setUpReadableByteStreamControllerFromUnderlyingSource,
+
+  readableStreamTee
+};

--- a/scripts/webidl/convert.js
+++ b/scripts/webidl/convert.js
@@ -59,6 +59,7 @@ addDir("../../lib/jsdom/living/navigator");
 addDir("../../lib/jsdom/living/nodes");
 addDir("../../lib/jsdom/living/range");
 addDir("../../lib/jsdom/living/selection");
+addDir("../../lib/jsdom/living/streams");
 addDir("../../lib/jsdom/living/svg");
 addDir("../../lib/jsdom/living/traversal");
 addDir("../../lib/jsdom/living/websockets");

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -7,7 +7,6 @@ blob/Blob-constructor.any.html:
   "Blob interface object": [fail, function is not instanceof Function]
   "Passing a Float16Array as element of the blobParts array should work.": [fail-node:<24, Float16Array not implemented]
   "Passing a FrozenArray as the blobParts array should work (FrozenArray<MessagePort>).": [fail, MessageChannel not implemented]
-blob/Blob-stream.any.html: [fail, Unknown]
 file/send-file-form*: [fail, DataTransfer not implemented]
 filelist-section/filelist.html:
   "Check if item is a instanceof Function": [fail, function is not instanceof Function]
@@ -2444,7 +2443,6 @@ responsexml-document-properties.htm: [fail, https://github.com/web-platform-test
 send-after-setting-document-domain.htm: [timeout, document.domain not implemented]
 send-authentication-competing-names-passwords.htm: [fail, Unknown]
 send-authentication-cors-setrequestheader-no-cred.htm: [fail, Unknown]
-send-data-es-object.any.html: [fail, Unknown]
 send-data-sharedarraybuffer.any.html: [fail, Unknown]
 send-redirect-bogus-sync.htm: [flaky, https://github.com/web-platform-tests/wpt/pull/57822]
 send-redirect-to-cors.htm: [fail, Unknown]

--- a/test/web-platform-tests/to-upstream/FileAPI/blob/Blob-stream.html
+++ b/test/web-platform-tests/to-upstream/FileAPI/blob/Blob-stream.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>blob.stream()</title>
+<link rel="help" href="https://w3c.github.io/FileAPI/#dom-blob-stream">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+async function readAll(stream) {
+  const reader = stream.getReader();
+  try {
+    const chunks = [];
+    let totalLength = 0;
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+      totalLength += value.byteLength;
+    }
+    const combined = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return combined;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+test(() => {
+  const blob = new Blob(["hello"]);
+  const stream = blob.stream();
+  assert_equals(typeof stream.getReader, "function", "stream() should return an object with a getReader method");
+  assert_equals(typeof stream.pipeTo, "function", "stream() should return an object with a pipeTo method");
+}, "stream() returns a ReadableStream");
+
+test(() => {
+  const blob = new Blob(["hello"]);
+  const a = blob.stream();
+  const b = blob.stream();
+  assert_not_equals(a, b, "stream() should return a new ReadableStream each call");
+}, "stream() returns a new ReadableStream each call");
+
+promise_test(async () => {
+  const blob = new Blob(["hello world"]);
+  const bytes = await readAll(blob.stream());
+  assert_equals(new TextDecoder().decode(bytes), "hello world");
+}, "stream() yields the blob's bytes");
+
+promise_test(async () => {
+  const blob = new Blob([]);
+  const bytes = await readAll(blob.stream());
+  assert_equals(bytes.byteLength, 0, "empty blob should produce zero bytes");
+}, "stream() on an empty blob closes immediately");
+
+promise_test(async () => {
+  const input = new Uint8Array([1, 2, 3, 4, 5]);
+  const blob = new Blob([input]);
+  input[0] = 99;
+
+  const bytes = await readAll(blob.stream());
+  assert_array_equals(
+    Array.from(bytes),
+    [1, 2, 3, 4, 5],
+    "stream() output should not be affected by mutating the input Uint8Array"
+  );
+}, "stream() data is isolated from input mutations");
+
+promise_test(async () => {
+  const blob = new Blob([new Uint8Array([1, 2, 3, 4, 5])]);
+  const sliced = blob.slice(1, 4);
+  const bytes = await readAll(sliced.stream());
+  assert_array_equals(
+    Array.from(bytes),
+    [2, 3, 4],
+    "stream() on a sliced blob should yield only the sliced bytes"
+  );
+}, "stream() on a sliced blob yields only the sliced bytes");
+
+promise_test(async () => {
+  const blob = new Blob(["abc", new Uint8Array([100, 101, 102]), "xyz"]);
+  const bytes = await readAll(blob.stream());
+  assert_equals(bytes.byteLength, blob.size, "stream output length should match blob.size");
+  assert_equals(new TextDecoder().decode(bytes), "abcdefxyz");
+}, "stream() concatenates all blob parts in order");
+
+promise_test(async () => {
+  const blob = new Blob([new Uint8Array([10, 20, 30, 40, 50])]);
+  const stream = blob.stream();
+  const reader = stream.getReader({ mode: "byob" });
+  const buffer = new Uint8Array(10);
+  const { value, done } = await reader.read(buffer);
+  assert_false(done, "BYOB read should return data before completing");
+  assert_array_equals(Array.from(value), [10, 20, 30, 40, 50]);
+}, "stream() supports BYOB readers (type: 'bytes')");
+
+promise_test(async () => {
+  const blob = new Blob(["hello"]);
+  const stream = blob.stream();
+  const bytes1 = await readAll(stream);
+  assert_equals(new TextDecoder().decode(bytes1), "hello");
+
+  // A second read on the same already-consumed stream should yield no more data.
+  const reader = stream.getReader();
+  const { done } = await reader.read();
+  assert_true(done, "stream should be exhausted after being fully read");
+}, "stream() exhausts after being fully read");
+</script>

--- a/test/web-platform-tests/to-upstream/FileAPI/blob/Blob-stream.html
+++ b/test/web-platform-tests/to-upstream/FileAPI/blob/Blob-stream.html
@@ -37,8 +37,7 @@ async function readAll(stream) {
 test(() => {
   const blob = new Blob(["hello"]);
   const stream = blob.stream();
-  assert_equals(typeof stream.getReader, "function", "stream() should return an object with a getReader method");
-  assert_equals(typeof stream.pipeTo, "function", "stream() should return an object with a pipeTo method");
+  assert_true(stream instanceof ReadableStream, "stream() should return a ReadableStream");
 }, "stream() returns a ReadableStream");
 
 test(() => {

--- a/test/web-platform-tests/to-upstream/streams/readable-stream-byob.html
+++ b/test/web-platform-tests/to-upstream/streams/readable-stream-byob.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ReadableStream with a byte controller and BYOB reader</title>
+<link rel="help" href="https://streams.spec.whatwg.org/#rbs-class">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const stream = new ReadableStream({ type: "bytes" });
+  const reader = stream.getReader({ mode: "byob" });
+  assert_true(stream.locked, "stream should be locked after acquiring a BYOB reader");
+  reader.releaseLock();
+  assert_false(stream.locked);
+}, "getReader({ mode: 'byob' }) locks the stream");
+
+test(() => {
+  const stream = new ReadableStream();
+  assert_throws_js(
+    TypeError,
+    () => stream.getReader({ mode: "byob" }),
+    "BYOB reader on a default (non-byte) stream should throw"
+  );
+}, "BYOB reader cannot be acquired on a non-byte stream");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    type: "bytes",
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+      controller.close();
+    }
+  });
+  const reader = stream.getReader({ mode: "byob" });
+  const buffer = new Uint8Array(8);
+  const { value, done } = await reader.read(buffer);
+  assert_false(done);
+  assert_array_equals(Array.from(value), [1, 2, 3, 4]);
+  assert_equals(value.byteOffset, 0);
+  assert_equals(value.byteLength, 4);
+  assert_not_equals(
+    value.buffer,
+    buffer.buffer,
+    "the input view's buffer should be transferred; result's buffer should be a different reference"
+  );
+}, "BYOB read fills the provided view with the enqueued bytes");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    type: "bytes",
+    start(controller) {
+      controller.close();
+    }
+  });
+  const reader = stream.getReader({ mode: "byob" });
+  const buffer = new Uint8Array(8);
+  const { value, done } = await reader.read(buffer);
+  assert_true(done);
+  assert_equals(value.byteLength, 0);
+  assert_equals(
+    value.constructor,
+    Uint8Array,
+    "the returned view should have the same constructor as the input"
+  );
+}, "BYOB read on an already-closed stream resolves with done=true and a zero-length view");
+
+promise_test(async t => {
+  const stream = new ReadableStream({ type: "bytes" });
+  const reader = stream.getReader({ mode: "byob" });
+  await promise_rejects_js(
+    t,
+    TypeError,
+    reader.read(new Uint8Array(0)),
+    "read with a zero-length view should reject"
+  );
+}, "BYOB read rejects on a zero-length view");
+
+promise_test(async t => {
+  const stream = new ReadableStream({ type: "bytes" });
+  const reader = stream.getReader({ mode: "byob" });
+  await promise_rejects_js(
+    t,
+    TypeError,
+    reader.read(new Uint8Array(8), { min: 0 }),
+    "min: 0 should reject"
+  );
+  await promise_rejects_js(
+    t,
+    RangeError,
+    reader.read(new Uint8Array(2), { min: 5 }),
+    "min greater than view length should reject with RangeError"
+  );
+}, "BYOB read validates the options.min parameter");
+
+promise_test(async () => {
+  let pullCount = 0;
+  const stream = new ReadableStream({
+    type: "bytes",
+    pull(controller) {
+      pullCount += 1;
+      if (pullCount === 1) {
+        controller.enqueue(new Uint8Array([1, 2]));
+      } else if (pullCount === 2) {
+        controller.enqueue(new Uint8Array([3, 4, 5]));
+      } else {
+        controller.close();
+      }
+    }
+  });
+  const reader = stream.getReader();
+  const got = [];
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    got.push(...value);
+  }
+  assert_array_equals(got, [1, 2, 3, 4, 5]);
+}, "byte stream serves a default reader with chunks from pull()");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    type: "bytes",
+    pull(controller) {
+      const req = controller.byobRequest;
+      assert_not_equals(req, null, "byobRequest should be available during pull when no internal queue is set");
+      const { view } = req;
+      view[0] = 42;
+      view[1] = 43;
+      req.respond(2);
+      controller.close();
+    }
+  });
+  const reader = stream.getReader({ mode: "byob" });
+  const buffer = new Uint8Array(4);
+  const { value, done } = await reader.read(buffer);
+  assert_false(done);
+  assert_array_equals(Array.from(value), [42, 43]);
+}, "byobRequest is exposed during pull and respond() forwards bytes to the reader");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    type: "bytes",
+    pull(controller) {
+      const req = controller.byobRequest;
+      const replacement = new Uint8Array(req.view.buffer, req.view.byteOffset, 3);
+      replacement[0] = 1;
+      replacement[1] = 2;
+      replacement[2] = 3;
+      req.respondWithNewView(replacement);
+      controller.close();
+    }
+  });
+  const reader = stream.getReader({ mode: "byob" });
+  const buffer = new Uint8Array(8);
+  const { value, done } = await reader.read(buffer);
+  assert_false(done);
+  assert_array_equals(Array.from(value), [1, 2, 3]);
+}, "respondWithNewView forwards a different view of the same buffer to the reader");
+
+test(() => {
+  let controllerRef;
+  const stream = new ReadableStream({
+    type: "bytes",
+    start(controller) {
+      controllerRef = controller;
+    }
+  }, { highWaterMark: 16 });
+  assert_false(stream.locked);
+  assert_equals(controllerRef.desiredSize, 16, "desiredSize starts at the high water mark");
+  controllerRef.enqueue(new Uint8Array(5));
+  assert_equals(controllerRef.desiredSize, 11, "desiredSize decreases by the enqueued chunk's byteLength");
+}, "byte controller desiredSize tracks the byte count");
+
+test(() => {
+  let controllerRef;
+  const stream = new ReadableStream({
+    type: "bytes",
+    start(controller) {
+      controllerRef = controller;
+    }
+  });
+  assert_false(stream.locked);
+  assert_throws_js(
+    TypeError,
+    () => controllerRef.enqueue(new Uint8Array(0)),
+    "enqueueing a zero-length view should throw"
+  );
+}, "byte controller refuses zero-length enqueues");
+
+test(() => {
+  assert_throws_js(
+    RangeError,
+    () => new ReadableStream({ type: "bytes" }, { size: () => 1 }),
+    "specifying a size function for a byte stream should throw"
+  );
+}, "byte stream constructor rejects a size function");
+
+promise_test(async t => {
+  const error = new Error("byte boom");
+  const stream = new ReadableStream({
+    type: "bytes",
+    start(controller) {
+      controller.error(error);
+    }
+  });
+  const reader = stream.getReader({ mode: "byob" });
+  const buffer = new Uint8Array(8);
+  await promise_rejects_exactly(t, error, reader.read(buffer));
+  await promise_rejects_exactly(t, error, reader.closed);
+}, "errored byte stream rejects BYOB reads and the closed promise");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    type: "bytes",
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+      controller.close();
+    }
+  });
+  const [b1, b2] = stream.tee();
+
+  async function drain(s) {
+    const reader = s.getReader();
+    const chunks = [];
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(...value);
+    }
+    return chunks;
+  }
+
+  const [r1, r2] = await Promise.all([drain(b1), drain(b2)]);
+  assert_array_equals(r1, [1, 2, 3]);
+  assert_array_equals(r2, [1, 2, 3]);
+}, "tee() on a byte stream yields the full bytes to both branches via default readers");
+</script>

--- a/test/web-platform-tests/to-upstream/streams/readable-stream-default.html
+++ b/test/web-platform-tests/to-upstream/streams/readable-stream-default.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ReadableStream with a default controller</title>
+<link rel="help" href="https://streams.spec.whatwg.org/#rs-class">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const stream = new ReadableStream();
+  assert_true(stream instanceof ReadableStream);
+  assert_false(stream.locked, "a freshly-constructed stream should not be locked");
+}, "construction with no arguments");
+
+test(() => {
+  const stream = new ReadableStream();
+  const reader = stream.getReader();
+  assert_true(stream.locked, "stream should be locked after acquiring a reader");
+  reader.releaseLock();
+  assert_false(stream.locked, "stream should not be locked after releasing the reader");
+}, "locked attribute reflects reader acquisition and release");
+
+test(() => {
+  const stream = new ReadableStream();
+  stream.getReader();
+  assert_throws_js(TypeError, () => stream.getReader(), "second getReader() should throw");
+}, "getReader() throws when stream is already locked");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+      controller.enqueue("b");
+      controller.close();
+    }
+  });
+  const reader = stream.getReader();
+  const r1 = await reader.read();
+  assert_equals(r1.value, "a");
+  assert_false(r1.done);
+  const r2 = await reader.read();
+  assert_equals(r2.value, "b");
+  assert_false(r2.done);
+  const r3 = await reader.read();
+  assert_equals(r3.value, undefined);
+  assert_true(r3.done);
+}, "enqueue from start, then close, is consumed in order by a default reader");
+
+promise_test(async () => {
+  let pullCount = 0;
+  const stream = new ReadableStream({
+    pull(controller) {
+      pullCount += 1;
+      if (pullCount > 3) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(pullCount);
+    }
+  });
+  const reader = stream.getReader();
+  const values = [];
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    values.push(value);
+  }
+  assert_array_equals(values, [1, 2, 3]);
+}, "pull is called repeatedly to satisfy reads");
+
+promise_test(async t => {
+  const error = new Error("boom");
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.error(error);
+    }
+  });
+  const reader = stream.getReader();
+  await promise_rejects_exactly(t, error, reader.read(), "read should reject with the error");
+  await promise_rejects_exactly(t, error, reader.closed, "closed should reject with the error");
+}, "errored stream rejects reads and the closed promise");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.close();
+    }
+  });
+  const reader = stream.getReader();
+  const result = await reader.read();
+  assert_equals(result.value, undefined);
+  assert_true(result.done);
+  await reader.closed;
+}, "closed stream's closed promise fulfills");
+
+promise_test(async () => {
+  let cancelReason;
+  const stream = new ReadableStream({
+    cancel(reason) {
+      cancelReason = reason;
+    }
+  });
+  const reason = new Error("cancelled");
+  await stream.cancel(reason);
+  assert_equals(cancelReason, reason, "the underlying source's cancel was called with the reason");
+}, "cancel forwards the reason to the underlying source");
+
+promise_test(async t => {
+  const stream = new ReadableStream();
+  stream.getReader();
+  await promise_rejects_js(t, TypeError, stream.cancel(), "cancel() on a locked stream should reject");
+}, "cancel rejects when the stream is locked");
+
+promise_test(async t => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("first");
+    }
+  });
+  const reader = stream.getReader();
+  reader.releaseLock();
+  await promise_rejects_js(t, TypeError, reader.read(), "read after release should reject");
+  await promise_rejects_js(t, TypeError, reader.closed, "closed after release should reject");
+}, "releaseLock() detaches a default reader from the stream");
+
+test(() => {
+  let controllerRef;
+  const stream = new ReadableStream({
+    start(controller) {
+      controllerRef = controller;
+    }
+  }, { highWaterMark: 3 });
+  assert_false(stream.locked);
+  assert_equals(controllerRef.desiredSize, 3, "desiredSize starts at the high water mark");
+  controllerRef.enqueue("x");
+  assert_equals(controllerRef.desiredSize, 2, "desiredSize decreases after enqueue with default size of 1");
+}, "default controller desiredSize honors the high water mark");
+
+test(() => {
+  let controllerRef;
+  const stream = new ReadableStream({
+    start(controller) {
+      controllerRef = controller;
+      controller.close();
+    }
+  });
+  assert_false(stream.locked);
+  assert_throws_js(TypeError, () => controllerRef.enqueue("x"), "enqueue after close should throw");
+  assert_throws_js(TypeError, () => controllerRef.close(), "close after close should throw");
+}, "default controller rejects operations after close");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+      controller.enqueue("b");
+      controller.enqueue("c");
+    }
+  });
+  const reader = stream.getReader();
+  const collected = [];
+  collected.push((await reader.read()).value);
+  collected.push((await reader.read()).value);
+  reader.releaseLock();
+
+  const reader2 = stream.getReader();
+  collected.push((await reader2.read()).value);
+  assert_array_equals(collected, ["a", "b", "c"]);
+}, "releasing a reader allows another reader to continue consuming");
+
+test(() => {
+  const stream = new ReadableStream();
+  const branches = stream.tee();
+  assert_true(Array.isArray(branches), "tee() returns an array");
+  assert_equals(branches.length, 2);
+  assert_true(branches[0] instanceof ReadableStream);
+  assert_true(branches[1] instanceof ReadableStream);
+  assert_not_equals(branches[0], branches[1]);
+  assert_true(stream.locked, "the original stream should be locked after tee()");
+}, "tee() returns two new ReadableStreams and locks the original");
+
+test(() => {
+  const stream = new ReadableStream();
+  stream.getReader();
+  assert_throws_js(TypeError, () => stream.tee(), "tee() on a locked stream should throw");
+}, "tee() throws when the stream is already locked");
+
+promise_test(async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("a");
+      controller.enqueue("b");
+      controller.close();
+    }
+  });
+  const [b1, b2] = stream.tee();
+
+  async function drain(s) {
+    const reader = s.getReader();
+    const out = [];
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      out.push(value);
+    }
+    return out;
+  }
+
+  const [r1, r2] = await Promise.all([drain(b1), drain(b2)]);
+  assert_array_equals(r1, ["a", "b"]);
+  assert_array_equals(r2, ["a", "b"]);
+}, "tee() branches each see the full sequence of chunks");
+
+promise_test(async () => {
+  let cancelReason;
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue("x");
+    },
+    cancel(reason) {
+      cancelReason = reason;
+    }
+  });
+  const [b1, b2] = stream.tee();
+
+  // Cancelling only one branch leaves the source live; the returned promise from cancel() does not resolve
+  // until the source cancellation runs (which only happens once both branches are cancelled).
+  const cancel1Promise = b1.cancel("one");
+  await Promise.resolve();
+  assert_equals(cancelReason, undefined, "source should not be cancelled while one branch is still live");
+
+  await Promise.all([cancel1Promise, b2.cancel("two")]);
+  assert_true(Array.isArray(cancelReason), "source cancel reason should be a composite array");
+  assert_array_equals(cancelReason, ["one", "two"]);
+}, "tee() cancels the source only after both branches are cancelled");
+</script>


### PR DESCRIPTION
This adds [Blob.stream()](https://developer.mozilla.org/en-US/docs/Web/API/Blob/stream) to the `BlobImpl`.

The [ReadableStream](https://nodejs.org/api/webstreams.html#class-readablestream) was added to node in 16.5.0, so it matches the range in `package.json`.

Since I'm new to the project I don't know exactly how the `ReadableStream` should be handled. Is it ok like that, or should it be added to the `Window` globals as well? If so, should I just expose the one from `node:stream/web` directly, which would be a pragmatic approach, or should it be recreated fully? The latter would be quite a lot of effort.