### PR TITLE
Implement relaxed DOM name validation

### DIFF
--- a/lib/jsdom/living/helpers/create-element.js
+++ b/lib/jsdom/living/helpers/create-element.js
@@ -303,7 +303,7 @@ function createElement(
 
 // https://dom.spec.whatwg.org/#internal-createelementns-steps
 function internalCreateElementNSSteps(document, namespace, qualifiedName, options) {
-  const extracted = validateAndExtract(document._globalObject, namespace, qualifiedName);
+  const extracted = validateAndExtract(document._globalObject, namespace, qualifiedName, "element");
 
   let isValue = null;
   if (options && options.is !== undefined) {

--- a/lib/jsdom/living/helpers/validate-names.js
+++ b/lib/jsdom/living/helpers/validate-names.js
@@ -3,26 +3,67 @@ const xnv = require("xml-name-validator");
 const DOMException = require("../../../generated/idl/DOMException");
 const { XML_NS, XMLNS_NS } = require("../helpers/namespaces");
 
-// https://dom.spec.whatwg.org/#validate
+// This is the exact regular expression provided by the standard.
+const validElementLocalNameRegex =
+  /^(?:[A-Za-z][^\0\t\n\f\r />]*|[:_\u0080-\u{10FFFF}][A-Za-z0-9-.:_\u0080-\u{10FFFF}]*)$/u;
+const invalidNamespacePrefix = /[\0\t\n\f\r />]/u;
+const invalidAttributeLocalName = /[\0\t\n\f\r /=>]/u;
+const invalidDoctypeName = /[\0\t\n\f\r >]/u;
 
-exports.name = (globalObject, name) => {
+// https://dom.spec.whatwg.org/#valid-namespace-prefix
+function isValidNamespacePrefix(name) {
+  return name.length >= 1 && !invalidNamespacePrefix.test(name);
+}
+
+// https://dom.spec.whatwg.org/#valid-attribute-local-name
+function isValidAttributeLocalName(name) {
+  return name.length >= 1 && !invalidAttributeLocalName.test(name);
+}
+
+// https://dom.spec.whatwg.org/#valid-element-local-name
+function isValidElementLocalName(name) {
+  return validElementLocalNameRegex.test(name);
+}
+
+// https://dom.spec.whatwg.org/#valid-doctype-name
+function isValidDoctypeName(name) {
+  return !invalidDoctypeName.test(name);
+}
+
+function throwInvalidCharacterError(globalObject, name, type) {
+  throw DOMException.create(globalObject, [`"${name}" is not a valid ${type}`, "InvalidCharacterError"]);
+}
+
+exports.elementLocalName = (globalObject, name) => {
+  if (!isValidElementLocalName(name)) {
+    throwInvalidCharacterError(globalObject, name, "element local name");
+  }
+};
+
+exports.attributeLocalName = (globalObject, name) => {
+  if (!isValidAttributeLocalName(name)) {
+    throwInvalidCharacterError(globalObject, name, "attribute local name");
+  }
+};
+
+exports.doctypeName = (globalObject, name) => {
+  if (!isValidDoctypeName(name)) {
+    throwInvalidCharacterError(globalObject, name, "doctype name");
+  }
+};
+
+// https://dom.spec.whatwg.org/#processinginstruction-initialize
+exports.xmlName = (globalObject, name) => {
   if (!xnv.name(name)) {
     throw DOMException.create(globalObject, [`"${name}" did not match the Name production`, "InvalidCharacterError"]);
   }
 };
 
-exports.qname = (globalObject, qname) => {
-  if (!xnv.qname(qname)) {
-    throw DOMException.create(globalObject, [`"${qname}" did not match the QName production`, "InvalidCharacterError"]);
-  }
-};
-
-exports.validateAndExtract = (globalObject, namespace, qualifiedName) => {
+// https://dom.spec.whatwg.org/#validate-and-extract
+exports.validateAndExtract = (globalObject, namespace, qualifiedName, context) => {
   if (namespace === "") {
     namespace = null;
   }
-
-  exports.qname(globalObject, qualifiedName);
 
   let prefix = null;
   let localName = qualifiedName;
@@ -31,11 +72,24 @@ exports.validateAndExtract = (globalObject, namespace, qualifiedName) => {
   if (colonIndex !== -1) {
     prefix = qualifiedName.substring(0, colonIndex);
     localName = qualifiedName.substring(colonIndex + 1);
+
+    if (!isValidNamespacePrefix(prefix)) {
+      throwInvalidCharacterError(globalObject, prefix, "namespace prefix");
+    }
+  }
+
+  // At this point, `prefix` is either `null` or a valid namespace prefix.
+  if (context === "attribute") {
+    exports.attributeLocalName(globalObject, localName);
+  }
+
+  if (context === "element") {
+    exports.elementLocalName(globalObject, localName);
   }
 
   if (prefix !== null && namespace === null) {
     throw DOMException.create(globalObject, [
-      "A namespace was given but a prefix was also extracted from the qualifiedName",
+      "A prefix was given but no namespace was provided",
       "NamespaceError"
     ]);
   }

--- a/lib/jsdom/living/nodes/DOMImplementation-impl.js
+++ b/lib/jsdom/living/nodes/DOMImplementation-impl.js
@@ -16,12 +16,13 @@ class DOMImplementationImpl {
     return true;
   }
 
-  createDocumentType(qualifiedName, publicId, systemId) {
-    validateNames.qname(this._globalObject, qualifiedName);
+  // https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype
+  createDocumentType(name, publicId, systemId) {
+    validateNames.doctypeName(this._globalObject, name);
 
     return DocumentType.createImpl(this._globalObject, [], {
       ownerDocument: this._ownerDocument,
-      name: qualifiedName,
+      name,
       publicId,
       systemId
     });

--- a/lib/jsdom/living/nodes/DOMImplementation.webidl
+++ b/lib/jsdom/living/nodes/DOMImplementation.webidl
@@ -1,7 +1,7 @@
 // https://dom.spec.whatwg.org/#interface-domimplementation
 [Exposed=Window]
 interface DOMImplementation {
-  [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
+  [NewObject] DocumentType createDocumentType(DOMString name, DOMString publicId, DOMString systemId);
   [NewObject] XMLDocument createDocument(DOMString? namespace, [LegacyNullToEmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
   [NewObject] Document createHTMLDocument(optional DOMString title);
 

--- a/lib/jsdom/living/nodes/DOMStringMap-impl.js
+++ b/lib/jsdom/living/nodes/DOMStringMap-impl.js
@@ -2,7 +2,7 @@
 
 const idlUtils = require("../../../generated/idl/utils.js");
 const { setAttributeValue, removeAttributeByName } = require("../attributes");
-const validateName = require("../helpers/validate-names").name;
+const validateAttributeLocalName = require("../helpers/validate-names").attributeLocalName;
 const DOMException = require("../../../generated/idl/DOMException");
 
 const dataAttrRe = /^data-([^A-Z]*)$/;
@@ -43,6 +43,7 @@ exports.implementation = class DOMStringMapImpl {
     }
     return undefined;
   }
+  // https://html.spec.whatwg.org/multipage/dom.html#dom-domstringmap-setitem
   [idlUtils.namedSetNew](name, value) {
     if (/-[a-z]/.test(name)) {
       throw DOMException.create(this._globalObject, [
@@ -51,7 +52,7 @@ exports.implementation = class DOMStringMapImpl {
       ]);
     }
     name = `data-${attrSnakeCase(name)}`;
-    validateName(this._globalObject, name);
+    validateAttributeLocalName(this._globalObject, name);
     setAttributeValue(this._element, name, value);
   }
   [idlUtils.namedSetExisting](name, value) {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -22,8 +22,12 @@ const History = require("../../../generated/idl/History");
 const Location = require("../../../generated/idl/Location");
 const HTMLCollection = require("../../../generated/idl/HTMLCollection");
 const NodeList = require("../../../generated/idl/NodeList");
-const validateName = require("../helpers/validate-names").name;
-const { validateAndExtract } = require("../helpers/validate-names");
+const {
+  attributeLocalName: validateAttributeLocalName,
+  elementLocalName: validateElementLocalName,
+  validateAndExtract,
+  xmlName: validateXMLName
+} = require("../helpers/validate-names");
 const { fireAnEvent } = require("../helpers/events");
 const { shadowIncludingInclusiveDescendantsIterator } = require("../helpers/shadow-dom");
 const { enqueueCECallbackReaction } = require("../helpers/custom-elements");
@@ -738,7 +742,7 @@ class DocumentImpl extends NodeImpl {
   }
 
   createProcessingInstruction(target, data) {
-    validateName(this._globalObject, target);
+    validateXMLName(this._globalObject, target);
 
     if (data.includes("?>")) {
       throw DOMException.create(this._globalObject, [
@@ -792,7 +796,7 @@ class DocumentImpl extends NodeImpl {
 
   // https://dom.spec.whatwg.org/#dom-document-createelement
   createElement(localName, options) {
-    validateName(this._globalObject, localName);
+    validateElementLocalName(this._globalObject, localName);
 
     if (this._parsingMode === "html") {
       localName = asciiLowercase(localName);
@@ -817,8 +821,9 @@ class DocumentImpl extends NodeImpl {
     return DocumentFragment.createImpl(this._globalObject, [], { ownerDocument: this });
   }
 
+  // https://dom.spec.whatwg.org/#dom-document-createattribute
   createAttribute(localName) {
-    validateName(this._globalObject, localName);
+    validateAttributeLocalName(this._globalObject, localName);
 
     if (this._parsingMode === "html") {
       localName = asciiLowercase(localName);
@@ -827,13 +832,14 @@ class DocumentImpl extends NodeImpl {
     return this._createAttribute({ localName });
   }
 
+  // https://dom.spec.whatwg.org/#dom-document-createattributens
   createAttributeNS(namespace, name) {
     if (namespace === undefined) {
       namespace = null;
     }
     namespace = namespace !== null ? String(namespace) : namespace;
 
-    const extracted = validateAndExtract(this._globalObject, namespace, name);
+    const extracted = validateAndExtract(this._globalObject, namespace, name, "attribute");
     return this._createAttribute({
       namespace: extracted.namespace,
       namespacePrefix: extracted.prefix,

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -209,7 +209,7 @@ class ElementImpl extends NodeImpl {
   }
 
   setAttribute(name, value) {
-    validateNames.name(this._globalObject, name);
+    validateNames.attributeLocalName(this._globalObject, name);
 
     if (this._namespaceURI === HTML_NS && this._ownerDocument._parsingMode === "html") {
       name = asciiLowercase(name);
@@ -230,7 +230,7 @@ class ElementImpl extends NodeImpl {
   }
 
   setAttributeNS(namespace, name, value) {
-    const extracted = validateNames.validateAndExtract(this._globalObject, namespace, name);
+    const extracted = validateNames.validateAndExtract(this._globalObject, namespace, name, "attribute");
 
     // Because of widespread use of this method internally, e.g. to manually implement attribute/content reflection, we
     // centralize the conversion to a string here, so that all call sites don't have to do it.
@@ -248,7 +248,7 @@ class ElementImpl extends NodeImpl {
   }
 
   toggleAttribute(qualifiedName, force) {
-    validateNames.name(this._globalObject, qualifiedName);
+    validateNames.attributeLocalName(this._globalObject, qualifiedName);
 
     if (this._namespaceURI === HTML_NS && this._ownerDocument._parsingMode === "html") {
       qualifiedName = asciiLowercase(qualifiedName);

--- a/test/to-port-to-wpts/level1/core.js
+++ b/test/to-port-to-wpts/level1/core.js
@@ -2048,82 +2048,6 @@ describe("level1/core", () => {
 
   /**
    *
-   The "createAttribute(tagName)" method raises an
-   INVALID_CHARACTER_ERR DOMException if the specified
-   tagName contains an invalid character.
-
-   Retrieve the entire DOM document and invoke its
-   "createAttribute(tagName)" method with the tagName equal
-   to the string "invalid^Name".  Due to the invalid
-   character the desired EXCEPTION should be raised.
-
-   * @author NIST
-   * @author Mary Brady
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-1084891198
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-1084891198')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-1084891198
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("documentinvalidcharacterexceptioncreateattribute", () => {
-    let success;
-    let doc;
-    let createdAttr;
-
-    doc = staff.staff();
-
-    {
-      success = false;
-      try {
-        createdAttr = doc.createAttribute("invalid'Name");
-      }
-      catch (ex) {
-        success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-      }
-      assert.ok(success, "throw_INVALID_CHARACTER_ERR");
-    }
-  });
-
-  /**
-   *
-   The "createElement(tagName)" method raises an
-   INVALID_CHARACTER_ERR DOMException if the specified
-   tagName contains an invalid character.
-
-   Retrieve the entire DOM document and invoke its
-   "createElement(tagName)" method with the tagName equal
-   to the string "invalid^Name".  Due to the invalid
-   character the desired EXCEPTION should be raised.
-
-   * @author NIST
-   * @author Mary Brady
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-2141741547
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-2141741547')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-2141741547
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("documentinvalidcharacterexceptioncreateelement", () => {
-    let success;
-    let doc;
-    let badElement;
-
-    doc = staff.staff();
-
-    {
-      success = false;
-      try {
-        badElement = doc.createElement("invalid^Name");
-      }
-      catch (ex) {
-        success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-      }
-      assert.ok(success, "throw_INVALID_CHARACTER_ERR");
-    }
-  });
-
-  /**
-   *
    The "createProcessingInstruction(target,data) method
    raises an INVALID_CHARACTER_ERR DOMException if the
    specified tagName contains an invalid character.
@@ -2690,53 +2614,6 @@ describe("level1/core", () => {
         success = (typeof (ex.code) !== "undefined" && ex.code === 10);
       }
       assert.ok(success, "throw_INUSE_ATTRIBUTE_ERR");
-    }
-  });
-
-  /**
-   *
-
-   The "setAttribute(name,value)" method raises an
-
-   "INVALID_CHARACTER_ERR DOMException if the specified
-
-   name contains an invalid character.
-
-
-
-   Retrieve the last child of the first employee and
-
-   call its "setAttribute(name,value)" method with
-
-   "name" containing an invalid character.
-
-
-   * @author NIST
-   * @author Mary Brady
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-F68F082
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-F68F082')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("elementinvalidcharacterexception", () => {
-    let success;
-    let doc;
-    let elementList;
-    let testAddress;
-
-    doc = staff.staff();
-    elementList = doc.getElementsByTagName("address");
-    testAddress = elementList.item(0);
-
-    {
-      success = false;
-      try {
-        testAddress.setAttribute("invalid'Name", "value");
-      }
-      catch (ex) {
-        success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-      }
-      assert.ok(success, "throw_INVALID_CHARACTER_ERR");
     }
   });
 
@@ -4883,43 +4760,6 @@ describe("level1/core", () => {
 
   /**
    *
-   The "createAttribute(tagName)" method raises an
-   INVALID_CHARACTER_ERR DOMException if the specified
-   tagName contains an invalid character.
-
-   Retrieve the entire DOM document and invoke its
-   "createAttribute(tagName)" method with the tagName equal
-   to the string "invalid^Name".  Due to the invalid
-   character the desired EXCEPTION should be raised.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-1084891198
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-1084891198')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-1084891198
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("hc_documentinvalidcharacterexceptioncreateattribute", () => {
-    let success;
-    let doc;
-    let createdAttr;
-
-    doc = hc_staff.hc_staff();
-
-    {
-      success = false;
-      try {
-        createdAttr = doc.createAttribute("invalid'Name");
-      }
-      catch (ex) {
-        success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-      }
-      assert.ok(success, "throw_INVALID_CHARACTER_ERR");
-    }
-  });
-
-  /**
-   *
    Creating an attribute with an empty name should cause an INVALID_CHARACTER_ERR.
 
    * @author Curt Arnold
@@ -4940,43 +4780,6 @@ describe("level1/core", () => {
       success = false;
       try {
         createdAttr = doc.createAttribute("");
-      }
-      catch (ex) {
-        success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-      }
-      assert.ok(success, "throw_INVALID_CHARACTER_ERR");
-    }
-  });
-
-  /**
-   *
-   The "createElement(tagName)" method raises an
-   INVALID_CHARACTER_ERR DOMException if the specified
-   tagName contains an invalid character.
-
-   Retrieve the entire DOM document and invoke its
-   "createElement(tagName)" method with the tagName equal
-   to the string "invalid^Name".  Due to the invalid
-   character the desired EXCEPTION should be raised.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-2141741547
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-2141741547')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-2141741547
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("hc_documentinvalidcharacterexceptioncreateelement", () => {
-    let success;
-    let doc;
-    let badElement;
-
-    doc = hc_staff.hc_staff();
-
-    {
-      success = false;
-      try {
-        badElement = doc.createElement("invalid^Name");
       }
       catch (ex) {
         success = (typeof (ex.code) !== "undefined" && ex.code === 5);
@@ -5531,44 +5334,6 @@ describe("level1/core", () => {
         success = (typeof (ex.code) !== "undefined" && ex.code === 10);
       }
       assert.ok(success, "throw_INUSE_ATTRIBUTE_ERR");
-    }
-  });
-
-  /**
-   *
-   The "setAttribute(name,value)" method raises an
-   "INVALID_CHARACTER_ERR DOMException if the specified
-   name contains an invalid character.
-
-   Retrieve the last child of the first employee and
-   call its "setAttribute(name,value)" method with
-   "strong" containing an invalid character.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-F68F082
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-F68F082')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("hc_elementinvalidcharacterexception", () => {
-    let success;
-    let doc;
-    let elementList;
-    let testAddress;
-
-    doc = hc_staff.hc_staff();
-    elementList = doc.getElementsByTagName("acronym");
-    testAddress = elementList.item(0);
-
-    {
-      success = false;
-      try {
-        testAddress.setAttribute("invalid'Name", "value");
-      }
-      catch (ex) {
-        success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-      }
-      assert.ok(success, "throw_INVALID_CHARACTER_ERR");
     }
   });
 

--- a/test/to-port-to-wpts/level1/html.js
+++ b/test/to-port-to-wpts/level1/html.js
@@ -1631,36 +1631,6 @@ describe("level1/html", () => {
 
   /**
    *
-   The "createAttribute(tagName)" method raises an
-   INVALID_CHARACTER_ERR DOMException if the specified
-   tagName contains an invalid character.
-
-   Retrieve the entire DOM document and invoke its
-   "createAttribute(tagName)" method with the tagName equal
-   to the string "invalid^Name".  Due to the invalid
-   character the desired EXCEPTION should be raised.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-1084891198
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-1084891198')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-1084891198
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("hc_documentinvalidcharacterexceptioncreateattribute", () => {
-    let doc = hc_staff.hc_staff();
-    let success = false;
-    try {
-      doc.createAttribute("invalid'Name");
-    }
-    catch (ex) {
-      success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-    }
-    assert.ok(success, "throw_INVALID_CHARACTER_ERR");
-  });
-
-  /**
-   *
    Creating an attribute with an empty name should cause an INVALID_CHARACTER_ERR.
 
    * @author Curt Arnold
@@ -1675,35 +1645,6 @@ describe("level1/html", () => {
     let success = false;
     try {
       doc.createAttribute("");
-    } catch (ex) {
-      success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-    }
-    assert.ok(success, "throw_INVALID_CHARACTER_ERR");
-  });
-
-  /**
-   *
-   The "createElement(tagName)" method raises an
-   INVALID_CHARACTER_ERR DOMException if the specified
-   tagName contains an invalid character.
-
-   Retrieve the entire DOM document and invoke its
-   "createElement(tagName)" method with the tagName equal
-   to the string "invalid^Name".  Due to the invalid
-   character the desired EXCEPTION should be raised.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-2141741547
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-2141741547')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-2141741547
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("hc_documentinvalidcharacterexceptioncreateelement", () => {
-    let doc = hc_staff.hc_staff();
-    let success = false;
-    try {
-      doc.createElement("invalid^Name");
     } catch (ex) {
       success = (typeof (ex.code) !== "undefined" && ex.code === 5);
     }
@@ -2142,34 +2083,6 @@ describe("level1/html", () => {
       success = (typeof (ex.code) !== "undefined" && ex.code === 10);
     }
     assert.ok(success, "throw_INUSE_ATTRIBUTE_ERR");
-  });
-
-  /**
-   *
-   The "setAttribute(name,value)" method raises an
-   "INVALID_CHARACTER_ERR DOMException if the specified
-   name contains an invalid character.
-
-   Retrieve the last child of the first employee and
-   call its "setAttribute(name,value)" method with
-   "strong" containing an invalid character.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-F68F082
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-F68F082')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("hc_elementinvalidcharacterexception", () => {
-    let doc = hc_staff.hc_staff();
-    let testAddress = doc.getElementsByTagName("acronym").item(0);
-    let success = false;
-    try {
-      testAddress.setAttribute("invalid'Name", "value");
-    } catch (ex) {
-      success = (typeof (ex.code) !== "undefined" && ex.code === 5);
-    }
-    assert.ok(success, "throw_INVALID_CHARACTER_ERR");
   });
 
   /**

--- a/test/to-port-to-wpts/level2/core.js
+++ b/test/to-port-to-wpts/level2/core.js
@@ -47,43 +47,6 @@ describe("level2/core", () => {
      *
      The "createAttributeNS(namespaceURI,qualifiedName)" method for a
     Document should raise NAMESPACE_ERR DOMException
-    if qualifiedName is malformed.
-
-    Invoke method createAttributeNS(namespaceURI,qualifiedName) on
-    the XMLNS Document with namespaceURI being "http://www.ecommerce.org/",
-    qualifiedName as "prefix::local".  Method should raise
-    NAMESPACE_ERR DOMException.
-
-    * @author NIST
-    * @author Mary Brady
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-258A00AF')/constant[@name='NAMESPACE_ERR'])
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#ID-DocCrAttrNS
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-DocCrAttrNS')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NAMESPACE_ERR'])
-    */
-    specify('createAttributeNS01', () => {
-      var success;
-      var namespaceURI = "http://www.ecommerce.org/";
-      var malformedName = "prefix::local";
-      var newAttr;
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-
-      {
-        success = false;
-        try {
-          newAttr = doc.createAttributeNS(namespaceURI,malformedName);
-        }
-        catch(ex) {
-          success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-        }
-        assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-      }
-    });
-    /**
-     *
-     The "createAttributeNS(namespaceURI,qualifiedName)" method for a
-    Document should raise NAMESPACE_ERR DOMException
     if qualifiedName has a prefix and namespaceURI is null.
 
     Invoke method createAttributeNS(namespaceURI,qualifiedName) on this document
@@ -115,75 +78,6 @@ describe("level2/core", () => {
           success = (typeof(ex.code) != 'undefined' && ex.code == 14);
         }
         assert.ok(success, 'throw_NAMESPACE_ERR');
-      }
-    });
-    /**
-     *
-     The "createAttributeNS(namespaceURI,qualifiedName)" method for a
-    Document should raise INVALID_CHARACTER_ERR DOMException
-    if qualifiedName contains an illegal character.
-
-    Invoke method createAttributeNS(namespaceURI,qualifiedName) on this document
-    with qualifiedName containing an illegal character from illegalChars[].
-    Method should raise INVALID_CHARACTER_ERR DOMException for all
-    characters in illegalChars[].
-
-    * @author NIST
-    * @author Mary Brady
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#ID-DocCrAttrNS
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-DocCrAttrNS')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-    */
-    specify('createAttributeNS03', () => {
-      var success;
-      var namespaceURI = "http://www.wedding.com/";
-      var qualifiedName;
-      var newAttr;
-      illegalQNames = new Array();
-      illegalQNames[0] = "person:{";
-      illegalQNames[1] = "person:}";
-      illegalQNames[2] = "person:~";
-      illegalQNames[3] = "person:'";
-      illegalQNames[4] = "person:!";
-      illegalQNames[5] = "person:@";
-      illegalQNames[6] = "person:#";
-      illegalQNames[7] = "person:$";
-      illegalQNames[8] = "person:%";
-      illegalQNames[9] = "person:^";
-      illegalQNames[10] = "person:&";
-      illegalQNames[11] = "person:*";
-      illegalQNames[12] = "person:(";
-      illegalQNames[13] = "person:)";
-      illegalQNames[14] = "person:+";
-      illegalQNames[15] = "person:=";
-      illegalQNames[16] = "person:[";
-      illegalQNames[17] = "person:]";
-      illegalQNames[18] = "person:\\";
-      illegalQNames[19] = "person:/";
-      illegalQNames[20] = "person:;";
-      illegalQNames[21] = "person:`";
-      illegalQNames[22] = "person:<";
-      illegalQNames[23] = "person:>";
-      illegalQNames[24] = "person:,";
-      illegalQNames[25] = "person:a ";
-      illegalQNames[26] = "person:\"";
-
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      for(var indexN10090 = 0;indexN10090 < illegalQNames.length; indexN10090++) {
-        qualifiedName = illegalQNames[indexN10090];
-
-        {
-    success = false;
-    try {
-            newAttr = doc.createAttributeNS(namespaceURI,qualifiedName);
-          }
-    catch(ex) {
-            success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-    }
-    assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-        }
-
       }
     });
     /**
@@ -284,49 +178,6 @@ describe("level2/core", () => {
   });
 
   describe('createDocument', () => {
-    /**
-     *
-     The "createDocument(namespaceURI,qualifiedName,doctype)" method for a
-    DOMImplementation should raise NAMESPACE_ERR DOMException
-    if parameter qualifiedName is malformed.
-
-    Retrieve the DOMImplementation on the XMLNS Document.
-    Invoke method createDocument(namespaceURI,qualifiedName,doctype)
-    on the retrieved DOMImplementation with namespaceURI being
-    the literal string "http://www.ecommerce.org/", qualifiedName as
-    "prefix::local", and doctype as null.  Method should raise
-    NAMESPACE_ERR DOMException.
-
-    * @author NIST
-    * @author Mary Brady
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-258A00AF')/constant[@name='NAMESPACE_ERR'])
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#Level-2-Core-DOM-createDocument
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('Level-2-Core-DOM-createDocument')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NAMESPACE_ERR'])
-    */
-    specify('createDocument01', () => {
-      var success;
-      var namespaceURI = "http://www.ecommerce.org/";
-      var malformedName = "prefix::local";
-      var docType = null;
-
-      var domImpl;
-      var aNewDoc;
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      domImpl = doc.implementation;
-
-      {
-        success = false;
-        try {
-          aNewDoc = domImpl.createDocument(namespaceURI,malformedName,docType);
-        }
-        catch(ex) {
-          success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-        }
-        assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-      }
-    });
     /**
      *
      The "createDocument(namespaceURI,qualifiedName,doctype)" method for a
@@ -553,120 +404,6 @@ describe("level2/core", () => {
     /**
      *
      The "createDocumentType(qualifiedName,publicId,systemId)" method for a
-    DOMImplementation should raise NAMESPACE_ERR DOMException if
-    qualifiedName is malformed.
-
-    Retrieve the DOMImplementation on the XMLNS Document.
-    Invoke method createDocumentType(qualifiedName,publicId,systemId)
-    on the retrieved DOMImplementation with qualifiedName being the literal
-    string "prefix::local", publicId as "STAFF", and systemId as "staff".
-    Method should raise NAMESPACE_ERR DOMException.
-
-    * @author NIST
-    * @author Mary Brady
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-258A00AF')/constant[@name='NAMESPACE_ERR'])
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#Level-2-Core-DOM-createDocType
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('Level-2-Core-DOM-createDocType')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NAMESPACE_ERR'])
-    */
-    specify('createDocumentType01', () => {
-      var success;
-      var publicId = "STAFF";
-      var systemId = "staff.xml";
-      var malformedName = "prefix::local";
-      var domImpl;
-      var newType;
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      domImpl = doc.implementation;
-
-      {
-        success = false;
-        try {
-          newType = domImpl.createDocumentType(malformedName,publicId,systemId);
-        }
-        catch(ex) {
-          success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-        }
-        assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-      }
-    });
-    /**
-     *
-     The "createDocumentType(qualifiedName,publicId,systemId)" method for a
-    DOMImplementation should raise INVALID_CHARACTER_ERR DOMException if
-    qualifiedName contains an illegal character.
-
-    Invoke method createDocumentType(qualifiedName,publicId,systemId) on
-    this domimplementation with qualifiedName containing an illegal character
-    from illegalChars[]. Method should raise INVALID_CHARACTER_ERR
-    DOMException for all characters in illegalChars[].
-
-    * @author NIST
-    * @author Mary Brady
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#Level-2-Core-DOM-createDocType
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('Level-2-Core-DOM-createDocType')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-    */
-    specify('createDocumentType02', () => {
-      var success;
-      var publicId = "http://www.localhost.com/";
-      var systemId = "myDoc.dtd";
-      var qualifiedName;
-      var docType = null;
-
-      var domImpl;
-      illegalQNames = new Array();
-      illegalQNames[0] = "edi:{";
-      illegalQNames[1] = "edi:}";
-      illegalQNames[2] = "edi:~";
-      illegalQNames[3] = "edi:'";
-      illegalQNames[4] = "edi:!";
-      illegalQNames[5] = "edi:@";
-      illegalQNames[6] = "edi:#";
-      illegalQNames[7] = "edi:$";
-      illegalQNames[8] = "edi:%";
-      illegalQNames[9] = "edi:^";
-      illegalQNames[10] = "edi:&";
-      illegalQNames[11] = "edi:*";
-      illegalQNames[12] = "edi:(";
-      illegalQNames[13] = "edi:)";
-      illegalQNames[14] = "edi:+";
-      illegalQNames[15] = "edi:=";
-      illegalQNames[16] = "edi:[";
-      illegalQNames[17] = "edi:]";
-      illegalQNames[18] = "edi:\\";
-      illegalQNames[19] = "edi:/";
-      illegalQNames[20] = "edi:;";
-      illegalQNames[21] = "edi:`";
-      illegalQNames[22] = "edi:<";
-      illegalQNames[23] = "edi:>";
-      illegalQNames[24] = "edi:,";
-      illegalQNames[25] = "edi:a ";
-      illegalQNames[26] = "edi:\"";
-
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      for(var indexN1009A = 0;indexN1009A < illegalQNames.length; indexN1009A++) {
-        qualifiedName = illegalQNames[indexN1009A];
-        domImpl = doc.implementation;
-
-        {
-    success = false;
-    try {
-            docType = domImpl.createDocumentType(qualifiedName,publicId,systemId);
-          }
-    catch(ex) {
-            success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-    }
-    assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-        }
-
-      }
-    });
-    /**
-     *
-     The "createDocumentType(qualifiedName,publicId,systemId)" method for a
     DOMImplementation should return a new DocumentType node
     given that qualifiedName is valid and correctly formed.
 
@@ -701,74 +438,9 @@ describe("level2/core", () => {
 
       assert.equal(nodeValue, null, 'nodeValue should not be null');
     });
-    /**
-     *
-     DOMImplementation.createDocumentType with an empty name should cause an INVALID_CHARACTER_ERR.
-
-    * @author Curt Arnold
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#Level-2-Core-DOM-createDocType
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('Level-2-Core-DOM-createDocType')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-    * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=525
-    */
-    specify('createDocumentType04', () => {
-      var success;
-      var publicId = "http://www.example.com/";
-      var systemId = "myDoc.dtd";
-      var qualifiedName;
-      var docType = null;
-      var domImpl = require('./core/files/staffNS.xml').staffNS().implementation;
-
-      {
-        success = false;
-        try {
-          docType = domImpl.createDocumentType("",publicId,systemId);
-        }
-        catch(ex) {
-          success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-        }
-        assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-      }
-    });
   });
 
   describe('createElementNS', () => {
-    /**
-     *
-     The "createElementNS(namespaceURI,qualifiedName)" method for a
-    Document should raise NAMESPACE_ERR DOMException if
-    qualifiedName is malformed.
-
-    Invoke method createElementNS(namespaceURI,qualifiedName) on
-    the XMLNS Document with namespaceURI being the literal string
-    "http://www.ecommerce.org/", and qualifiedName as "prefix::local".
-    Method should raise NAMESPACE_ERR DOMException.
-
-    * @author NIST
-    * @author Mary Brady
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-258A00AF')/constant[@name='NAMESPACE_ERR'])
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#ID-DocCrElNS
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-DocCrElNS')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NAMESPACE_ERR'])
-    */
-    specify('createElementNS01', () => {
-      var success;
-      var namespaceURI = "http://www.ecommerce.org/";
-      var malformedName = "prefix::local";
-      var newElement;
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-
-      {
-        success = false;
-        try {
-          newElement = doc.createElementNS(namespaceURI,malformedName);
-        }
-        catch(ex) {
-          success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-        }
-        assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-      }
-    });
     /**
      *
      The "createElementNS(namespaceURI,qualifiedName)" method for a
@@ -1059,112 +731,6 @@ describe("level2/core", () => {
       assert.equal(name, "xmlns", "documentcreateattributeNS02_att2_name");
       assert.equal(nodeValue, "", "documentcreateattributeNS02_att2_nodeValue");
       assert.equal(namespaceURI, "http://www.w3.org/2000/xmlns/", "documentcreateattributeNS02_att2_namespaceURI");
-    });
-    /**
-     *
-
-    The method createAttributeNS raises an INVALID_CHARACTER_ERR if the specified
-
-    qualified name contains an illegal character
-
-
-
-    Invoke the createAttributeNS method on this Document object with a valid value for
-
-    namespaceURI, and qualifiedNames that contain illegal characters.  Check if the an
-
-    INVALID_CHARACTER_ERR was thrown.
-
-
-    * @author IBM
-    * @author Neil Delima
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#ID-DocCrAttrNS
-    */
-    specify('documentcreateattributeNS03', () => {
-      var success;
-      var attribute;
-      var namespaceURI = "http://www.w3.org/DOM/Test/Level2";
-      var qualifiedName;
-      qualifiedNames = new Array();
-      qualifiedNames[0] = "/";
-      qualifiedNames[1] = "//";
-      qualifiedNames[2] = "\\";
-      qualifiedNames[3] = ";";
-      qualifiedNames[4] = "&";
-      qualifiedNames[5] = "*";
-      qualifiedNames[6] = "]]";
-      qualifiedNames[7] = ">";
-      qualifiedNames[8] = "<";
-
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      for(var indexN1005A = 0;indexN1005A < qualifiedNames.length; indexN1005A++) {
-        qualifiedName = qualifiedNames[indexN1005A];
-
-        {
-    success = false;
-    try {
-            attribute = doc.createAttributeNS(namespaceURI,qualifiedName);
-          }
-    catch(ex) {
-            success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-    }
-    assert.ok(success, 'documentcreateattributeNS03');
-        }
-
-      }
-    });
-    /**
-     *
-
-    The method createAttributeNS raises a NAMESPACE_ERR if the specified qualified name
-
-    is malformed.
-
-
-
-    Invoke the createAttributeNS method on this Document object with a valid value for
-
-    namespaceURI, and malformed qualifiedNames.  Check if the a NAMESPACE_ERR was thrown.
-
-
-    * @author IBM
-    * @author Neil Delima
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#ID-DocCrAttrNS
-    */
-    specify('documentcreateattributeNS04', () => {
-      var success;
-      var attribute;
-      var namespaceURI = "http://www.w3.org/DOM/Test/Level2";
-      var qualifiedName;
-      qualifiedNames = new Array();
-      qualifiedNames[0] = "_:";
-      qualifiedNames[1] = ":0a";
-      qualifiedNames[2] = ":";
-      qualifiedNames[3] = "a:b:c";
-      qualifiedNames[4] = "_::a";
-
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      for(var indexN1004E = 0;indexN1004E < qualifiedNames.length; indexN1004E++) {
-        qualifiedName = qualifiedNames[indexN1004E];
-
-        {
-    success = false;
-    try {
-            attribute = doc.createAttributeNS(namespaceURI,qualifiedName);
-          }
-    catch(ex) {
-            success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-    }
-    assert.ok(success, 'documentcreateattributeNS04');
-        }
-
-      }
     });
     /**
      *
@@ -2296,67 +1862,6 @@ describe("level2/core", () => {
 
       }
     });
-    /**
-     *
-
-    The method createDocumentType should raise a INVALID_CHARACTER_ERR if the qualifiedName
-
-    contains an illegal characters.
-
-
-
-    Invoke createDocument on this DOMImplementation with qualifiedNames having illegal characters.
-
-    Check if an INVALID_CHARACTER_ERR is raised in each case.
-
-
-    * @author IBM
-    * @author Neil Delima
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#Level-2-Core-DOM-createDocType
-    */
-    specify('domimplementationcreatedocumenttype04', () => {
-      var success;
-      var domImpl;
-      var newDocType;
-      var publicId = "http://www.w3.org/DOM/Test/dom2.dtd";
-      var systemId = "dom2.dtd";
-      var qualifiedName;
-      qualifiedNames = new Array();
-      qualifiedNames[0] = "{";
-      qualifiedNames[1] = "}";
-      qualifiedNames[2] = "'";
-      qualifiedNames[3] = "~";
-      qualifiedNames[4] = "`";
-      qualifiedNames[5] = "@";
-      qualifiedNames[6] = "#";
-      qualifiedNames[7] = "$";
-      qualifiedNames[8] = "%";
-      qualifiedNames[9] = "^";
-      qualifiedNames[10] = "&";
-      qualifiedNames[11] = "*";
-      qualifiedNames[12] = "(";
-      qualifiedNames[13] = ")";
-
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      domImpl = doc.implementation;
-      for(var indexN10073 = 0;indexN10073 < qualifiedNames.length; indexN10073++) {
-        qualifiedName = qualifiedNames[indexN10073];
-
-        {
-    success = false;
-    try {
-            newDocType = domImpl.createDocumentType(qualifiedName,publicId,systemId);
-          }
-    catch(ex) {
-            success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-    }
-    assert.ok(success, 'domimplementationcreatedocumenttype04');
-        }
-
-      }
-    });
   })
 
   describe('domimplementationfeaturecore', () => {
@@ -3069,53 +2574,6 @@ describe("level2/core", () => {
 
       assert.equal(attrName, "defaultAttr", "elementsetattributens03_attrName");
       assert.equal(attrValue, "default1", "elementsetattributens03_attrValue");
-    });
-    /**
-     *
-     The method setAttributeNS adds a new attribute and raises a INVALID_CHARACTER_ERR if
-    the specified qualified name contains an illegal character.
-    Invoke the setAttributeNS method on this Element object with a valid value for
-    namespaceURI, and qualifiedNames that contain illegal characters.  Check if the an
-    INVALID_CHARACTER_ERR was thrown.
-
-    * @author IBM
-    * @author Neil Delima
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#ID-ElSetAttrNS
-    */
-    specify('elementsetattributens04', () => {
-      var success;
-      var element;
-      var qualifiedName;
-      qualifiedNames = new Array();
-      qualifiedNames[0] = "/";
-      qualifiedNames[1] = "//";
-      qualifiedNames[2] = "\\";
-      qualifiedNames[3] = ";";
-      qualifiedNames[4] = "&";
-      qualifiedNames[5] = "*";
-      qualifiedNames[6] = "]]";
-      qualifiedNames[7] = ">";
-      qualifiedNames[8] = "<";
-
-
-
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      element = doc.createElementNS("http://www.w3.org/DOM/Test/L2","dom:elem");
-      for(var indexN10058 = 0;indexN10058 < qualifiedNames.length; indexN10058++) {
-        qualifiedName = qualifiedNames[indexN10058];
-
-        {
-    success = false;
-    try {
-            element.setAttributeNS("http://www.w3.org/DOM/Test/L2",qualifiedName,"test");
-          }
-    catch(ex) {
-            success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-    }
-    assert.ok(success, 'elementsetattributens04');
-        }
-
-      }
     });
     /**
      *
@@ -6094,42 +5552,6 @@ describe("level2/core", () => {
   });
 
   describe('setAttributeNS', () => {
-    /**
-     *
-     The "setAttributeNS(namespaceURI,qualifiedName,Value)" method raises a
-    INVALID_CHARACTER_ERR DOMException if the specified
-    prefix contains an illegal character.
-
-    Attempt to add a new attribute on the first employee node.
-    An exception should be raised since the "qualifiedName" has an invalid
-    character.
-
-    * @author NIST
-    * @author Mary Brady
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-258A00AF')/constant[@name='INVALID_CHARACTER_ERR'])
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#ID-ElSetAttrNS
-    * @see http://www.w3.org/TR/DOM-Level-2-Core/core#xpointer(id('ID-ElSetAttrNS')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='INVALID_CHARACTER_ERR'])
-    */
-    specify('setAttributeNS01', () => {
-      var doc = require('./core/files/staffNS.xml').staffNS();
-      var success;
-      var namespaceURI = "http://www.nist.gov";
-      var qualifiedName = "emp:qual?name";
-      var elementList;
-      var testAddr;
-      elementList = doc.getElementsByTagName("employee");
-      testAddr = elementList.item(0);
-      {
-        success = false;
-        try {
-          testAddr.setAttributeNS(namespaceURI,qualifiedName,"newValue");
-        }
-        catch(ex) {
-          success = (typeof(ex.code) != 'undefined' && ex.code == 5);
-        }
-        assert.ok(success, 'throw_INVALID_CHARACTER_ERR');
-      }
-    });
     /**
      *
      The "setAttributeNS(namespaceURI,qualifiedName,value)" method raises a

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1033,14 +1033,9 @@ DOMTokenList-coverage-for-attributes.html: [fail, Several DOMTokenList attribute
 
 DIR: dom/nodes
 
-DOMImplementation-createDocument.html: [fail, Unknown]
-DOMImplementation-createDocumentType.html: [fail, Unknown]
 Document-URL.html: [fail, Unknown]
 Document-adoptNode-DocumentFragment-with-host.window.html:
   "appendChild() template.content: moves children, fragment ownerDocument stays": [fail, Unknown]
-Document-createAttribute.html: [fail, Unknown]
-Document-createElement.html: [fail, Unknown]
-Document-createElementNS.html: [fail, Unknown]
 Document-createEvent.https.html:
   "DragEvent should be an alias for DragEvent.": [fail, Interface not implemented]
   "createEvent('DragEvent') should be initialized correctly.": [fail, Interface not implemented]
@@ -1075,9 +1070,6 @@ ProcessingInstruction-escapes-1.xhtml: [fail, Unknown]
 adoption.window.html: [fail, "We do not implement https://github.com/whatwg/dom/pull/754 due to https://github.com/whatwg/dom/issues/813"]
 attach-shadow-realm-after-adoption.html: [fail, Unknown]
 attributes-namednodemap-cross-document.window.html: [fail, Unknown]
-attributes.html:
-  "Basic functionality should be intact. (toggleAttribute)": [fail, Unknown]
-  "Basic functionality should be intact.": [fail, Unknown]
 insertion-removing-steps/Node-append-form-and-script-from-fragment.html: [fail, Unknown]
 insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.html: [fail, Unknown]
 insertion-removing-steps/Node-appendChild-script-and-button-from-div.html: [fail, Unknown]
@@ -1098,7 +1090,6 @@ insertion-removing-steps/insertion-removing-steps-iframe.window.html:
 insertion-removing-steps/insertion-removing-steps-script.window.html: [fail, Unknown]
 insertion-removing-steps/later-script-removed-by-earlier-script.html: [fail, Unknown]
 moveBefore/**: [fail-slow, Not implemented]
-name-validation.html: [fail, Unknown]
 processing-instruction-attributes.html: [fail, Not implemented]
 querySelector-mixed-case.html: [fail, Unknown]
 remove-and-adopt-thcrash.html: [fail, window.open not implemented]
@@ -1622,7 +1613,6 @@ documents/resource-metadata-management/document-lastModified.html: [fail, Unknow
 documents/resource-metadata-management/document-readyState.html: [fail, Unknown]
 elements/global-attributes/cdata-dir_auto.html: [fail-slow, Unknown]
 elements/global-attributes/dataset-prototype.html: [fail, Tests Object.prototype which jsdom has trouble with due to VM globals]
-elements/global-attributes/dataset-set.html: [fail, Unknown]
 elements/global-attributes/dataset.html:
   "MathML elements should have a .dataset": [fail, MathML not implemented]
 elements/global-attributes/dir-assorted.window.html: [fail, Unknown]


### PR DESCRIPTION
Implements the DOM Standard's relaxed, context-specific validation rules for element local names, attribute local names, namespace prefixes, and doctype names.

Removes the corresponding WPT failure expectations and obsolete DOM Level 1/2 tests that enforce the superseded XML `Name` and `QName` restrictions.