### PR TITLE
Ignore data: and javascript: URLs in <base href>

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -279,8 +279,18 @@ class DocumentImpl extends NodeImpl {
     // TODO: implement, with tests for all code paths, the spec's behavior.
 
     const baseHrefAttribute = baseElement.getAttributeNS(null, "href");
-    const result = whatwgURL.parseURL(baseHrefAttribute, { baseURL: fallbackBaseURL });
-    return result === null ? fallbackBaseURL : result;
+    const urlRecord = whatwgURL.parseURL(baseHrefAttribute, { baseURL: fallbackBaseURL });
+
+    // data: and javascript: URLs are never usable as a base URL, so the fallback base URL is used
+    // instead. Note this does not fall through to any later base element: the document base URL is
+    // the first base element with an href, whether or not that element's URL turns out to be usable.
+    //
+    // We don't implement the "Is base allowed for Document?" CSP check.
+    if (urlRecord === null || urlRecord.scheme === "data" || urlRecord.scheme === "javascript") {
+      return fallbackBaseURL;
+    }
+
+    return urlRecord;
   }
 
   // https://html.spec.whatwg.org/#fallback-base-url

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1455,8 +1455,6 @@ DIR: html/semantics/disabled-elements
 
 DIR: html/semantics/document-metadata/the-base-element
 
-base-data.html: [fail, Unknown]
-base-javascript.html: [fail, Unknown]
 base_multiple.html: [timeout, We don't support navigation via <a target>]
 base_target_does_not_affect_location_assignment.html: [timeout, We don't support navigation via location]
 


### PR DESCRIPTION
### How browsers differ from jsdom

Per [set the frozen base URL](https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url), a `<base href>` whose parsed scheme is `data` or `javascript` is unusable, and the element's frozen base URL becomes the document's fallback base URL. `_frozenBaseURL()` only handled the *parse failure* branch, so those two schemes were accepted as the document base URL.

The user-visible effect is worse than a wrong base: resolving a relative URL against an opaque-path base throws, so URL-reflecting properties silently returned the raw attribute.

```js
const { document } = new JSDOM(
  '<base href="data:/,test"><a href="blah">a</a>',
  { url: 'https://doc.example/page/1' }
).window;

document.querySelector('a').href;
// before: 'blah'
// after:  'https://doc.example/page/blah'   (what Chrome and Firefox return)
```

MDN documents the same rule for [`<base>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base): "data: and javascript: URLs are not allowed."

### Tests

This enables two WPTs that were listed in `to-run.yaml` as `[fail, Unknown]`:

- `html/semantics/document-metadata/the-base-element/base-data.html`
- `html/semantics/document-metadata/the-base-element/base-javascript.html`

Both have three subtests, and the second one is the subtle part: when the first `<base>` has a `data:` URL, the fallback base URL is used rather than falling through to a later usable `<base>`. The document base URL is the first base element *with an href*, usable or not. The implementation and the comment call that out explicitly.

I could not run the WPT suite locally — that needs the `web-platform.test` hosts entries, and this machine isn't set up for them — so I verified each assertion of both test files against the equivalent script, on this branch:

| scenario | result |
| --- | --- |
| first `<base>` is `data:` | resolves against document URL ✓ |
| first `<base>` removed, second is `https://example.com/` | resolves against the second ✓ |
| `data:` base prepended dynamically | resolves against document URL ✓ |
| `javascript:` base | resolves against document URL ✓ |
| ordinary `<base href="/assets/">` | unchanged, resolves against the base ✓ |

`test:api` (573 passing) and `test:to-port-to-wpts` (191 passing) are green, and ESLint is clean on the touched file. Happy to add a `to-upstream` test as well if you'd like coverage beyond the two WPTs.

### Out of scope

The `Is base allowed for Document?` CSP check is the third condition in that spec step and stays unimplemented; the comment says so.

---

I found this while cross-checking `<base>` handling in another HTML library against jsdom as the reference implementation, which is how the divergence turned up.
