### PR TITLE
Track NodeIterator candidates during traversal

### DIFF
--- a/lib/jsdom/living/traversal/NodeIterator-impl.js
+++ b/lib/jsdom/living/traversal/NodeIterator-impl.js
@@ -55,8 +55,7 @@ exports.implementation = class NodeIteratorImpl {
   }
 
   _adjustNodePointer(referenceNode, pointerBeforeReferenceNode, toBeRemovedNode) {
-    // Second clause is https://github.com/whatwg/dom/issues/496
-    if (!toBeRemovedNode.contains(referenceNode) || toBeRemovedNode === this.root) {
+    if (!toBeRemovedNode.contains(referenceNode) || toBeRemovedNode.contains(this.root)) {
       return [referenceNode, pointerBeforeReferenceNode];
     }
 

--- a/lib/jsdom/living/traversal/NodeIterator-impl.js
+++ b/lib/jsdom/living/traversal/NodeIterator-impl.js
@@ -11,6 +11,8 @@ exports.implementation = class NodeIteratorImpl {
 
     this._referenceNode = this.root;
     this._pointerBeforeReferenceNode = true;
+    this._candidateReferenceNode = null;
+    this._candidatePointerBeforeReferenceNode = false;
 
     this._globalObject = globalObject;
   }
@@ -37,12 +39,28 @@ exports.implementation = class NodeIteratorImpl {
 
   // Called by Documents.
   _preRemovingSteps(toBeRemovedNode) {
+    [this._referenceNode, this._pointerBeforeReferenceNode] = this._adjustNodePointer(
+      this._referenceNode,
+      this._pointerBeforeReferenceNode,
+      toBeRemovedNode
+    );
+
+    if (this._candidateReferenceNode !== null) {
+      [this._candidateReferenceNode, this._candidatePointerBeforeReferenceNode] = this._adjustNodePointer(
+        this._candidateReferenceNode,
+        this._candidatePointerBeforeReferenceNode,
+        toBeRemovedNode
+      );
+    }
+  }
+
+  _adjustNodePointer(referenceNode, pointerBeforeReferenceNode, toBeRemovedNode) {
     // Second clause is https://github.com/whatwg/dom/issues/496
-    if (!toBeRemovedNode.contains(this._referenceNode) || toBeRemovedNode === this.root) {
-      return;
+    if (!toBeRemovedNode.contains(referenceNode) || toBeRemovedNode === this.root) {
+      return [referenceNode, pointerBeforeReferenceNode];
     }
 
-    if (this._pointerBeforeReferenceNode) {
+    if (pointerBeforeReferenceNode) {
       let next = null;
       let candidateForNext = domSymbolTree.following(toBeRemovedNode, { skipChildren: true });
       while (candidateForNext !== null) {
@@ -54,54 +72,67 @@ exports.implementation = class NodeIteratorImpl {
       }
 
       if (next !== null) {
-        this._referenceNode = next;
-        return;
+        return [next, true];
       }
-
-      this._pointerBeforeReferenceNode = false;
     }
 
     const { previousSibling } = toBeRemovedNode;
-    this._referenceNode = previousSibling === null ?
-                          toBeRemovedNode.parentNode :
-                          domSymbolTree.lastInclusiveDescendant(toBeRemovedNode.previousSibling);
+    const newNode = previousSibling === null ?
+      toBeRemovedNode.parentNode :
+      domSymbolTree.lastInclusiveDescendant(toBeRemovedNode.previousSibling);
+    return [newNode, false];
   }
 
   _traverse(direction) {
-    let node = this._referenceNode;
-    let beforeNode = this._pointerBeforeReferenceNode;
+    this._candidateReferenceNode = this._referenceNode;
+    this._candidatePointerBeforeReferenceNode = this._pointerBeforeReferenceNode;
+    let result = null;
 
     while (true) {
       if (direction === "next") {
-        if (!beforeNode) {
-          node = domSymbolTree.following(node, { root: this.root });
+        if (!this._candidatePointerBeforeReferenceNode) {
+          const following = domSymbolTree.following(this._candidateReferenceNode, { root: this.root });
 
-          if (!node) {
-            return null;
+          if (!following) {
+            break;
           }
+
+          this._candidateReferenceNode = following;
         }
 
-        beforeNode = false;
+        this._candidatePointerBeforeReferenceNode = false;
       } else if (direction === "previous") {
-        if (beforeNode) {
-          node = domSymbolTree.preceding(node, { root: this.root });
+        if (this._candidatePointerBeforeReferenceNode) {
+          const preceding = domSymbolTree.preceding(this._candidateReferenceNode, { root: this.root });
 
-          if (!node) {
-            return null;
+          if (!preceding) {
+            break;
           }
+
+          this._candidateReferenceNode = preceding;
         }
 
-        beforeNode = true;
+        this._candidatePointerBeforeReferenceNode = true;
       }
 
-      const result = filter(this, node);
-      if (result === FILTER_ACCEPT) {
+      const node = this._candidateReferenceNode;
+      let filterResult;
+      try {
+        filterResult = filter(this, node);
+      } catch (error) {
+        this._candidateReferenceNode = null;
+        throw error;
+      }
+
+      if (filterResult === FILTER_ACCEPT) {
+        this._referenceNode = this._candidateReferenceNode;
+        this._pointerBeforeReferenceNode = this._candidatePointerBeforeReferenceNode;
+        result = node;
         break;
       }
     }
 
-    this._referenceNode = node;
-    this._pointerBeforeReferenceNode = beforeNode;
-    return node;
+    this._candidateReferenceNode = null;
+    return result;
   }
 };

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1126,7 +1126,6 @@ Range-surroundContents.html: [fail-slow, Unknown]
 
 DIR: dom/traversal
 
-NodeIterator-removal-during-filtering.html: [fail, Unknown]
 NodeIterator-removal.html: [fail, Unknown]
 TreeWalker-acceptNode-filter-cross-realm-null-browsing-context.html: [fail, No relevant realm support for callbacks in webidl2js]
 


### PR DESCRIPTION
Track and retarget the in-flight `NodeIterator` candidate when filtering removes it. This failure surfaced with [the upstream removal-during-filtering WPT](https://github.com/web-platform-tests/wpt/commit/8faac02eca341da6d7ac1744f99adfc8912ccc43).