### PR TITLE
Fix XPath TYPE_ERR for non-node result conversions

### DIFF
--- a/lib/jsdom/level3/xpath.js
+++ b/lib/jsdom/level3/xpath.js
@@ -1737,8 +1737,9 @@ module.exports = core => {
             core.DOMException.NOT_SUPPORTED_ERR,
             'You must provide an XPath result type (0=any).');
       else if (XPathResult.ANY_TYPE !== type &&
-               (value === null || 'object' !== typeof value))
-        throw new TypeError(
+               (value === null || 'object' !== typeof value || !value.nodes))
+        throw new XPathException(
+            XPathException.TYPE_ERR,
             'The result is not a node set, and therefore cannot be converted to the desired type.');
       return new XPathResult(doc, value, type);
     }

--- a/test/to-port-to-wpts/level3/xpath.js
+++ b/test/to-port-to-wpts/level3/xpath.js
@@ -673,6 +673,16 @@ describe("xpath", () => {
       stringifyNodeList([img]),
       stringifyNodeList(r));
   });
+  specify("testDocumentEvaluateNonNodeSetResultType", function() {
+    const doc = (new JSDOM('<html><body><div>a<div>b</div></div><img></body></html>')).window.document;
+
+    assert.throws(() => {
+      doc.evaluate("string(/)", doc, null, doc.defaultView.XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+    }, {
+      name: "XPathException",
+      code: doc.defaultView.XPathException.TYPE_ERR
+    });
+  });
   specify("testDocumentEvaluate2", function() {
     const doc = (new JSDOM('<html><body><div>a<div>b</div></div><img></body></html>')).window.document;
     var html = doc.getElementsByTagName('html')[0],


### PR DESCRIPTION
## Summary
- Throw `XPathException.TYPE_ERR` when a requested XPath node-set result type receives a non-node-set value.
- Add regression coverage for `document.evaluate("string(/)", ..., FIRST_ORDERED_NODE_TYPE)`.

Fixes #4147.

## Tests
- `npm run pretest`
- `npm run lint`
- `npm exec -- mocha test/to-port-to-wpts/level3/xpath.js --reporter min`
- `git diff --check`

Additional local runs:
- `npm run test:api -- --reporter min` currently hits unrelated timeout/resource-loading failures in this checkout.
- `npm run test:to-port-to-wpts -- --reporter min` stops before level3 on existing `frame_parent` and JSONP timeouts; the focused `level3/xpath.js` run passes.