### PR TITLE
Honor Blob charset in FileReader.readAsText

### DIFF
--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -41,7 +41,12 @@ class FileReaderImpl extends EventTargetImpl {
     this._readFile(file, "dataURL");
   }
   readAsText(file, encodingLabel) {
-    this._readFile(file, "text", labelToName(encodingLabel) || "UTF-8");
+    let encoding = labelToName(encodingLabel);
+    if (encoding === null) {
+      const type = MIMEType.parse(file.type);
+      encoding = type === null ? null : labelToName(type.parameters.get("charset"));
+    }
+    this._readFile(file, "text", encoding || "UTF-8");
   }
 
   abort() {

--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -40,13 +40,8 @@ class FileReaderImpl extends EventTargetImpl {
   readAsDataURL(file) {
     this._readFile(file, "dataURL");
   }
-  readAsText(file, encodingLabel) {
-    let encoding = labelToName(encodingLabel);
-    if (encoding === null) {
-      const type = MIMEType.parse(file.type);
-      encoding = type === null ? null : labelToName(type.parameters.get("charset"));
-    }
-    this._readFile(file, "text", encoding || "UTF-8");
+  readAsText(file, encodingName) {
+    this._readFile(file, "text", encodingName);
   }
 
   abort() {
@@ -69,7 +64,7 @@ class FileReaderImpl extends EventTargetImpl {
     fireAnEvent(name, this, ProgressEvent, props);
   }
 
-  _readFile(file, format, encodingLabel) {
+  _readFile(file, format, encodingName) {
     if (this.readyState === READY_STATES.LOADING) {
       throw DOMException.create(this._globalObject, [
         "The object is in an invalid state.",
@@ -110,7 +105,7 @@ class FileReaderImpl extends EventTargetImpl {
             return;
           }
 
-          this._setResult(file, format, encodingLabel);
+          this._setResult(file, format, encodingName);
           this.readyState = READY_STATES.DONE;
           this._fireProgressEvent("load");
           this._fireProgressEvent("loadend");
@@ -119,7 +114,7 @@ class FileReaderImpl extends EventTargetImpl {
     });
   }
 
-  _setResult(file, format, encodingLabel) {
+  _setResult(file, format, encodingName) {
     switch (format) {
       case "binaryString": {
         // Convert Uint8Array to binary string (each byte as a code point)
@@ -137,7 +132,21 @@ class FileReaderImpl extends EventTargetImpl {
         break;
       }
       case "text": {
-        this.result = legacyHookDecode(file._bytes, encodingLabel);
+        let encoding = null;
+        if (encodingName !== undefined) {
+          encoding = labelToName(encodingName);
+        }
+        if (encoding === null) {
+          const type = MIMEType.parse(file.type);
+          if (type !== null) {
+            encoding = labelToName(type.parameters.get("charset"));
+          }
+        }
+        if (encoding === null) {
+          encoding = "UTF-8";
+        }
+
+        this.result = legacyHookDecode(file._bytes, encoding);
         break;
       }
       case "buffer":

--- a/lib/jsdom/living/file-api/FileReader-impl.js
+++ b/lib/jsdom/living/file-api/FileReader-impl.js
@@ -40,8 +40,8 @@ class FileReaderImpl extends EventTargetImpl {
   readAsDataURL(file) {
     this._readFile(file, "dataURL");
   }
-  readAsText(file, encodingName) {
-    this._readFile(file, "text", encodingName);
+  readAsText(file, encodingLabel) {
+    this._readFile(file, "text", encodingLabel);
   }
 
   abort() {
@@ -64,7 +64,7 @@ class FileReaderImpl extends EventTargetImpl {
     fireAnEvent(name, this, ProgressEvent, props);
   }
 
-  _readFile(file, format, encodingName) {
+  _readFile(file, format, encodingLabel) {
     if (this.readyState === READY_STATES.LOADING) {
       throw DOMException.create(this._globalObject, [
         "The object is in an invalid state.",
@@ -105,7 +105,7 @@ class FileReaderImpl extends EventTargetImpl {
             return;
           }
 
-          this._setResult(file, format, encodingName);
+          this._setResult(file, format, encodingLabel);
           this.readyState = READY_STATES.DONE;
           this._fireProgressEvent("load");
           this._fireProgressEvent("loadend");
@@ -114,7 +114,7 @@ class FileReaderImpl extends EventTargetImpl {
     });
   }
 
-  _setResult(file, format, encodingName) {
+  _setResult(file, format, encodingLabel) {
     switch (format) {
       case "binaryString": {
         // Convert Uint8Array to binary string (each byte as a code point)
@@ -133,8 +133,8 @@ class FileReaderImpl extends EventTargetImpl {
       }
       case "text": {
         let encoding = null;
-        if (encodingName !== undefined) {
-          encoding = labelToName(encodingName);
+        if (encodingLabel !== undefined) {
+          encoding = labelToName(encodingLabel);
         }
         if (encoding === null) {
           const type = MIMEType.parse(file.type);

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -21,7 +21,6 @@ idlharness.any.html: [fail, URL.createObjectURL not implemented]
 idlharness.html: [fail, URL.createObjectURL not implemented]
 reading-data-section/FileReader-multiple-reads.any.html: [timeout, Unknown; spews tons of zeros on the screen when failing]
 reading-data-section/filereader_events.any.html: [fail, jsdom lacks microtask checkpoints during event dispatch]
-reading-data-section/filereader_readAsText_blob_type_charset.any.html: [fail, Unknown]
 url/**: [timeout, blob URLs not implemented]
 
 ---


### PR DESCRIPTION
Use the `Blob` MIME type’s charset when `FileReader.readAsText()` has no supported explicit encoding. This failure surfaced with [the upstream Blob-charset WPT](https://github.com/web-platform-tests/wpt/commit/2a91c2e71952bdceef8b2825ce3a0a0dc73aa588).