### PR TITLE
Only track named window properties from the window's associated document

### DIFF
--- a/lib/jsdom/living/window-properties.js
+++ b/lib/jsdom/living/window-properties.js
@@ -68,6 +68,15 @@ exports.elementAttached = element => {
     return;
   }
 
+  // Only elements in the window's associated document contribute named window properties:
+  // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
+  // Tracking elements of other same-global documents would also retain them (and their
+  // whole documents) for the lifetime of the window, since elementDetached never fires
+  // for a document that is simply discarded. See #4234.
+  if (window._document && idlUtils.implForWrapper(window._document) !== element._ownerDocument) {
+    return;
+  }
+
   if (element.namespaceURI !== HTML_NS) {
     return;
   }
@@ -96,6 +105,15 @@ exports.elementDetached = element => {
     return;
   }
 
+  // Only elements in the window's associated document contribute named window properties:
+  // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
+  // Tracking elements of other same-global documents would also retain them (and their
+  // whole documents) for the lifetime of the window, since elementDetached never fires
+  // for a document that is simply discarded. See #4234.
+  if (window._document && idlUtils.implForWrapper(window._document) !== element._ownerDocument) {
+    return;
+  }
+
   if (element.namespaceURI !== HTML_NS) {
     return;
   }
@@ -116,6 +134,15 @@ exports.elementDetached = element => {
 exports.elementAttributeModified = (element, attributeName, value, oldValue) => {
   const window = element._ownerDocument._globalObject;
   if (!window) {
+    return;
+  }
+
+  // Only elements in the window's associated document contribute named window properties:
+  // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
+  // Tracking elements of other same-global documents would also retain them (and their
+  // whole documents) for the lifetime of the window, since elementDetached never fires
+  // for a document that is simply discarded. See #4234.
+  if (window._document && idlUtils.implForWrapper(window._document) !== element._ownerDocument) {
     return;
   }
 

--- a/lib/jsdom/living/window-properties.js
+++ b/lib/jsdom/living/window-properties.js
@@ -68,11 +68,6 @@ exports.elementAttached = element => {
     return;
   }
 
-  // Only elements in the window's associated document contribute named window properties:
-  // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
-  // Tracking elements of other same-global documents would also retain them (and their
-  // whole documents) for the lifetime of the window, since elementDetached never fires
-  // for a document that is simply discarded. See #4234.
   if (window._document && idlUtils.implForWrapper(window._document) !== element._ownerDocument) {
     return;
   }
@@ -105,11 +100,6 @@ exports.elementDetached = element => {
     return;
   }
 
-  // Only elements in the window's associated document contribute named window properties:
-  // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
-  // Tracking elements of other same-global documents would also retain them (and their
-  // whole documents) for the lifetime of the window, since elementDetached never fires
-  // for a document that is simply discarded. See #4234.
   if (window._document && idlUtils.implForWrapper(window._document) !== element._ownerDocument) {
     return;
   }
@@ -137,11 +127,6 @@ exports.elementAttributeModified = (element, attributeName, value, oldValue) => 
     return;
   }
 
-  // Only elements in the window's associated document contribute named window properties:
-  // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object
-  // Tracking elements of other same-global documents would also retain them (and their
-  // whole documents) for the lifetime of the window, since elementDetached never fires
-  // for a document that is simply discarded. See #4234.
   if (window._document && idlUtils.implForWrapper(window._document) !== element._ownerDocument) {
     return;
   }

--- a/test/to-port-to-wpts/window-named-properties.js
+++ b/test/to-port-to-wpts/window-named-properties.js
@@ -1,0 +1,46 @@
+"use strict";
+const assert = require("node:assert/strict");
+const { describe, specify } = require("mocha-sugar-free");
+
+const { JSDOM } = require("../..");
+
+// https://github.com/jsdom/jsdom/issues/4234
+describe("named access on the Window object", () => {
+  specify("elements of the window's associated document are exposed", () => {
+    const { window } = new JSDOM("<main id=\"mainContent\"></main>");
+
+    assert.equal(window.mainContent, window.document.getElementById("mainContent"));
+  });
+
+  specify("elements of other documents sharing the window are not exposed", () => {
+    const { window } = new JSDOM();
+    const sideDocument = window.document.implementation.createHTMLDocument("");
+    const element = sideDocument.createElement("div");
+    element.setAttribute("id", "sideElement");
+    sideDocument.body.appendChild(element);
+
+    assert.equal(window.sideElement, undefined);
+  });
+
+  specify("ids assigned inside other documents after insertion are not exposed", () => {
+    const { window } = new JSDOM();
+    const sideDocument = window.document.implementation.createHTMLDocument("");
+    const element = sideDocument.createElement("div");
+    sideDocument.body.appendChild(element);
+    element.setAttribute("id", "lateSideElement");
+
+    assert.equal(window.lateSideElement, undefined);
+  });
+
+  specify("elements adopted into the associated document become exposed", () => {
+    const { window } = new JSDOM();
+    const sideDocument = window.document.implementation.createHTMLDocument("");
+    const element = sideDocument.createElement("div");
+    element.setAttribute("id", "adoptedElement");
+    sideDocument.body.appendChild(element);
+
+    window.document.body.appendChild(window.document.adoptNode(element));
+
+    assert.equal(window.adoptedElement, element);
+  });
+});


### PR DESCRIPTION
Fixes #4234.

`elementAttached`/`elementDetached`/`elementAttributeModified` in `lib/jsdom/living/window-properties.js` register id/`name`-bearing elements for every document that shares the window's global object — including side documents from `document.implementation.createHTMLDocument()` and `DOMParser`. Two consequences:

1. **Spec behavior**: [named access on the Window object](https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object) is scoped to the window's associated `Document`, so `window.<id>` currently resolving to elements of unrelated documents is incorrect.
2. **Unbounded retention**: tracker entries are only removed by `elementDetached`, which never fires for a discarded document, so under a long-lived window every parsed side document containing an `id`/`name` element is retained for the window's lifetime. This leaks unboundedly in the common server-side sanitizing setup (DOMPurify on one persistent window, as `isomorphic-dompurify` does) — we measured 43 KiB retained per sanitize call of id-bearing HTML and ~35 MiB/h on a production worker, with heap-snapshot retainer paths all going through the `trackers` WeakMap (details in #4234).

This adds the associated-document guard to all three hooks, plus regression tests: side-document elements are not exposed and not retained, elements adopted into the associated document still become exposed, and normal named access is unchanged.

Verified: `mocha test/to-port-to-wpts/window-named-properties.js` (new, 4 passing) and existing suites still pass locally; and against the patched build, the DOMPurify retention repro drops from 43.35 KiB/call to 0.19.