### PR TITLE
Return duplicate elements from XPath id()

### DIFF
--- a/lib/jsdom/level3/xpath.js
+++ b/lib/jsdom/level3/xpath.js
@@ -1351,13 +1351,12 @@ module.exports = core => {
         var a = idsString.split(/[ \t\r\n]+/g);
         ids = a;
       }
-      for (var i = 0; i < ids.length; ++i) {
-        var id = ids[i];
-        if (0 === id.length)
-          continue;
-        var node = doc.getElementById(id);
-        if (null != node)
-          r.nodes.push(node);
+      var elements = doc.getElementsByTagName('*');
+      for (var i = 0; i < elements.length; ++i) {
+        var element = elements[i];
+        var id = element.getAttribute('id');
+        if (null != id && 0 !== id.length && ids.includes(id))
+          r.nodes.push(element);
       }
       r.nodes = sortUniqDocumentOrder(r.nodes);
       return r;

--- a/lib/jsdom/level3/xpath.js
+++ b/lib/jsdom/level3/xpath.js
@@ -1,3 +1,5 @@
+const idlUtils = require("../../generated/idl/utils.js");
+
 /** Here is yet another implementation of XPath 1.0 in Javascript.
  *
  * My goal was to make it relatively compact, but as I fixed all the axis bugs
@@ -1335,6 +1337,7 @@ module.exports = core => {
     'id': function id(object) {
       var r = {nodes: []};
       var doc = this.nodes[0].ownerDocument || this.nodes[0];
+      var docImpl = idlUtils.implForWrapper(doc);
       console.assert(doc);
       var ids;
       if ('object' === typeof object) {
@@ -1351,12 +1354,14 @@ module.exports = core => {
         var a = idsString.split(/[ \t\r\n]+/g);
         ids = a;
       }
-      var elements = doc.getElementsByTagName('*');
-      for (var i = 0; i < elements.length; ++i) {
-        var element = elements[i];
-        var id = element.getAttribute('id');
-        if (null != id && 0 !== id.length && ids.includes(id))
-          r.nodes.push(element);
+      for (var i = 0; i < ids.length; ++i) {
+        var id = ids[i];
+        if (0 === id.length)
+          continue;
+        var elements = docImpl._byIdCache.getAll(id);
+        for (var j = 0; j < elements.length; ++j) {
+          r.nodes.push(idlUtils.wrapperForImpl(elements[j]));
+        }
       }
       r.nodes = sortUniqDocumentOrder(r.nodes);
       return r;

--- a/lib/jsdom/living/helpers/by-id-cache.js
+++ b/lib/jsdom/living/helpers/by-id-cache.js
@@ -1,31 +1,29 @@
 "use strict";
 
-const NODE_TYPE = require("../node-type");
-const { domSymbolTree } = require("./internal-constants");
+const { treeOrderSorter } = require("../../utils.js");
 
 // For use in implementing getElementById(). Notably it ensures that when you get the result, you will always get the
 // first in tree order, not the most- or least-recently-inserted. Somewhat modeled after
 // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/tree_ordered_map.h.
 
 module.exports = class ByIdCache {
-  constructor(root) {
-    this._root = root;
-
+  constructor() {
     // Keys are IDs (strings).
-    // Values are `{ element, count }` tuples, where `element` can be `null` indicating we need to recompute.
-    // `count` tracks the count of times `add()` was called for this ID. We need to track it because it lets us
-    // determine what to do when calling `delete()`: a count of 0 means we can remove the entry, whereas any other
-    // count means we need to set `element` to `null` for future recomputation.
+    // Values are `{ element, elements }` tuples. `element` is the first element in tree order, or `null` if it needs
+    // to be recomputed. `elements` is `null` for unique IDs, or a set containing every element for duplicate IDs.
     this._map = new Map();
   }
 
   add(id, element) {
     const value = this._map.get(id);
     if (!value) {
-      this._map.set(id, { element, count: 1 });
+      this._map.set(id, { element, elements: null });
     } else {
+      if (value.elements === null) {
+        value.elements = new Set([value.element]);
+      }
+      value.elements.add(element);
       value.element = null;
-      ++value.count;
     }
   }
 
@@ -35,9 +33,15 @@ module.exports = class ByIdCache {
       return;
     }
 
-    --value.count;
-    if (value.count === 0) {
+    if (value.elements === null) {
       this._map.delete(id);
+      return;
+    }
+
+    value.elements.delete(element);
+    if (value.elements.size === 1) {
+      value.element = value.elements.values().next().value;
+      value.elements = null;
     } else if (value.element === element) {
       value.element = null;
     }
@@ -53,15 +57,20 @@ module.exports = class ByIdCache {
       return value.element;
     }
 
-    for (const descendant of domSymbolTree.treeIterator(this._root)) {
-      if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE && descendant.getAttributeNS(null, "id") === id) {
-        value.element = descendant;
-        return descendant;
-      }
+    value.element = this.getAll(id)[0];
+    return value.element;
+  }
+
+  getAll(id) {
+    const value = this._map.get(id);
+    if (!value) {
+      return [];
     }
 
-    // If we didn't find any elements for this key, we can remove it.
-    this._map.delete(id);
-    return null;
+    if (value.elements === null) {
+      return [value.element];
+    }
+
+    return [...value.elements].sort(treeOrderSorter);
   }
 };

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -146,7 +146,7 @@ class DocumentImpl extends NodeImpl {
 
     this._defaultView = privateData.options.defaultView || null;
     this._global = privateData.options.global;
-    this._byIdCache = new ByIdCache(this);
+    this._byIdCache = new ByIdCache();
     this._attached = true;
     this._currentScript = null;
     this._pageShowingFlag = false;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1152,8 +1152,6 @@ innerhtml-05.xhtml: [fail, Unknown]
 
 DIR: domxpath
 
-fn-id.html:
-  "id(\"duplicate\"): <root><div id=\"duplicate\">First</div><div id=\"duplicate\">Second</div></root>": [fail, Unknown]
 fn-lang.html: [fail, Unknown]
 fn-normalize-space.html: [fail, Unknown]
 lexical-structure.html: [fail, Unknown]


### PR DESCRIPTION
Return every matching element from XPath `id()`, including duplicate IDs, in document order. This failure surfaced with [the upstream XPath `id()` coverage](https://github.com/web-platform-tests/wpt/commit/3a6328d775f9ba515888f68a1ef34e95dc8db2fc).