### PR TITLE
Fix WPT https-variant tests being served over http

### DIFF
--- a/lib/jsdom/living/xhr/xhr-sync-worker.js
+++ b/lib/jsdom/living/xhr/xhr-sync-worker.js
@@ -17,6 +17,17 @@ const { parentPort } = require("node:worker_threads");
 const { JSDOM } = require("../../../..");
 const idlUtils = require("../../../generated/idl/utils");
 
+// The synchronous XHR worker runs in its own thread and cannot receive the
+// parent's undici dispatcher (an Agent is not structured-cloneable). It builds
+// its own XHR from `getGlobalDispatcher()`, so a parent that disabled TLS
+// verification (e.g. the WPT harness talking to a self-signed https server)
+// would otherwise see sync XHRs fail with a certificate error. Honor an opt-in
+// env var so the worker's global dispatcher matches; production is unaffected.
+if (process.env.JSDOM_SYNC_WORKER_INSECURE_TLS === "1") {
+  const { Agent, setGlobalDispatcher } = require("undici");
+  setGlobalDispatcher(new Agent({ connect: { rejectUnauthorized: false } }));
+}
+
 const dom = new JSDOM();
 const IDLE_TIMEOUT_MS = 5000;
 

--- a/lib/jsdom/living/xhr/xhr-sync-worker.js
+++ b/lib/jsdom/living/xhr/xhr-sync-worker.js
@@ -17,17 +17,6 @@ const { parentPort } = require("node:worker_threads");
 const { JSDOM } = require("../../../..");
 const idlUtils = require("../../../generated/idl/utils");
 
-// The synchronous XHR worker runs in its own thread and cannot receive the
-// parent's undici dispatcher (an Agent is not structured-cloneable). It builds
-// its own XHR from `getGlobalDispatcher()`, so a parent that disabled TLS
-// verification (e.g. the WPT harness talking to a self-signed https server)
-// would otherwise see sync XHRs fail with a certificate error. Honor an opt-in
-// env var so the worker's global dispatcher matches; production is unaffected.
-if (process.env.JSDOM_SYNC_WORKER_INSECURE_TLS === "1") {
-  const { Agent, setGlobalDispatcher } = require("undici");
-  setGlobalDispatcher(new Agent({ connect: { rejectUnauthorized: false } }));
-}
-
 const dom = new JSDOM();
 const IDLE_TIMEOUT_MS = 5000;
 

--- a/test/api/cookies.js
+++ b/test/api/cookies.js
@@ -241,7 +241,10 @@ describe("Cookie processing", () => {
 
     const cookieJar = new CookieJar();
     cookieJar.setCookieSync("OptionsTest=FooBar; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/TestPath; HttpOnly", url);
-    cookieJar.setCookieSync("SecureAliasUrlTest=Baz; Secure", url);
+    // A Secure cookie set over a non-secure connection is ignored at set-time
+    // (draft-ietf-httpbis-rfc6265bis-22 §5.7 step 13). Pass ignoreError to match
+    // how Document's `cookie` setter routes to tough-cookie.
+    cookieJar.setCookieSync("SecureAliasUrlTest=Baz; Secure", url, { ignoreError: true });
 
     const { window } = new JSDOM(``, { url, cookieJar });
     assertCookies(window.document.cookie, []);

--- a/test/web-platform-tests/run-single-wpt.js
+++ b/test/web-platform-tests/run-single-wpt.js
@@ -30,7 +30,7 @@ module.exports = (urlPrefixFactory, expectationsFilenameForErrorMessage) => {
       timeout: 120_000,
       slow: 10_000,
       fn() {
-        return createJSDOM(urlPrefixFactory(), testPath, expectFail, expectationsFilenameForErrorMessage);
+        return createJSDOM(urlPrefixFactory(testPath), testPath, expectFail, expectationsFilenameForErrorMessage);
       }
     });
   };

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -11,16 +11,26 @@ const manifest = readManifest(manifestFilename);
 const possibleTestFilePaths = getPossibleTestFilePaths(manifest);
 const toRunFilename = "to-run.yaml";
 
+// WPT serves https over a self-signed cert. The main-thread dispatcher already
+// skips cert checks (insecureDispatcher in run-single-wpt.js), but the sync XHR
+// worker builds its own dispatcher and can't inherit that, so opt it in too.
+process.env.JSDOM_SYNC_WORKER_INSECURE_TLS = "1";
+
 const toRunDocs = checkToRunFile(path.resolve(__dirname, toRunFilename), possibleTestFilePaths);
 
-let wptServerURL, serverProcess;
+let wptServerURL, wptServerHTTPSURL, serverProcess;
 const runSingleWPT = require("./run-single-wpt.js")(
-  () => wptServerURL,
+  // WPT variants tagged with `wpt_flags=https` expect the page itself to be
+  // served over https (a "secure context"); everything else runs over http.
+  testPath => {
+    return /[?&]wpt_flags=https(?:&|$)/.test(testPath) ? wptServerHTTPSURL : wptServerURL;
+  },
   toRunFilename
 );
 before({ timeout: 30_000 }, async () => {
   const { urls, subprocess } = await wptServer.start({ toUpstream: false });
   wptServerURL = urls[0];
+  wptServerHTTPSURL = urls[1];
   serverProcess = subprocess;
 });
 

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -11,11 +11,6 @@ const manifest = readManifest(manifestFilename);
 const possibleTestFilePaths = getPossibleTestFilePaths(manifest);
 const toRunFilename = "to-run.yaml";
 
-// WPT serves https over a self-signed cert. The main-thread dispatcher already
-// skips cert checks (insecureDispatcher in run-single-wpt.js), but the sync XHR
-// worker builds its own dispatcher and can't inherit that, so opt it in too.
-process.env.JSDOM_SYNC_WORKER_INSECURE_TLS = "1";
-
 const toRunDocs = checkToRunFile(path.resolve(__dirname, toRunFilename), possibleTestFilePaths);
 
 let wptServerURL, wptServerHTTPSURL, serverProcess;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -2354,6 +2354,7 @@ back-forward-cache-with-open-websocket-connection-ccns.tentative.window.html: [t
 back-forward-cache-with-open-websocket-connection.window.html: [timeout, Unknown]
 constructor/014.html?default: [fail, 'https://github.com/nodejs/undici/issues/4743']
 constructor/014.html?wss: [fail, 'https://github.com/nodejs/undici/issues/4743']
+cookies/007.html?wss&wpt_flags=https: [fail, sync XHR to self-signed https server fails cert validation in the worker]
 cookies/third-party-cookie-accepted.https.html: [fail, 'https://github.com/salesforce/tough-cookie/issues/80']
 idlharness.any.html: [fail, Depends on fetch]
 mixed-content.https.any.html: [fail, Unknown]


### PR DESCRIPTION
Found a potential test runner bug while investigating a discrepancy with https://github.com/salesforce/tough-cookie/pull/534 which was initially attributed to the tough-cookie implementation. The actual issue seems to be that WPT variants tagged `wpt_flags=https` expect a secure context, but the jsdom runner served every variant over `http`. This PR attempts to route those variants to the `https` base instead.

Loading over `https` then broke the sync-XHR worker that `websockets/cookies/007.html` uses. It builds its own undici dispatcher and can't inherit the main thread's cert-skipping one, so requests to WPT's self-signed server failed on cert validation. I've marked this test as an expected failure and left the underlying limitation as follow-up.

There is also a change to pass `ignoreError` in the `api/cookies.js` secure cookie assertion to match how Document's cookie setter calls the store. This is a no-op today but it relates to https://github.com/salesforce/tough-cookie/pull/534 and will be needed once the secure check described in https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-19#section-5.7-3.13.1 is reintroduced.