### PR TITLE
Return the XML and XMLNS namespaces from locate a namespace

### DIFF
--- a/lib/jsdom/living/node.js
+++ b/lib/jsdom/living/node.js
@@ -4,7 +4,7 @@ const NODE_TYPE = require("./node-type");
 
 const orderedSetParse = require("./helpers/ordered-set").parse;
 const { createElement } = require("./helpers/create-element");
-const { HTML_NS, XMLNS_NS } = require("./helpers/namespaces");
+const { HTML_NS, XML_NS, XMLNS_NS } = require("./helpers/namespaces");
 const { cloningSteps, domSymbolTree } = require("./helpers/internal-constants");
 const { asciiCaseInsensitiveMatch, asciiLowercase } = require("./helpers/strings");
 
@@ -270,6 +270,14 @@ exports.locateNamespacePrefix = (element, namespace) => {
 exports.locateNamespace = (node, prefix) => {
   switch (node.nodeType) {
     case NODE_TYPE.ELEMENT_NODE: {
+      if (prefix === "xml") {
+        return XML_NS;
+      }
+
+      if (prefix === "xmlns") {
+        return XMLNS_NS;
+      }
+
       if (node._namespaceURI !== null && node._prefix === prefix) {
         return node._namespaceURI;
       }

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -834,7 +834,6 @@ MutationObserver-cross-realm-callback-report-exception.html: [fail, No relevant 
 MutationObserver-document.html: [fail, Usage of external scripts doesn't block HTML parsing, https://github.com/jsdom/jsdom/issues/2413]
 Node-appendChild-cereactions-vs-script.window.html: [fail, customElements not implemented]
 Node-isConnected.html: [fail, Last two tests with <iframe> are failing]
-Node-lookupNamespaceURI.html: [fail, Unknown]
 Node-mutation-adoptNode.html:
   "Adopting an element into a different document update's the element's owner doc as well as the owner docs of it's attributes": [fail, Unknown]
 NodeList-static-length-getter-tampered*: [flaky, Nested for-loops are really slow and these often time out]


### PR DESCRIPTION
### How browsers differ from jsdom

The `Element` branch of [locate a namespace](https://dom.spec.whatwg.org/#locate-a-namespace) begins with two unconditional steps:

> 1. If *prefix* is "`xml`", then return the [XML namespace](https://infra.spec.whatwg.org/#xml-namespace).
> 2. If *prefix* is "`xmlns`", then return the [XMLNS namespace](https://infra.spec.whatwg.org/#xmlns-namespace).

`locateNamespace()` started at step 3, so those two prefixes were only answered when the element happened to carry a matching `xmlns:` declaration:

```js
const el = document.createElementNS('fooNamespace', 'prefix:elem');

el.lookupNamespaceURI('xml');
// before: null
// after:  'http://www.w3.org/XML/1998/namespace'

el.lookupNamespaceURI('xmlns');
// before: null
// after:  'http://www.w3.org/2000/xmlns/'
```

Both values match what Chrome and Firefox return.

The two steps live in the `Element` branch only, so `DocumentFragment`, `DocumentType` and a disconnected `Attr` keep returning null — `Node-lookupNamespaceURI.html` asserts exactly that, and a `Document` reaches the element branch through its document element, which is also what the test expects.

### Tests

This enables `dom/nodes/Node-lookupNamespaceURI.html`, previously listed as `[fail, Unknown]`. It has 4 failing subtests today ("Element should have XML namespace", "Element should have XMLNS namespace", "Element should have namespace with xmlns prefix", "Child element should have XMLNS namespace") and passes in full with this change.

`isDefaultNamespace()` and `lookupPrefix()` are unaffected: the former goes through `locate a namespace` with a null prefix, the latter through `locate a namespace prefix`.

I can't run the WPT server on this machine, so I ran the test through a static file server pointed at the vendored WPT checkout, reusing `run-single-wpt.js` and its `/resources/` interceptor. Before/after comparison on `dom/nodes/attributes.html`, `dom/nodes/Element-getAttributeNames.html` and `domparsing/XMLSerializer-serializeToString.html` shows no newly failing subtests. `test:api` (573 passing) and `test:to-port-to-wpts` (191 passing) are green, ESLint clean on the touched file.
