### PR TITLE
Precompute WPT expectation matches

### DIFF
--- a/test/web-platform-tests/expectations-utils.js
+++ b/test/web-platform-tests/expectations-utils.js
@@ -48,14 +48,13 @@ exports.checkToUpstreamExpectations = (toUpstreamExpectationsFilename, possibleT
     expectations = {};
   }
 
-  checkExpectations(expectations, possibleTestFilePaths);
-
-  return expectations;
+  return exports.prepareExpectations(expectations, possibleTestFilePaths);
 };
 
 exports.checkToRunFile = (toRunFilename, possibleTestFilePaths) => {
   const toRunString = fs.readFileSync(toRunFilename, { encoding: "utf-8" });
   const toRunDocs = jsYAML.loadAll(toRunString, null, { filename: toRunFilename, schema: jsYAML.DEFAULT_SAFE_SCHEMA });
+  const testGroups = [];
 
   let lastDir = "";
   for (const doc of toRunDocs) {
@@ -78,30 +77,39 @@ exports.checkToRunFile = (toRunFilename, possibleTestFilePaths) => {
     }
     lastDir = doc.DIR;
 
-    checkExpectations(exports.expectationsInToRunDoc(doc), possibleTestFilePaths, {
-      prefix: doc.DIR + "/"
+    const prefix = doc.DIR + "/";
+    const testFilePaths = possibleTestFilePaths.filter(testFilePath => testFilePath.startsWith(prefix));
+    const expectations = structuredClone(doc);
+    delete expectations.DIR;
+
+    const expectationDataByTestFilePath = exports.prepareExpectations(expectations, testFilePaths, { prefix });
+    testGroups.push({
+      dir: doc.DIR,
+      expectationDataByTestFilePath,
+      testFilePaths
     });
   }
 
-  return toRunDocs;
+  return testGroups;
 };
 
-exports.runTestWithExpectations = (testFilePath, expectations, { runSingleWPT, prefix = "" } = {}) => {
-  const matchingPattern = Object.keys(expectations).find(pattern => {
-    return path.matchesGlob(testFilePath, prefix + pattern);
-  });
-
+exports.runTestWithExpectations = (
+  testFilePath,
+  expectationDataByTestFilePath,
+  { runSingleWPT, prefix = "" } = {}
+) => {
+  const expectationData = expectationDataByTestFilePath.get(testFilePath);
   const testFile = testFilePath.slice(prefix.length);
   let reason, data;
 
-  if (matchingPattern) {
+  if (expectationData) {
     // The array case is when the failure affects the whole test file
     // (ex.: testharness timeout or error, uncaught exception, etc.)
-    reason = expectations[matchingPattern][0];
-    if (!Array.isArray(expectations[matchingPattern])) {
+    reason = expectationData[0];
+    if (!Array.isArray(expectationData)) {
       // The non-array case is when some subtests in the test file pass,
       // but others fail, and testharness status is OK.
-      data = expectations[matchingPattern];
+      data = expectationData;
     }
   } else if (prefix.startsWith("html/canvas/")) {
     reason = "needs-canvas";
@@ -142,14 +150,10 @@ exports.runTestWithExpectations = (testFilePath, expectations, { runSingleWPT, p
   }
 };
 
-exports.expectationsInToRunDoc = doc => {
-  const expectations = structuredClone(doc);
-  delete expectations.DIR;
-  return expectations;
-};
-
-function checkExpectations(expectations, possibleTestFilePaths, { prefix = "" } = {}) {
+exports.prepareExpectations = (expectations, possibleTestFilePaths, { prefix = "" } = {}) => {
+  const expectationDataByTestFilePath = new Map();
   let lastPattern = "";
+
   for (const [pattern, data] of Object.entries(expectations)) {
     if (pattern.startsWith("/")) {
       throw new Error(`Expectation patterns must not start with a slash: saw "${pattern}"`);
@@ -185,12 +189,23 @@ function checkExpectations(expectations, possibleTestFilePaths, { prefix = "" } 
       }
     }
 
-    if (!possibleTestFilePaths.some(filename => path.matchesGlob(filename, prefix + pattern))) {
+    let matched = false;
+    for (const testFilePath of possibleTestFilePaths) {
+      if (path.matchesGlob(testFilePath, prefix + pattern)) {
+        matched = true;
+        if (!expectationDataByTestFilePath.has(testFilePath)) {
+          expectationDataByTestFilePath.set(testFilePath, data);
+        }
+      }
+    }
+
+    if (!matched) {
       throw new Error(`Expectation pattern "${pattern}" does not match any test files`);
     }
   }
-}
 
+  return expectationDataByTestFilePath;
+};
 
 function resolveReason(reason) {
   if (["fail-slow", "pass-slow", "timeout", "flaky"].includes(reason)) {

--- a/test/web-platform-tests/run-tuwpts.js
+++ b/test/web-platform-tests/run-tuwpts.js
@@ -27,7 +27,7 @@ if (lintResult.status !== 0) {
 }
 const possibleTestFilePaths = getPossibleTestFilePaths(manifest);
 
-const expectations = checkToUpstreamExpectations(
+const expectationDataByTestFilePath = checkToUpstreamExpectations(
   path.resolve(__dirname, expectationsFilename),
   possibleTestFilePaths
 );
@@ -47,6 +47,6 @@ after({ timeout: 5000 }, () => killSubprocess(serverProcess));
 
 describe("Local tests in web-platform-test format (to-upstream)", () => {
   for (const testFilePath of possibleTestFilePaths) {
-    runTestWithExpectations(testFilePath, expectations, { runSingleWPT });
+    runTestWithExpectations(testFilePath, expectationDataByTestFilePath, { runSingleWPT });
   }
 });

--- a/test/web-platform-tests/run-wpts.js
+++ b/test/web-platform-tests/run-wpts.js
@@ -4,14 +4,14 @@ const { describe, before, after } = require("mocha-sugar-free");
 const { readManifest, getPossibleTestFilePaths } = require("./wpt-manifest-utils.js");
 const wptServer = require("./wpt-server.js");
 const { killSubprocess } = require("./utils.js");
-const { checkToRunFile, expectationsInToRunDoc, runTestWithExpectations } = require("./expectations-utils.js");
+const { checkToRunFile, runTestWithExpectations } = require("./expectations-utils.js");
 
 const manifestFilename = path.resolve(__dirname, "wpt-manifest.json");
 const manifest = readManifest(manifestFilename);
 const possibleTestFilePaths = getPossibleTestFilePaths(manifest);
 const toRunFilename = "to-run.yaml";
 
-const toRunDocs = checkToRunFile(path.resolve(__dirname, toRunFilename), possibleTestFilePaths);
+const testGroups = checkToRunFile(path.resolve(__dirname, toRunFilename), possibleTestFilePaths);
 
 let wptServerURL, serverProcess;
 const runSingleWPT = require("./run-single-wpt.js")(
@@ -27,16 +27,13 @@ before({ timeout: 30_000 }, async () => {
 after({ timeout: 5000 }, () => killSubprocess(serverProcess));
 
 describe("web-platform-tests", () => {
-  for (const toRunDoc of toRunDocs) {
-    const expectations = expectationsInToRunDoc(toRunDoc);
-    describe(toRunDoc.DIR, () => {
-      for (const testFilePath of possibleTestFilePaths) {
-        if (testFilePath.startsWith(toRunDoc.DIR + "/")) {
-          runTestWithExpectations(testFilePath, expectations, {
-            runSingleWPT,
-            prefix: toRunDoc.DIR + "/"
-          });
-        }
+  for (const { dir, expectationDataByTestFilePath, testFilePaths } of testGroups) {
+    describe(dir, () => {
+      for (const testFilePath of testFilePaths) {
+        runTestWithExpectations(testFilePath, expectationDataByTestFilePath, {
+          runSingleWPT,
+          prefix: dir + "/"
+        });
       }
     });
   }


### PR DESCRIPTION
The Node.js floor and dependency update replaced reusable `Minimatch` instances with `path.matchesGlob()`. Because `path.matchesGlob()` reparses its pattern on every call, validating every expectation against the complete WPT manifest caused a large test-registration regression.

This precomputes the first matching expectation for each manifest path while validating the expectation files. It limits matching to each configured WPT directory, reuses those file groups during Mocha registration, and keeps the implementation on Node.js builtins while preserving first-pattern-wins behavior.

On Node.js 26.3.1 with the current manifest (27,171 candidate paths, 103 directory groups, and 1,728 expectation patterns), the matching and validation benchmark was:

| Implementation | Time |
| --- | ---: |
| Current `main` | More than 120 seconds |
| #4191 | Approximately 22.9 seconds |
| This PR | Approximately 3.1 seconds |

A full Mocha dry run registered all 6,863 selected tests in 3.78 seconds. Local lint, the API suite, the to-upstream WPT suite, and a targeted overlapping WebSocket expectation all pass.