### PR TITLE
Ignore replaced children during insertion validation

### DIFF
--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -628,7 +628,7 @@ class NodeImpl extends EventTargetImpl {
   }
 
   // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
-  _preInsertValidity(nodeImpl, childImpl, childrenToExclude = []) {
+  _preInsertValidity(nodeImpl, childImpl, childrenToExclude) {
     const { nodeType } = nodeImpl;
     const parentType = this.nodeType;
 
@@ -682,88 +682,74 @@ class NodeImpl extends EventTargetImpl {
       ]);
     }
 
-    if (parentType === NODE_TYPE.DOCUMENT_NODE) {
+    if (parentType !== NODE_TYPE.DOCUMENT_NODE) {
+      return;
+    }
+
+    if (nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
       const nodeChildren = domSymbolTree.childrenToArray(nodeImpl);
-      const parentChildren = domSymbolTree.childrenToArray(this).filter(child => !childrenToExclude.includes(child));
+      const nodeChildrenElements = nodeChildren.filter(child => child.nodeType === NODE_TYPE.ELEMENT_NODE);
+      const hasNodeTextChildren = nodeChildren.some(child => {
+        return child.nodeType === NODE_TYPE.TEXT_NODE || child.nodeType === NODE_TYPE.CDATA_SECTION_NODE;
+      });
 
-      switch (nodeType) {
-        case NODE_TYPE.DOCUMENT_FRAGMENT_NODE: {
-          const nodeChildrenElements = nodeChildren.filter(child => child.nodeType === NODE_TYPE.ELEMENT_NODE);
-          if (nodeChildrenElements.length > 1) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
+      if (nodeChildrenElements.length > 1 || hasNodeTextChildren) {
+        throw DOMException.create(this._globalObject, [
+          `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
+          "HierarchyRequestError"
+        ]);
+      }
 
-          const hasNodeTextChildren = nodeChildren.some(child => child.nodeType === NODE_TYPE.TEXT_NODE);
-          if (hasNodeTextChildren) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
+      if (nodeChildrenElements.length === 0) {
+        return;
+      }
+    }
 
-          if (
-            nodeChildrenElements.length === 1 &&
-            (
-              parentChildren.some(child => child.nodeType === NODE_TYPE.ELEMENT_NODE) ||
-              (childImpl && childImpl.nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE) ||
-              (
-                childImpl &&
-                domSymbolTree.nextSibling(childImpl) &&
-                domSymbolTree.nextSibling(childImpl).nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE
-              )
-            )
-          ) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-          break;
-        }
+    const parentChildren = domSymbolTree.childrenToArray(this);
+    const childIndex = childImpl === null ? -1 : parentChildren.indexOf(childImpl);
+    const hasElementChildNotExcluded = parentChildren.some(child => {
+      return child.nodeType === NODE_TYPE.ELEMENT_NODE && !childrenToExclude.has(child);
+    });
 
-        case NODE_TYPE.ELEMENT_NODE:
-          if (
-            parentChildren.some(child => child.nodeType === NODE_TYPE.ELEMENT_NODE) ||
-            (childImpl && childImpl.nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE) ||
-            (
-              childImpl &&
-              domSymbolTree.nextSibling(childImpl) &&
-              domSymbolTree.nextSibling(childImpl).nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE
-            )
-          ) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-          break;
+    if (nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE || nodeType === NODE_TYPE.ELEMENT_NODE) {
+      const hasDoctypeFollowingChild = childImpl !== null &&
+        parentChildren.slice(childIndex + 1).some(child => child.nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE);
+      const childIsDoctypeNotExcluded = childImpl !== null &&
+        childImpl.nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE && !childrenToExclude.has(childImpl);
 
-        case NODE_TYPE.DOCUMENT_TYPE_NODE:
-          if (
-            parentChildren.some(child => child.nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE) ||
-            (
-              childImpl &&
-              domSymbolTree.previousSibling(childImpl) &&
-              domSymbolTree.previousSibling(childImpl).nodeType === NODE_TYPE.ELEMENT_NODE
-            ) ||
-            (!childImpl && parentChildren.some(child => child.nodeType === NODE_TYPE.ELEMENT_NODE))
-          ) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-          break;
+      if (hasElementChildNotExcluded || hasDoctypeFollowingChild || childIsDoctypeNotExcluded) {
+        throw DOMException.create(this._globalObject, [
+          `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
+          "HierarchyRequestError"
+        ]);
+      }
+
+      return;
+    }
+
+    if (nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE) {
+      const hasDoctypeChildNotExcluded = parentChildren.some(child => {
+        return child.nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE && !childrenToExclude.has(child);
+      });
+      const hasElementPrecedingChild = childImpl !== null &&
+        parentChildren.slice(0, childIndex).some(child => child.nodeType === NODE_TYPE.ELEMENT_NODE);
+
+      if (
+        hasDoctypeChildNotExcluded ||
+        hasElementPrecedingChild ||
+        (childImpl === null && hasElementChildNotExcluded)
+      ) {
+        throw DOMException.create(this._globalObject, [
+          `Invalid insertion of ${nodeImpl.nodeName} node in ${this.nodeName} node.`,
+          "HierarchyRequestError"
+        ]);
       }
     }
   }
 
   // https://dom.spec.whatwg.org/#concept-node-pre-insert
   _preInsert(nodeImpl, childImpl) {
-    this._preInsertValidity(nodeImpl, childImpl);
+    this._preInsertValidity(nodeImpl, childImpl, new Set());
 
     let referenceChildImpl = childImpl;
     if (referenceChildImpl === nodeImpl) {
@@ -883,136 +869,7 @@ class NodeImpl extends EventTargetImpl {
 
   // https://dom.spec.whatwg.org/#concept-node-replace
   _replace(nodeImpl, childImpl) {
-    const { nodeType, nodeName } = nodeImpl;
-    const { nodeType: parentType, nodeName: parentName } = this;
-
-    // Note: This section differs from the pre-insert validation algorithm.
-    if (
-      parentType !== NODE_TYPE.DOCUMENT_NODE &&
-      parentType !== NODE_TYPE.DOCUMENT_FRAGMENT_NODE &&
-      parentType !== NODE_TYPE.ELEMENT_NODE
-    ) {
-      throw DOMException.create(this._globalObject, [
-        `Node can't be inserted in a ${parentName} parent.`,
-        "HierarchyRequestError"
-      ]);
-    }
-
-    if (isHostInclusiveAncestor(nodeImpl, this)) {
-      throw DOMException.create(this._globalObject, [
-        "The operation would yield an incorrect node tree.",
-        "HierarchyRequestError"
-      ]);
-    }
-
-    if (childImpl && domSymbolTree.parent(childImpl) !== this) {
-      throw DOMException.create(this._globalObject, [
-        "The child can not be found in the parent.",
-        "NotFoundError"
-      ]);
-    }
-
-    if (
-      nodeType !== NODE_TYPE.DOCUMENT_FRAGMENT_NODE &&
-      nodeType !== NODE_TYPE.DOCUMENT_TYPE_NODE &&
-      nodeType !== NODE_TYPE.ELEMENT_NODE &&
-      nodeType !== NODE_TYPE.TEXT_NODE &&
-      nodeType !== NODE_TYPE.CDATA_SECTION_NODE && // CData section extends from Text
-      nodeType !== NODE_TYPE.PROCESSING_INSTRUCTION_NODE &&
-      nodeType !== NODE_TYPE.COMMENT_NODE
-    ) {
-      throw DOMException.create(this._globalObject, [
-        `${nodeName} node can't be inserted in parent node.`,
-        "HierarchyRequestError"
-      ]);
-    }
-
-    if (
-      (nodeType === NODE_TYPE.TEXT_NODE && parentType === NODE_TYPE.DOCUMENT_NODE) ||
-      (nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE && parentType !== NODE_TYPE.DOCUMENT_NODE)
-    ) {
-      throw DOMException.create(this._globalObject, [
-        `${nodeName} node can't be inserted in ${parentName} parent.`,
-        "HierarchyRequestError"
-      ]);
-    }
-
-    if (parentType === NODE_TYPE.DOCUMENT_NODE) {
-      const nodeChildren = domSymbolTree.childrenToArray(nodeImpl);
-      const parentChildren = domSymbolTree.childrenToArray(this);
-
-      switch (nodeType) {
-        case NODE_TYPE.DOCUMENT_FRAGMENT_NODE: {
-          const nodeChildrenElements = nodeChildren.filter(child => child.nodeType === NODE_TYPE.ELEMENT_NODE);
-          if (nodeChildrenElements.length > 1) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeName} node in ${parentName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-
-          const hasNodeTextChildren = nodeChildren.some(child => child.nodeType === NODE_TYPE.TEXT_NODE);
-          if (hasNodeTextChildren) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeName} node in ${parentName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-
-
-          const parentChildElements = parentChildren.filter(child => child.nodeType === NODE_TYPE.ELEMENT_NODE);
-          if (
-            nodeChildrenElements.length === 1 &&
-            (
-              (parentChildElements.length === 1 && parentChildElements[0] !== childImpl) ||
-              (
-                childImpl &&
-                domSymbolTree.nextSibling(childImpl) &&
-                domSymbolTree.nextSibling(childImpl).nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE
-              )
-            )
-          ) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeName} node in ${parentName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-          break;
-        }
-
-        case NODE_TYPE.ELEMENT_NODE:
-          if (
-            parentChildren.some(child => child.nodeType === NODE_TYPE.ELEMENT_NODE && child !== childImpl) ||
-            (
-              childImpl &&
-              domSymbolTree.nextSibling(childImpl) &&
-              domSymbolTree.nextSibling(childImpl).nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE
-            )
-          ) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeName} node in ${parentName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-          break;
-
-        case NODE_TYPE.DOCUMENT_TYPE_NODE:
-          if (
-            parentChildren.some(child => child.nodeType === NODE_TYPE.DOCUMENT_TYPE_NODE && child !== childImpl) ||
-            (
-              childImpl &&
-              domSymbolTree.previousSibling(childImpl) &&
-              domSymbolTree.previousSibling(childImpl).nodeType === NODE_TYPE.ELEMENT_NODE
-            )
-          ) {
-            throw DOMException.create(this._globalObject, [
-              `Invalid insertion of ${nodeName} node in ${parentName} node.`,
-              "HierarchyRequestError"
-            ]);
-          }
-          break;
-      }
-    }
+    this._preInsertValidity(nodeImpl, childImpl, new Set([childImpl]));
 
     let referenceChildImpl = domSymbolTree.nextSibling(childImpl);
     if (referenceChildImpl === nodeImpl) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -628,7 +628,7 @@ class NodeImpl extends EventTargetImpl {
   }
 
   // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
-  _preInsertValidity(nodeImpl, childImpl) {
+  _preInsertValidity(nodeImpl, childImpl, childrenToExclude = []) {
     const { nodeType } = nodeImpl;
     const parentType = this.nodeType;
 
@@ -684,7 +684,7 @@ class NodeImpl extends EventTargetImpl {
 
     if (parentType === NODE_TYPE.DOCUMENT_NODE) {
       const nodeChildren = domSymbolTree.childrenToArray(nodeImpl);
-      const parentChildren = domSymbolTree.childrenToArray(this);
+      const parentChildren = domSymbolTree.childrenToArray(this).filter(child => !childrenToExclude.includes(child));
 
       switch (nodeType) {
         case NODE_TYPE.DOCUMENT_FRAGMENT_NODE: {

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -55,7 +55,7 @@ class ParentNodeImpl {
 
   replaceChildren(...nodes) {
     const node = convertNodesIntoNode(this._ownerDocument, nodes);
-    this._preInsertValidity(node, null);
+    this._preInsertValidity(node, null, domSymbolTree.childrenToArray(this));
     this._replaceAll(node);
   }
 

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -55,7 +55,7 @@ class ParentNodeImpl {
 
   replaceChildren(...nodes) {
     const node = convertNodesIntoNode(this._ownerDocument, nodes);
-    this._preInsertValidity(node, null, domSymbolTree.childrenToArray(this));
+    this._preInsertValidity(node, null, new Set(domSymbolTree.childrenToArray(this)));
     this._replaceAll(node);
   }
 

--- a/lib/jsdom/living/range/Range-impl.js
+++ b/lib/jsdom/living/range/Range-impl.js
@@ -598,7 +598,7 @@ function insertNodeInRange(node, range) {
     startNode :
     domSymbolTree.parent(referenceNode);
 
-  parent._preInsertValidity(node, referenceNode);
+  parent._preInsertValidity(node, referenceNode, new Set());
 
   if (startNode.nodeType === NODE_TYPE.TEXT_NODE) {
     referenceNode = startNode.splitText(startOffset);

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1067,10 +1067,6 @@ Node-mutation-adoptNode.html:
 NodeList-static-length-getter-tampered*: [flaky, Nested for-loops are really slow and these often time out]
 ParentNode-querySelector-All-xht.xht: [fail-slow, Depends on requestAnimationFrame; has dont-upstream version]
 ParentNode-querySelector-All.html: [fail-slow, Depends on requestAnimationFrame; has dont-upstream version]
-ParentNode-replaceChildren.html:
-  "Document.replaceChildren() with an element, replacing an existing doctype and element.": [fail, Throws HierarchyRequestError]
-  "Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.": [fail, Throws HierarchyRequestError]
-  "Document.replaceChildren() with a doctype, replacing an existing doctype and element.": [fail, Throws HierarchyRequestError]
 ProcessingInstruction-escapes-1.xhtml: [fail, Unknown]
 adoption.window.html: [fail, "We do not implement https://github.com/whatwg/dom/pull/754 due to https://github.com/whatwg/dom/issues/813"]
 attach-shadow-realm-after-adoption.html: [fail, Unknown]

--- a/test/web-platform-tests/to-upstream/dom/nodes/pre-insertion-validity-children-to-exclude.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/pre-insertion-validity-children-to-exclude.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Pre-insertion validity with excluded children</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+test(() => {
+  const doc = document.implementation.createDocument(null, null);
+  const firstComment = doc.appendChild(doc.createComment("first"));
+  doc.appendChild(doc.createComment("second"));
+  doc.appendChild(doc.implementation.createDocumentType("html", "", ""));
+
+  assert_throws_dom("HierarchyRequestError", () => doc.insertBefore(doc.createElement("html"), firstComment));
+}, "insertBefore() rejects an element when a non-adjacent doctype follows the reference child");
+
+test(() => {
+  const doc = document.implementation.createDocument(null, "html");
+  doc.appendChild(doc.createComment("first"));
+  const secondComment = doc.appendChild(doc.createComment("second"));
+
+  const doctype = doc.implementation.createDocumentType("html", "", "");
+  assert_throws_dom("HierarchyRequestError", () => doc.insertBefore(doctype, secondComment));
+}, "insertBefore() rejects a doctype when a non-adjacent element precedes the reference child");
+
+test(() => {
+  const doc = document.implementation.createDocument(null, null);
+  const firstComment = doc.appendChild(doc.createComment("first"));
+  doc.appendChild(doc.createComment("second"));
+  doc.appendChild(doc.implementation.createDocumentType("html", "", ""));
+
+  assert_throws_dom("HierarchyRequestError", () => doc.replaceChild(doc.createElement("html"), firstComment));
+}, "replaceChild() rejects an element when a non-adjacent doctype follows the replaced child");
+
+test(() => {
+  const doc = document.implementation.createDocument(null, "html");
+  doc.appendChild(doc.createComment("first"));
+  const secondComment = doc.appendChild(doc.createComment("second"));
+
+  const doctype = doc.implementation.createDocumentType("html", "", "");
+  assert_throws_dom("HierarchyRequestError", () => doc.replaceChild(doctype, secondComment));
+}, "replaceChild() rejects a doctype when a non-adjacent element precedes the replaced child");
+
+test(() => {
+  const doc = document.implementation.createDocument(null, null);
+  const doctype = doc.appendChild(doc.implementation.createDocumentType("html", "", ""));
+  const element = doc.createElement("html");
+
+  assert_equals(doc.replaceChild(element, doctype), doctype);
+  assert_array_equals(doc.childNodes, [element]);
+}, "replaceChild() excludes the replaced doctype when validating an element");
+
+test(() => {
+  const doc = document.implementation.createHTMLDocument();
+  const { documentElement } = doc;
+
+  doc.replaceChildren(documentElement);
+  assert_array_equals(doc.childNodes, [documentElement]);
+}, "replaceChildren() excludes all current children when validating a retained element");
+</script>


### PR DESCRIPTION
Aligns pre-insertion validity with the current DOM algorithm across pre-insertion, replacement, `replaceChildren()`, and range insertion. Each call now supplies a `Set` of children to exclude, replacement delegates to the shared validator with the replaced child excluded, and document validation examines the full preceding and following child order instead of only adjacent siblings.

This fixes valid document replacements that were rejected because the outgoing doctype or document element was still considered, as well as invalid element and doctype placements hidden by intervening comments. Focused to-upstream tests cover those exclusion and document-order cases, and the three corresponding upstream `Document.replaceChildren()` tests are now enabled.

The `Document.replaceChildren()` failures surfaced with [the upstream `replaceChildren()` coverage](https://github.com/web-platform-tests/wpt/commit/e3cad70090774540f1e8ee0137b3d1310a86dd8b).
