### PR TITLE
Replace lone surrogates before XML parsing

### DIFF
--- a/lib/jsdom/living/domparsing/DOMParser-impl.js
+++ b/lib/jsdom/living/domparsing/DOMParser-impl.js
@@ -21,7 +21,7 @@ exports.implementation = class DOMParserImpl {
       case "application/xhtml+xml":
       case "image/svg+xml": {
         try {
-          return this.createScriptingDisabledDocument("xml", contentType, string);
+          return this.createScriptingDisabledDocument("xml", contentType, string.toWellFormed());
         } catch (error) {
           const document = this.createScriptingDisabledDocument("xml", contentType);
           const element = document.createElementNS("http://www.mozilla.org/newlayout/xml/parsererror.xml", "parsererror");

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1141,8 +1141,6 @@ DOMParser-parseFromString-url-moretests.html: [fail, Unknown]
 DOMParser-parseFromString-url-pushstate.html: [fail, iframe onload timing]
 DOMParser-parseFromString-url.html: [fail, iframe onload timing]
 DOMParser-parseFromString-xml-doctype.html: [fail, saxes doesn't support DTD validation]
-DOMParser-parseFromString-xml-parsererror.html:
-  "A lone surrogate is replaced with U+FFFD": [fail, Unknown]
 XMLSerializer-serializeToString.html: [fail, Unknown]
 createContextualFragment-xhtml.xhtml: [fail, Unknown]
 createContextualFragment.html: [fail, Script execution timing]


### PR DESCRIPTION
Replace lone UTF-16 surrogates before XML parsing so they become U+FFFD instead of parser errors. This failure surfaced with [the upstream lone-surrogate parser coverage](https://github.com/web-platform-tests/wpt/commit/6308049a5f8d8f1e07d75d606a009af2415c5d81).