### PR TITLE
Handle detached TextDecoder input

### DIFF
--- a/lib/jsdom/living/encoding/TextDecoder-impl.js
+++ b/lib/jsdom/living/encoding/TextDecoder-impl.js
@@ -8,6 +8,11 @@ exports.implementation = class TextDecoderImpl {
   }
 
   decode(input, options) {
+    // A view whose buffer was detached during `options` conversion represents an empty byte sequence.
+    if (ArrayBuffer.isView(input) && input.buffer.byteLength === 0) {
+      input = new Uint8Array();
+    }
+
     return this._innerImpl.decode(input, options);
   }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1224,8 +1224,6 @@ idlharness.any.html: [fail, Depends on fetch]
 "legacy-mb-tchinese/big5/big5-encode-href.html?!(1-1000)": [pass-slow]
 "streams/!(realms.window.html)": [fail, Not implemented]
 streams/realms.window.html: [fail-slow, Not implemented]
-textdecoder-arguments.any.html: [fail, Unknown]
-
 ---
 
 DIR: fetch/api/headers


### PR DESCRIPTION
Treats input views detached during `TextDecoder.decode()` option conversion as empty input, matching Web IDL's byte-copy semantics; the failure surfaced because jsdom's WPT roll incorporated [web-platform-tests/wpt@cc6ea24](https://github.com/web-platform-tests/wpt/commit/cc6ea2479a37aea01fdeb26496e195898efeb98b), which added reentrant argument-conversion coverage, and [web-platform-tests/wpt@0dc50ad](https://github.com/web-platform-tests/wpt/commit/0dc50adc2e989134defaea66aacff377ab940543), which corrected the detached-buffer expectation to an empty byte sequence.
