### PR TITLE
Handle large input valueAsNumber values

### DIFF
--- a/lib/jsdom/living/helpers/number-and-date-inputs.js
+++ b/lib/jsdom/living/helpers/number-and-date-inputs.js
@@ -142,6 +142,10 @@ exports.serializeDateByType = {
     });
   },
   "datetime-local"(input) {
+    if (isNaN(input)) {
+      return "";
+    }
+
     return serializeNormalizedDateAndTime({
       date: {
         year: input.getUTCFullYear(),
@@ -184,8 +188,7 @@ exports.convertNumberToStringByType = {
   },
   // https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type=datetime-local):concept-input-value-number-string
   "datetime-local"(input) {
-    const date = new Date(input);
-    return isNaN(date) ? "" : exports.serializeDateByType["datetime-local"](date);
+    return exports.serializeDateByType["datetime-local"](new Date(input));
   },
   // https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number):concept-input-value-number-string
   number(input) {

--- a/lib/jsdom/living/helpers/number-and-date-inputs.js
+++ b/lib/jsdom/living/helpers/number-and-date-inputs.js
@@ -31,6 +31,7 @@ function getUTCMs(year, month = 1, day = 1, hour = 0, minute = 0, second = 0, mi
 }
 
 const dayOfWeekRelMondayLUT = [-1, 0, 1, 2, 3, -3, -2];
+const dayInMilliseconds = 24 * 60 * 60 * 1000;
 
 exports.convertStringToNumberByType = {
   // https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date):concept-input-value-string-number
@@ -178,11 +179,13 @@ exports.convertNumberToStringByType = {
   },
   // https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time):concept-input-value-string-date
   time(input) {
-    return exports.serializeDateByType.time(new Date(input));
+    const time = ((input % dayInMilliseconds) + dayInMilliseconds) % dayInMilliseconds;
+    return exports.serializeDateByType.time(new Date(time));
   },
   // https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type=datetime-local):concept-input-value-number-string
   "datetime-local"(input) {
-    return exports.serializeDateByType["datetime-local"](new Date(input));
+    const date = new Date(input);
+    return isNaN(date) ? "" : exports.serializeDateByType["datetime-local"](date);
   },
   // https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number):concept-input-value-number-string
   number(input) {

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1950,8 +1950,6 @@ input-type-change-value.html: [fail, Unknown]
 input-untrusted-key-event.html: [fail-slow, Not implemented]
 input-valueasnumber.html:
   "valueAsNumber setter on type month (actual valueAsNumber: -1, expected value: 1969-12)": [fail, Unknown]
-  "valueAsNumber setter on type time (actual valueAsNumber: 2.734333707189448e+26, expected value: 10:54:10.944)": [fail, Unknown]
-  "valueAsNumber setter on type datetime-local (actual valueAsNumber: 2.734333707189448e+26, expected value: )": [fail, Unknown]
 radio-disconnected-group-owner.html: [fail, Unknown]
 radio-input-cancel.html:
   "radio input cancel behavior reverts previous selected radio input state": [fail, Unknown]


### PR DESCRIPTION
Normalize time values within a day and clear out-of-range `datetime-local` values instead of serializing `NaN` components. These failures surfaced with [the upstream large-`valueAsNumber` coverage](https://github.com/web-platform-tests/wpt/commit/a161fb9ca0d5dc9467b934dde40c7ed1237de1e2).