### PR TITLE
Use reflected cols for textarea wrapping

### DIFF
--- a/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTextAreaElement-impl.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+const idlUtils = require("../../../generated/idl/utils.js");
 
 const DefaultConstraintValidationImpl =
   require("../constraint-validation/DefaultConstraintValidation-impl").implementation;
@@ -41,7 +42,7 @@ class HTMLTextAreaElementImpl extends HTMLElementImpl {
     const apiValue = this._getAPIValue();
     const wrap = this.getAttributeNS(null, "wrap");
     return wrap === "hard" ?
-      textareaWrappingTransformation(apiValue, this.getAttributeNS(null, "cols") ?? 20) :
+      textareaWrappingTransformation(apiValue, idlUtils.wrapperForImpl(this).cols) :
       apiValue;
   }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -2009,7 +2009,6 @@ DIR: html/semantics/forms/the-textarea-element
 
 textarea-placeholder-lineheight.html: [fail, getBoundingClientRect() is not implemented]
 wrap-enumerated-ascii-case-insensitive.html: [timeout, Unknown]
-wrapping-transformation.window.html: [fail, Unknown]
 
 ---
 


### PR DESCRIPTION
Uses the numeric cols IDL reflection for textarea hard-wrapping, preventing line offsets from concatenating with the raw attribute string and enabling the full wrapping-transformation WPT.

The failure surfaced in the latest WPT roll because [4d5bf7d8db40d995ef310ed21d322d193b666a5e](https://github.com/web-platform-tests/wpt/commit/4d5bf7d8db40d995ef310ed21d322d193b666a5e) added hard-wrap round-trip coverage, and [e593a173440c109ae5c1ae01533d1de9e07acf6e](https://github.com/web-platform-tests/wpt/commit/e593a173440c109ae5c1ae01533d1de9e07acf6e) added an unconditional 10-column assertion. Those checks exercise repeated wrapping, where adding an offset to the raw string value 10 produced string concatenation instead of numeric addition.