### PR TITLE
Keep mixed length-percentage and calc() track lists in grid-template-columns

### DIFF
--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -156,7 +156,7 @@ function resolveCalc(val, opt = { format: "specifiedValue" }) {
     } else if (itemType === AST_TYPES.STRING) {
       values.push(`"${itemValue}"`);
     } else {
-      values.push(itemName ?? itemValue);
+      values.push(cssTree.generate(item));
     }
   }
   const resolvedValue = values.join(" ");

--- a/test/to-port-to-wpts/level2/style.js
+++ b/test/to-port-to-wpts/level2/style.js
@@ -287,6 +287,29 @@ describe("level2/style", () => {
     window.getComputedStyle(window.document.body);
   });
 
+  specify("gridTemplateColumns mixed length + calc (GH-4141)", () => {
+    const document = (new JSDOM()).window.document;
+    const div = document.createElement("div");
+    const values = [
+      "100px 1fr",
+      "40% 60%",
+      "6.25rem 50%",
+      "calc(100px) calc(100% - 100px)",
+      "calc(100%) calc(50%)",
+      "repeat(2, minmax(calc(50% - 2rem), 50%))",
+      "minmax(8rem, calc(100% - 8rem))",
+      "100px calc(100% - 100px)",
+      "6.25rem calc((100% - 6.25rem) / 1)",
+      "6.25rem 60% calc((40% - 6.25rem) / 2) calc((40% - 6.25rem) / 2)"
+    ];
+
+    for (const value of values) {
+      div.style.gridTemplateColumns = "";
+      div.style.gridTemplateColumns = value;
+      assert.equal(div.style.gridTemplateColumns, value);
+    }
+  });
+
   specify("padding and margin component properties work correctly (GH-1353)", () => {
     const document = (new JSDOM()).window.document;
 


### PR DESCRIPTION
Fixes #4141.

`grid-template-columns` (and the sibling grid track-list properties) silently rejected valid top-level track lists mixing a bare `<length-percentage>` with `calc()` (e.g. `100px calc(100% - 100px)`), because the value was reassembled from a name/value fallback that dropped `calc()` items. Regenerate each item from its parsed CSS node instead. Added a test covering mixed length/percentage/calc track lists.