### PR TITLE
Default BlobEvent timecode to NaN

### DIFF
--- a/lib/jsdom/living/events/BlobEvent-impl.js
+++ b/lib/jsdom/living/events/BlobEvent-impl.js
@@ -6,7 +6,7 @@ class BlobEventImpl extends EventImpl {}
 // Cannot use the usual pattern since `data` is required.
 BlobEventImpl.defaultInit = {
   __proto__: null,
-  timecode: 0
+  timecode: NaN
 };
 
 module.exports = {

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -2376,8 +2376,6 @@ timer-nesting-not-inherited-in-microtask.html: [flaky]
 DIR: mediacapture-record
 
 "**/!(BlobEvent-constructor.html)": [fail-slow, Not implemented]
-BlobEvent-constructor.html:
-  "The BlobEvent instance's timecode defaults to NaN when not specified.": [fail, Unknown]
 
 ---
 


### PR DESCRIPTION
Default constructor-created `BlobEvent.timecode` values to `NaN`. This failure surfaced when [the BlobEvent constructor test was migrated into WPT](https://github.com/web-platform-tests/wpt/commit/90d9bd61d4ec48eeeaf9fea1c999bcdd68997304).