### PR TITLE
Implement CSS as a Web IDL namespace

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -5,7 +5,6 @@ const whatwgURL = require("whatwg-url");
 const { notImplementedMethod } = require("./not-implemented");
 const { installInterfaces } = require("../living/interfaces");
 const { define, mixin } = require("../utils");
-const CSS = require("../../generated/idl/CSS");
 const Element = require("../../generated/idl/Element");
 const EventTarget = require("../../generated/idl/EventTarget");
 const EventHandlerNonNull = require("../../generated/idl/EventHandlerNonNull");
@@ -79,9 +78,6 @@ exports.createWindow = options => {
 
   // Create instances of all the web platform interfaces and install them on the window.
   installInterfaces(window, ["Window"]);
-
-  // Mount CSS.
-  window.CSS = CSS.create(window, [], {});
 
   // Now we have an EventTarget contructor so we can work on the prototype chain.
 

--- a/lib/jsdom/living/css/CSS-impl.js
+++ b/lib/jsdom/living/css/CSS-impl.js
@@ -7,14 +7,10 @@ const csstree = require("./helpers/patched-csstree.js");
 const PROP_VAL_REGEXP = /^([^():]+)\s*:\s*(.+)\s*$/;
 
 class CSSImpl {
-  #testNode;
-
-  constructor(globalObject) {
-    this._globalObject = globalObject;
-  }
+  static #testNodes = new WeakMap();
 
   // https://drafts.csswg.org/cssom/#the-css.escape()-method
-  escape(ident) {
+  static escape(ident) {
     const l = ident.length;
     const firstCodeUnit = l > 0 ? ident.charCodeAt(0) : 0;
     let escaped = "";
@@ -66,27 +62,27 @@ class CSSImpl {
   }
 
   // https://drafts.csswg.org/css-conditional-3/#the-css-namespace
-  supports(...args) {
+  static supports(globalObject, ...args) {
     if (args.length === 1) {
-      return this.#supportsConditionText(args[0].trim());
+      return this.#supportsConditionText(globalObject, args[0].trim());
     }
 
     const [property, value] = args;
-    return this.#supportsDeclaration(property, value);
+    return this.#supportsDeclaration(globalObject, property, value);
   }
 
-  #supportsConditionText(conditionText) {
+  static #supportsConditionText(globalObject, conditionText) {
     // Condition without parens (e.g., "color: red")
     if (PROP_VAL_REGEXP.test(conditionText)) {
       const [, property, value] = PROP_VAL_REGEXP.exec(conditionText);
-      return this.#supportsDeclaration(property, value);
+      return this.#supportsDeclaration(globalObject, property, value);
     }
 
     const ast = csstree.parse(`@supports ${conditionText} {}`, { context: "stylesheet" });
-    return this.#evaluateList(ast.children.first.prelude?.children);
+    return this.#evaluateList(globalObject, ast.children.first.prelude?.children);
   }
 
-  #supportsDeclaration(property, value) {
+  static #supportsDeclaration(globalObject, property, value) {
     // Custom property
     if (property.startsWith("--")) {
       try {
@@ -106,10 +102,10 @@ class CSSImpl {
       return false;
     }
 
-    return this.#isValueSupported(lowerProp, value);
+    return this.#isValueSupported(globalObject, lowerProp, value);
   }
 
-  #evaluateList(list) {
+  static #evaluateList(globalObject, list) {
     if (!list || !list.head) {
       return false;
     }
@@ -156,15 +152,15 @@ class CSSImpl {
       switch (type) {
         case "Parentheses":
         case "Condition": {
-          childResult = this.#evaluateList(children);
+          childResult = this.#evaluateList(globalObject, children);
           break;
         }
         case "Declaration": {
-          childResult = this.#validateDeclarationAST(property, value);
+          childResult = this.#validateDeclarationAST(globalObject, property, value);
           break;
         }
         case "SupportsDeclaration": {
-          childResult = this.#validateDeclarationAST(declaration.property, declaration.value);
+          childResult = this.#validateDeclarationAST(globalObject, declaration.property, declaration.value);
           break;
         }
         default: {
@@ -198,7 +194,7 @@ class CSSImpl {
     return result === null ? false : result;
   }
 
-  #validateDeclarationAST(property, ast) {
+  static #validateDeclarationAST(globalObject, property, ast) {
     // Custom property
     if (property.startsWith("--")) {
       return true;
@@ -209,17 +205,19 @@ class CSSImpl {
       return false;
     }
 
-    return this.#isValueSupported(lowerProp, csstree.generate(ast));
+    return this.#isValueSupported(globalObject, lowerProp, csstree.generate(ast));
   }
 
-  #isValueSupported(property, value) {
-    if (!this.#testNode) {
-      this.#testNode = this._globalObject.document.createElement("div");
+  static #isValueSupported(globalObject, property, value) {
+    let testNode = this.#testNodes.get(globalObject);
+    if (testNode === undefined) {
+      testNode = globalObject.document.createElement("div");
+      this.#testNodes.set(globalObject, testNode);
     }
-    this.#testNode.style.setProperty(property, value);
+    testNode.style.setProperty(property, value);
 
-    const isSupported = this.#testNode.style.getPropertyValue(property) !== "";
-    this.#testNode.style.cssText = "";
+    const isSupported = testNode.style.getPropertyValue(property) !== "";
+    testNode.style.cssText = "";
     return isSupported;
   }
 }

--- a/lib/jsdom/living/css/CSS.webidl
+++ b/lib/jsdom/living/css/CSS.webidl
@@ -1,7 +1,7 @@
 // https://drafts.csswg.org/cssom/#namespacedef-css
-[Exposed=Window, LegacyNoInterfaceObject]
-interface CSS {
-  boolean supports(CSSOMString conditionText);
-  boolean supports(CSSOMString property, CSSOMString value);
+[Exposed=Window]
+namespace CSS {
+  [WebIDL2JSCallWithGlobal] boolean supports(CSSOMString conditionText);
+  [WebIDL2JSCallWithGlobal] boolean supports(CSSOMString property, CSSOMString value);
   CSSOMString escape(CSSOMString ident);
 };

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -335,7 +335,6 @@ DIR: css/css-transitions
 
 DIR: css/cssom
 
-CSS-namespace-object-class-string.html: [fail, Unknown]
 CSSFontFeatureValuesRule.html: [fail, Unknown]
 CSSStyleRule-set-selectorText-namespace.html: [fail, csstree does not validate or normalize selectors]
 CSSStyleRule-set-selectorText.html: [fail, csstree does not validate or normalize selectors]


### PR DESCRIPTION
Uses webidl2js namespace generation for `CSS` and enables the namespace object class-string WPT.