### PR TITLE
Implement link fetchPriority reflection

### DIFF
--- a/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
@@ -3,6 +3,7 @@ const DOMTokenList = require("../../../generated/idl/DOMTokenList");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const idlUtils = require("../../../generated/idl/utils");
 const { fetchStyleSheet, removeStyleSheet } = require("../css/helpers/stylesheets");
+const { asciiLowercase } = require("../helpers/strings");
 const whatwgURL = require("whatwg-url");
 
 // Important reading: "appropriate times to obtain the resource" in
@@ -24,6 +25,22 @@ class HTMLLinkElementImpl extends HTMLElementImpl {
       });
     }
     return this._relList;
+  }
+
+  get fetchPriority() {
+    let value = this.getAttributeNS(null, "fetchpriority");
+    if (value !== null) {
+      value = asciiLowercase(value);
+      if (value === "high" || value === "low" || value === "auto") {
+        return value;
+      }
+    }
+
+    return "auto";
+  }
+
+  set fetchPriority(value) {
+    this.setAttributeNS(null, "fetchpriority", value);
   }
 
   _attach() {

--- a/lib/jsdom/living/nodes/HTMLLinkElement.webidl
+++ b/lib/jsdom/living/nodes/HTMLLinkElement.webidl
@@ -15,6 +15,7 @@ interface HTMLLinkElement : HTMLElement {
 //  [CEReactions] attribute USVString imageSrcset;
 //  [CEReactions] attribute DOMString imageSizes;
 //  [CEReactions] attribute DOMString referrerPolicy;
+  [CEReactions] attribute DOMString fetchPriority;
 
   // also has obsolete members
 };

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1741,7 +1741,6 @@ base_target_does_not_affect_location_assignment.html: [timeout, We don't support
 
 DIR: html/semantics/document-metadata/the-link-element
 
-attr-link-fetchpriority.html: [fail, Unknown]
 link-load-error-events.html: [fail, We don't fire error events]
 link-load-error-events.https.html: [fail, We don't fire error events]
 link-multiple-load-events.html: [fail, Unknown]


### PR DESCRIPTION
Implements `HTMLLinkElement.fetchPriority` reflection so [`attr-link-fetchpriority.html`](https://github.com/web-platform-tests/wpt/blob/e94af787e39d4161f01f0ef78d933f1103ee32b4/html/semantics/document-metadata/the-link-element/attr-link-fetchpriority.html), surfaced by [web-platform-tests/wpt@817b065e](https://github.com/web-platform-tests/wpt/commit/817b065e035c5624351472c9131c05eb94e2ea36) when the test moved into the rolled document-metadata directory, now passes.
