### PR TITLE
Preserve fragment owner document during insertion

### DIFF
--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -770,7 +770,9 @@ class NodeImpl extends EventTargetImpl {
       referenceChildImpl = domSymbolTree.nextSibling(nodeImpl);
     }
 
-    this._ownerDocument._adoptNode(nodeImpl);
+    if (nodeImpl.nodeType !== NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
+      this._ownerDocument._adoptNode(nodeImpl);
+    }
 
     this._insert(nodeImpl, referenceChildImpl);
 
@@ -821,6 +823,8 @@ class NodeImpl extends EventTargetImpl {
     let isConnected;
 
     for (const node of nodesImpl) {
+      this._ownerDocument._adoptNode(node);
+
       if (!childImpl) {
         domSymbolTree.appendChild(this, node);
       } else {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -770,10 +770,6 @@ class NodeImpl extends EventTargetImpl {
       referenceChildImpl = domSymbolTree.nextSibling(nodeImpl);
     }
 
-    if (nodeImpl.nodeType !== NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
-      this._ownerDocument._adoptNode(nodeImpl);
-    }
-
     this._insert(nodeImpl, referenceChildImpl);
 
     return nodeImpl;

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1036,8 +1036,6 @@ DIR: dom/nodes
 DOMImplementation-createDocument.html: [fail, Unknown]
 DOMImplementation-createDocumentType.html: [fail, Unknown]
 Document-URL.html: [fail, Unknown]
-Document-adoptNode-DocumentFragment-with-host.window.html:
-  "appendChild() template.content: moves children, fragment ownerDocument stays": [fail, Unknown]
 Document-createAttribute.html: [fail, Unknown]
 Document-createElement.html: [fail, Unknown]
 Document-createElementNS.html: [fail, Unknown]


### PR DESCRIPTION
Align the node mutation algorithms with the DOM Standard: pre-insert now delegates directly to insertion, and insertion adopts each node from the extracted insertion list before adding it to the parent. As a result, inserting `template.content` adopts the moved children without changing the hosted `DocumentFragment`'s owner document.

The failure surfaced after [web-platform-tests/wpt@3f9d8f8](https://github.com/web-platform-tests/wpt/commit/3f9d8f8cd7134bc977db89cf3d48e4f8fe886142) added coverage for this distinction.