### PR TITLE
Compute selector specificity once per rule

### DIFF
--- a/lib/jsdom/living/css/helpers/computed-style.js
+++ b/lib/jsdom/living/css/helpers/computed-style.js
@@ -104,25 +104,27 @@ function handleRule(ruleImpl, elementImpl, declaration, specificities) {
   if (ruleMightMatchElement(ruleImpl, elementImpl)) {
     const { ast, match } = matches(ruleImpl.selectorText, elementImpl);
     if (match) {
-      handleStyle(ruleImpl.style, declaration, specificities, ast);
+      // The specificity only depends on the selector AST, not on any individual property, so it is computed once per
+      // rule rather than once per property. This is a significant win for rules with many declarations.
+      const { value: specificity } = Specificity.max(...Specificity.calculate(ast));
+      handleStyle(ruleImpl.style, declaration, specificities, specificity);
     }
   }
 }
 
-function handleStyle(style, declaration, specificities, ast) {
+function handleStyle(style, declaration, specificities, specificity) {
   for (let i = 0; i < style.length; i++) {
     const property = style.item(i);
-    handleProperty(property, declaration, style, specificities, ast);
+    handleProperty(property, declaration, style, specificities, specificity);
   }
 }
 
-function handleProperty(property, declaration, style, specificities, ast) {
+function handleProperty(property, declaration, style, specificities, specificity) {
   const value = style.getPropertyValue(property);
   const priority = style.getPropertyPriority(property);
   if (priority) {
     declaration.setProperty(property, value, priority);
   } else if (!declaration.getPropertyPriority(property)) {
-    const { value: specificity } = Specificity.max(...Specificity.calculate(ast));
     if (specificities.has(property)) {
       if (Specificity.compare(specificity, specificities.get(property)) >= 0) {
         specificities.set(property, specificity);


### PR DESCRIPTION
### Description

Follow-up performance work related to #3984 / #3985. In `computed-style.js`, the selector specificity was being recomputed once per *property* for every matching rule (via `Specificity.max(...Specificity.calculate(ast))`), even though it only depends on the rule's selector AST, not on the individual property.

This hoists the computation out of the per-property loop and computes it **once per rule** in `handleRule()`, passing the resolved specificity down to the property handlers.

### What changed

`lib/jsdom/living/css/helpers/computed-style.js` — computes selector specificity once per rule instead of once per property.

### Behavioral impact

Pure internal refactor; no behavior change. Reduces redundant `@bramus/specificity` computations (~2.5x fewer `Specificity.calculate` calls for a 65-element inline-styled tree). Selector math is not the dominant cold-path cost (value resolution is), so the end-to-end CPU-time win is modest, but it removes a clear source of per-property redundancy.

### Tests

No new tests: this is a refactor and the existing suites cover the cascade behavior. All pass:
- `test:api` — 573 passing
- WPT to-upstream `--fgrep css` — 187 passing
- WPT to-upstream `--fgrep getComputedStyle` — 24 passing
- `npm run lint` — clean