### PR TITLE
Optimize WPT test file matching and filtering

### DIFF
--- a/test/web-platform-tests/expectations-utils.js
+++ b/test/web-platform-tests/expectations-utils.js
@@ -87,11 +87,18 @@ exports.checkToRunFile = (toRunFilename, possibleTestFilePaths) => {
 };
 
 exports.runTestWithExpectations = (testFilePath, expectations, { runSingleWPT, prefix = "" } = {}) => {
-  const matchingPattern = Object.keys(expectations).find(pattern => {
-    return path.matchesGlob(testFilePath, prefix + pattern);
+  const testFile = testFilePath.slice(prefix.length);
+
+  let matchingPattern = Object.keys(expectations).find(pattern => {
+    return !/[*?\[\]{}()!@+]/.test(pattern) && testFilePath === prefix + pattern;
   });
 
-  const testFile = testFilePath.slice(prefix.length);
+  if (!matchingPattern) {
+    matchingPattern = Object.keys(expectations).find(pattern => {
+      return /[*?\[\]{}()!@+]/.test(pattern) && path.matchesGlob(testFilePath, prefix + pattern);
+    });
+  }
+
   let reason, data;
 
   if (matchingPattern) {
@@ -143,13 +150,15 @@ exports.runTestWithExpectations = (testFilePath, expectations, { runSingleWPT, p
 };
 
 exports.expectationsInToRunDoc = doc => {
-  const expectations = structuredClone(doc);
-  delete expectations.DIR;
+  const { DIR, ...expectations } = doc;
   return expectations;
 };
 
 function checkExpectations(expectations, possibleTestFilePaths, { prefix = "" } = {}) {
   let lastPattern = "";
+
+  const testFilePathSet = new Set(possibleTestFilePaths);
+
   for (const [pattern, data] of Object.entries(expectations)) {
     if (pattern.startsWith("/")) {
       throw new Error(`Expectation patterns must not start with a slash: saw "${pattern}"`);
@@ -185,12 +194,17 @@ function checkExpectations(expectations, possibleTestFilePaths, { prefix = "" } 
       }
     }
 
-    if (!possibleTestFilePaths.some(filename => path.matchesGlob(filename, prefix + pattern))) {
+    const fullPattern = prefix + pattern;
+    const isGlob = /[*?\[\]{}()!@+]/.test(fullPattern); 
+    const exists = isGlob
+      ? possibleTestFilePaths.some(filename => path.matchesGlob(filename, fullPattern))
+      : testFilePathSet.has(fullPattern);
+
+    if (!exists) {
       throw new Error(`Expectation pattern "${pattern}" does not match any test files`);
     }
   }
 }
-
 
 function resolveReason(reason) {
   if (["fail-slow", "pass-slow", "timeout", "flaky"].includes(reason)) {

--- a/test/web-platform-tests/expectations-utils.js
+++ b/test/web-platform-tests/expectations-utils.js
@@ -90,12 +90,12 @@ exports.runTestWithExpectations = (testFilePath, expectations, { runSingleWPT, p
   const testFile = testFilePath.slice(prefix.length);
 
   let matchingPattern = Object.keys(expectations).find(pattern => {
-    return !/[*?\[\]{}()!@+]/.test(pattern) && testFilePath === prefix + pattern;
+    return !/[*?[\]{}()!@+]/.test(pattern) && testFilePath === prefix + pattern;
   });
 
   if (!matchingPattern) {
     matchingPattern = Object.keys(expectations).find(pattern => {
-      return /[*?\[\]{}()!@+]/.test(pattern) && path.matchesGlob(testFilePath, prefix + pattern);
+      return /[*?[\]{}()!@+]/.test(pattern) && path.matchesGlob(testFilePath, prefix + pattern);
     });
   }
 
@@ -150,7 +150,8 @@ exports.runTestWithExpectations = (testFilePath, expectations, { runSingleWPT, p
 };
 
 exports.expectationsInToRunDoc = doc => {
-  const { DIR, ...expectations } = doc;
+  const expectations = structuredClone(doc);
+  delete expectations.DIR;
   return expectations;
 };
 
@@ -195,10 +196,10 @@ function checkExpectations(expectations, possibleTestFilePaths, { prefix = "" } 
     }
 
     const fullPattern = prefix + pattern;
-    const isGlob = /[*?\[\]{}()!@+]/.test(fullPattern); 
-    const exists = isGlob
-      ? possibleTestFilePaths.some(filename => path.matchesGlob(filename, fullPattern))
-      : testFilePathSet.has(fullPattern);
+    const isGlob = /[*?[\]{}()!@+]/.test(fullPattern);
+    const exists = isGlob ?
+      possibleTestFilePaths.some(filename => path.matchesGlob(filename, fullPattern)) :
+      testFilePathSet.has(fullPattern);
 
     if (!exists) {
       throw new Error(`Expectation pattern "${pattern}" does not match any test files`);

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -31,9 +31,7 @@ describe("web-platform-tests", () => {
 
   for (const toRunDoc of toRunDocs) {
     const dirPrefix = toRunDoc.DIR.endsWith("/") ? toRunDoc.DIR : toRunDoc.DIR + "/";
-    const matchedFiles = possibleTestFilePaths.filter(filePath => 
-      filePath.startsWith(dirPrefix)
-    );
+    const matchedFiles = possibleTestFilePaths.filter(filePath => filePath.startsWith(dirPrefix));
 
     filesByDir.set(toRunDoc, matchedFiles);
   }

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -27,16 +27,27 @@ before({ timeout: 30_000 }, async () => {
 after({ timeout: 5000 }, () => killSubprocess(serverProcess));
 
 describe("web-platform-tests", () => {
+  const filesByDir = new Map();
+
+  for (const toRunDoc of toRunDocs) {
+    const dirPrefix = toRunDoc.DIR.endsWith("/") ? toRunDoc.DIR : toRunDoc.DIR + "/";
+    const matchedFiles = possibleTestFilePaths.filter(filePath => 
+      filePath.startsWith(dirPrefix)
+    );
+
+    filesByDir.set(toRunDoc, matchedFiles);
+  }
+
   for (const toRunDoc of toRunDocs) {
     const expectations = expectationsInToRunDoc(toRunDoc);
+    const dirFiles = filesByDir.get(toRunDoc) || [];
+
     describe(toRunDoc.DIR, () => {
-      for (const testFilePath of possibleTestFilePaths) {
-        if (testFilePath.startsWith(toRunDoc.DIR + "/")) {
-          runTestWithExpectations(testFilePath, expectations, {
-            runSingleWPT,
-            prefix: toRunDoc.DIR + "/"
-          });
-        }
+      for (const testFilePath of dirFiles) {
+        runTestWithExpectations(testFilePath, expectations, {
+          runSingleWPT,
+          prefix: toRunDoc.DIR.endsWith("/") ? toRunDoc.DIR : toRunDoc.DIR + "/"
+        });
       }
     });
   }


### PR DESCRIPTION
Improve performance of web platform test execution by:

expectations-utils.js
- Separating exact path matches from glob pattern matches in expectation resolution, prioritizing exact matches to avoid unnecessary glob operations
- Using a Set for O(1) exact path lookups instead of O(n) array operations in checkExpectations

run-wpt.js
- Pre-filtering test files by directory in run-wpts.js to avoid repeated startsWith checks in the test loop
