### PR TITLE
perf: significantly speeds  up range operations on large documents

### DIFF
--- a/benchmark/dom/ranges.js
+++ b/benchmark/dom/ranges.js
@@ -1,0 +1,122 @@
+"use strict";
+const documentBench = require("../document-bench");
+
+// Range mutation, sized along the two axes that matter for it: how much the
+// range covers, and how large the surrounding tree is. The second axis is the
+// interesting one, because containment is decided with boundary-point
+// comparisons and those walk the tree rather than the range.
+//
+// The surrounding tree is built once per task (beforeAll) and only the boundary
+// container is restored between iterations (beforeEach), so the timed window
+// holds just the range operation and the per-iteration allocation stays
+// proportional to the span rather than to the whole tree.
+module.exports = () => {
+  const { document, bench } = documentBench();
+
+  function buildRow(index) {
+    const row = document.createElement("div");
+    row.appendChild(document.createTextNode(`row ${index}`));
+    row.appendChild(document.createElement("span"));
+    return row;
+  }
+
+  // container
+  //   span.filler * siblingCount
+  //   div            <- `parent`, the shared boundary container
+  //     header
+  //     #comment     <- start marker
+  //     div * listSize
+  //     #comment     <- end marker
+  //     footer
+  function buildTree(listSize, siblingCount) {
+    const container = document.createElement("div");
+    for (let i = 0; i < siblingCount; ++i) {
+      const filler = document.createElement("span");
+      filler.appendChild(document.createTextNode("filler"));
+      container.appendChild(filler);
+    }
+
+    const parent = document.createElement("div");
+    container.appendChild(parent);
+
+    // Rebuilds `parent` outright rather than just the span, so it also restores
+    // an op that took the markers with it (selectNodeContents).
+    const tree = { container, parent, start: null, end: null };
+    tree.reset = () => {
+      parent.replaceChildren();
+      parent.appendChild(document.createElement("header"));
+      tree.start = document.createComment("start");
+      parent.appendChild(tree.start);
+      for (let i = 0; i < listSize; ++i) {
+        parent.appendChild(buildRow(i));
+      }
+      tree.end = document.createComment("end");
+      parent.appendChild(tree.end);
+      parent.appendChild(document.createElement("footer"));
+    };
+    tree.reset();
+
+    return tree;
+  }
+
+  /** A range over the marker span: both boundary points are inside `parent`. */
+  function addSpanTask(name, listSize, siblingCount, run, { destructive = true } = {}) {
+    let tree,
+      range;
+    bench.add(name, () => run(range), {
+      beforeAll() {
+        tree = buildTree(listSize, siblingCount);
+      },
+      beforeEach() {
+        if (destructive) {
+          tree.reset();
+        }
+        range = document.createRange();
+        range.setStartAfter(tree.start);
+        range.setEndBefore(tree.end);
+      }
+    });
+  }
+
+  addSpanTask("deleteContents: small span, small tree", 10, 20, range => range.deleteContents());
+  addSpanTask("deleteContents: small span, large tree", 10, 2000, range => range.deleteContents());
+  addSpanTask("deleteContents: large span, large tree", 500, 2000, range => range.deleteContents());
+  addSpanTask("extractContents: small span, large tree", 10, 2000, range => range.extractContents());
+  addSpanTask("cloneContents: small span, large tree", 10, 2000, range => range.cloneContents(), {
+    destructive: false
+  });
+
+  let selectTree, selectRange, partialTree, partialRange;
+
+  // selectNodeContents() produces the same shared-container shape, over every
+  // child of the container rather than a marked span.
+  bench.add("deleteContents: selectNodeContents", () => selectRange.deleteContents(), {
+    beforeAll() {
+      selectTree = buildTree(200, 500);
+    },
+    beforeEach() {
+      selectTree.reset();
+      selectRange = document.createRange();
+      selectRange.selectNodeContents(selectTree.parent);
+    }
+  });
+
+  // Partially contained boundaries: the range starts and ends inside different
+  // text nodes, so neither boundary container is fully covered. This is the
+  // shape that cannot be reduced to one container's children, and it keeps the
+  // general path measured.
+  bench.add("deleteContents: partially contained boundaries", () => partialRange.deleteContents(), {
+    beforeAll() {
+      partialTree = buildTree(100, 500);
+    },
+    beforeEach() {
+      partialTree.reset();
+      const rows = partialTree.parent.getElementsByTagName("div");
+      partialRange = document.createRange();
+      partialRange.setStart(rows[0].firstChild, 2);
+      partialRange.setEnd(rows[rows.length - 1].firstChild, 2);
+    }
+  });
+
+  return bench;
+};

--- a/lib/jsdom/living/helpers/node.js
+++ b/lib/jsdom/living/helpers/node.js
@@ -81,28 +81,9 @@ function isInclusiveAncestor(ancestorNode, node) {
   return false;
 }
 
-// https://dom.spec.whatwg.org/#concept-tree-following
-function isFollowing(nodeA, nodeB) {
-  if (nodeA === nodeB) {
-    return false;
-  }
-
-  let current = nodeB;
-  while (current) {
-    if (current === nodeA) {
-      return true;
-    }
-
-    current = domSymbolTree.following(current);
-  }
-
-  return false;
-}
-
 module.exports = {
   nodeLength,
   nodeRoot,
 
-  isInclusiveAncestor,
-  isFollowing
+  isInclusiveAncestor
 };

--- a/lib/jsdom/living/range/boundary-point.js
+++ b/lib/jsdom/living/range/boundary-point.js
@@ -1,17 +1,20 @@
 "use strict";
 
+const { TreePosition } = require("symbol-tree");
 const { domSymbolTree } = require("../helpers/internal-constants");
-const { nodeRoot, isFollowing, isInclusiveAncestor } = require("../helpers/node");
 
 // Returns 0 if equal, +1 for after and -1 for before
 // https://dom.spec.whatwg.org/#concept-range-bp-after
+//
+// The relative tree position comes from symbol-tree, which walks the two
+// ancestor chains and compares indices within their lowest common ancestor.
+// Deriving it from a tree-order scan instead — walking forward from one node
+// until the other is found or the tree runs out — costs O(nodes following the
+// node) per comparison, and the Range containment tests call this once or twice
+// per candidate node.
 function compareBoundaryPointsPosition(bpA, bpB) {
   const { node: nodeA, offset: offsetA } = bpA;
   const { node: nodeB, offset: offsetB } = bpB;
-
-  if (nodeRoot(nodeA) !== nodeRoot(nodeB)) {
-    throw new Error(`Internal Error: Boundary points should have the same root!`);
-  }
 
   if (nodeA === nodeB) {
     if (offsetA === offsetB) {
@@ -23,23 +26,36 @@ function compareBoundaryPointsPosition(bpA, bpB) {
     return 1;
   }
 
-  if (isFollowing(nodeA, nodeB)) {
-    return compareBoundaryPointsPosition(bpB, bpA) === -1 ? 1 : -1;
+  const position = domSymbolTree.compareTreePosition(nodeA, nodeB);
+
+  if (position & TreePosition.DISCONNECTED) {
+    throw new Error(`Internal Error: Boundary points should have the same root!`);
   }
 
-  if (isInclusiveAncestor(nodeA, nodeB)) {
+  // nodeA is an ancestor of nodeB: the boundary points are ordered by whether
+  // offsetA is past the child of nodeA that contains nodeB.
+  if (position & TreePosition.CONTAINED_BY) {
     let child = nodeB;
-
     while (domSymbolTree.parent(child) !== nodeA) {
       child = domSymbolTree.parent(child);
     }
 
-    if (domSymbolTree.index(child) < offsetA) {
-      return 1;
-    }
+    return domSymbolTree.index(child) < offsetA ? 1 : -1;
   }
 
-  return -1;
+  // nodeB is an ancestor of nodeA, i.e. the mirror of the above with the
+  // boundary points swapped, so the result is inverted.
+  if (position & TreePosition.CONTAINS) {
+    let child = nodeA;
+    while (domSymbolTree.parent(child) !== nodeB) {
+      child = domSymbolTree.parent(child);
+    }
+
+    return domSymbolTree.index(child) < offsetB ? -1 : 1;
+  }
+
+  // Disjoint subtrees: tree order alone decides.
+  return position & TreePosition.PRECEDING ? 1 : -1;
 }
 
 module.exports = {


### PR DESCRIPTION
# Compare boundary points via ancestor chains instead of walking the tree

## Summary

`compareBoundaryPointsPosition()` derives the relative order of two boundary
points from `isFollowing()`, which walks forward from one node until it finds
the other — or runs out of tree. That makes a single comparison
O(nodes following the node), and Range operations call it once or twice per
candidate node, so their cost grows with the content that happens to sit *after*
the range rather than with the range itself.

`symbol-tree` (already a dependency) provides `compareTreePosition()`, which
compares the two ancestor chains and their indices within the lowest common
ancestor — O(depth), with `index()` amortized O(1). Using it makes the
comparison independent of tree size.

No behavior change: this computes the same answer a cheaper way.

## The problem

Deleting a **constant** 10-element span while growing the content that follows
it:

```js
const { JSDOM } = require("jsdom");
const { document } = new JSDOM().window;

for (const trailing of [500, 1000, 2000, 4000, 8000]) {
  const container = document.createElement("div");
  const parent = document.createElement("div");
  const start = document.createComment("s");
  const end = document.createComment("e");
  container.appendChild(parent);
  for (let i = 0; i < trailing; ++i) {
    container.appendChild(document.createElement("span"));
  }

  let total = 0;
  const RUNS = 20;
  for (let r = 0; r < RUNS; ++r) {
    parent.replaceChildren();
    parent.appendChild(start);
    for (let i = 0; i < 10; ++i) {
      parent.appendChild(document.createElement("p"));
    }
    parent.appendChild(end);

    const range = document.createRange();
    range.setStartAfter(start);
    range.setEndBefore(end);

    const t0 = performance.now();
    range.deleteContents();
    total += performance.now() - t0;
  }
  console.log(`${trailing} trailing nodes: ${(total / RUNS).toFixed(2)} ms`);
}
```

| trailing nodes | before | after |
| --- | --- | --- |
| 500 | 1.01 ms | 0.19 ms |
| 1000 | 1.69 ms | 0.10 ms |
| 2000 | 3.35 ms | 0.08 ms |
| 4000 | 6.69 ms | 0.07 ms |
| 8000 | 14.00 ms | 0.08 ms |

The span being deleted is identical in every row; only the unrelated content
after it grows. This shape is common in UI framework tests, where a keyed list
bracketed by comment markers is cleared with a range — the cost then scales with
the rest of the page rather than with the list.

## The fix

`compareTreePosition(left, right)` returns the position of `right` relative to
`left` using the same flags as `compareDocumentPosition`, which maps onto the
spec's algorithm directly:

- `CONTAINED_BY` — `nodeA` is an ancestor of `nodeB`, so the order is decided by
  whether `offsetA` is past the child of `nodeA` that contains `nodeB`. This is
  step 3 of the spec algorithm.
- `CONTAINS` — the mirror of that with the boundary points swapped, which the
  spec expresses as step 2 recursing into step 3; the result is inverted.
- otherwise the subtrees are disjoint and tree order alone decides.

`DISCONNECTED` replaces the previous explicit `nodeRoot(nodeA) !==
nodeRoot(nodeB)` check, preserving the same thrown error while dropping two root
walks per comparison.

This was the only caller of `isFollowing()` in `lib/jsdom/living/helpers/node.js`,
so that helper is removed rather than left as dead code. It was the tree-order
scan being replaced, and `compareDocumentPosition()` — the other place in jsdom
that needs tree order — has been built on `compareTreePosition()` since 2015.

## Benchmarks

Adds `benchmark/dom/ranges.js`, since there was no Range suite. It sizes tasks
along the two axes that matter — how much the range covers, and how much content
surrounds it — and includes a task whose boundaries are only partially contained,
which is the shape that cannot be reduced to a single container.

`npm run benchmark -- --suite dom/ranges`, latency avg:

| task | before | after |
| --- | --- | --- |
| `deleteContents: large span, large tree` | 508.6 ms | **6.10 ms** |
| `deleteContents: selectNodeContents` | 76.0 ms | **3.33 ms** |
| `deleteContents: partially contained boundaries` | 11.7 ms | **2.44 ms** |
| `cloneContents: small span, large tree` | 152 µs | **87 µs** |
| `deleteContents: small span, large tree` | 777 µs | 649 µs |
| `deleteContents: small span, small tree` | 795 µs | 657 µs |
| `extractContents: small span, large tree` | 719 µs | 695 µs |

`extractContents()`, `cloneContents()`, and `Selection` go through the same
comparison, so they benefit without being touched.

## Correctness

Since this computes the same answer a different way, it was verified
differentially against the current implementation:

- **`compareBoundaryPointsPosition()` itself**: every *ordered* pair of boundary
  points (both directions, so an asymmetry would show) across 7 fixtures —
  element-only, mixed text/comment/element, nested, pure text, deep nesting, a
  wide container, and a deep single chain. **7666 comparisons, identical**,
  including the two cases that must throw (two separate documents, and a
  detached node against an attached one).
- **`deleteContents()` end to end**: every ordered pair of boundary points across
  7 fixtures, recording both the resulting tree and the collapsed range position.
  **2658 cases, byte-identical.** Fixtures include an XML document containing a
  CDATASection.



