### PR TITLE
perf(forms): Cache label associations by root

### DIFF
--- a/benchmark/forms/labels.js
+++ b/benchmark/forms/labels.js
@@ -5,35 +5,39 @@ const { JSDOM } = require("../..");
 module.exports = () => {
   const bench = new Bench();
 
-  const CONTROLS = 100;
-  const { document } = (new JSDOM()).window;
+  function addTask(controlCount, labelCount, readCount) {
+    const { document } = (new JSDOM()).window;
+    const inputs = [];
 
-  for (let i = 0; i < CONTROLS; i++) {
-    const label = document.createElement("label");
-    label.htmlFor = `control-${i}`;
-    label.textContent = `Control ${i}`;
+    for (let i = 0; i < controlCount; i++) {
+      if (i < labelCount) {
+        const label = document.createElement("label");
+        label.htmlFor = `control-${i}`;
+        label.textContent = `Control ${i}`;
+        document.body.append(label);
+      }
 
-    const input = document.createElement("input");
-    input.id = `control-${i}`;
+      const input = document.createElement("input");
+      input.id = `control-${i}`;
+      document.body.append(input);
+      inputs.push(input);
+    }
 
-    document.body.append(label, input);
+    bench.add(`read labels for ${readCount}/${controlCount} controls after mutation (${labelCount} labels)`, () => {
+      document.body.toggleAttribute("data-mutated");
+      let labels = 0;
+      for (let i = 0; i < readCount; i++) {
+        labels += inputs[i].labels.length;
+      }
+      return labels;
+    });
   }
 
-  const inputs = document.querySelectorAll("input");
-
-  bench.add(`read labels for 1 of ${CONTROLS} controls after mutation`, () => {
-    document.body.toggleAttribute("data-mutated");
-    return inputs[0].labels.length;
-  });
-
-  bench.add(`read labels for ${CONTROLS} controls after mutation`, () => {
-    document.body.toggleAttribute("data-mutated");
-    let labelCount = 0;
-    for (const input of inputs) {
-      labelCount += input.labels.length;
-    }
-    return labelCount;
-  });
+  addTask(100, 100, 1);
+  addTask(10, 10, 10);
+  addTask(100, 100, 100);
+  addTask(100, 10, 100);
+  addTask(100, 0, 100);
 
   return bench;
 };

--- a/benchmark/forms/labels.js
+++ b/benchmark/forms/labels.js
@@ -21,6 +21,11 @@ module.exports = () => {
 
   const inputs = document.querySelectorAll("input");
 
+  bench.add(`read labels for 1 of ${CONTROLS} controls after mutation`, () => {
+    document.body.toggleAttribute("data-mutated");
+    return inputs[0].labels.length;
+  });
+
   bench.add(`read labels for ${CONTROLS} controls after mutation`, () => {
     document.body.toggleAttribute("data-mutated");
     let labelCount = 0;

--- a/benchmark/forms/labels.js
+++ b/benchmark/forms/labels.js
@@ -1,0 +1,34 @@
+"use strict";
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+module.exports = () => {
+  const bench = new Bench();
+
+  const CONTROLS = 100;
+  const { document } = (new JSDOM()).window;
+
+  for (let i = 0; i < CONTROLS; i++) {
+    const label = document.createElement("label");
+    label.htmlFor = `control-${i}`;
+    label.textContent = `Control ${i}`;
+
+    const input = document.createElement("input");
+    input.id = `control-${i}`;
+
+    document.body.append(label, input);
+  }
+
+  const inputs = document.querySelectorAll("input");
+
+  bench.add(`read labels for ${CONTROLS} controls after mutation`, () => {
+    document.body.toggleAttribute("data-mutated");
+    let labelCount = 0;
+    for (const input of inputs) {
+      labelCount += input.labels.length;
+    }
+    return labelCount;
+  });
+
+  return bench;
+};

--- a/lib/jsdom/living/helpers/custom-elements.js
+++ b/lib/jsdom/living/helpers/custom-elements.js
@@ -82,6 +82,10 @@ function upgradeElement(definition, element) {
 
   element._ceDefinition = definition;
   element._ceState = "failed";
+  if (definition.formAssociated) {
+    // The definition makes the element labelable before its constructor runs.
+    element._modified();
+  }
 
   for (const attribute of element._attributeList) {
     const { _localName, _namespace, _value } = attribute;
@@ -121,16 +125,16 @@ function upgradeElement(definition, element) {
 
   if (constructionError !== undefined) {
     element._ceDefinition = null;
+    if (definition.formAssociated) {
+      // Roll back label associations created while the constructor could observe the definition.
+      element._modified();
+    }
     element._ceReactionQueue = [];
 
     throw constructionError;
   }
 
   element._ceState = "custom";
-  if (definition.formAssociated) {
-    // The upgrade makes the element labelable, which can change live `labels` NodeLists without a tree mutation.
-    element._modified();
-  }
 }
 
 // https://html.spec.whatwg.org/#concept-try-upgrade

--- a/lib/jsdom/living/helpers/custom-elements.js
+++ b/lib/jsdom/living/helpers/custom-elements.js
@@ -127,6 +127,10 @@ function upgradeElement(definition, element) {
   }
 
   element._ceState = "custom";
+  if (definition.formAssociated) {
+    // The upgrade makes the element labelable, which can change live `labels` NodeLists without a tree mutation.
+    element._modified();
+  }
 }
 
 // https://html.spec.whatwg.org/#concept-try-upgrade

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -147,6 +147,8 @@ function getLabelAssociations(root) {
     return cached.labelsByControl;
   }
 
+  // `_modified()` bumps the root version for tree and attribute mutations. Form-associated custom element upgrades
+  // also bump it, since they can change the first labelable descendant of a label.
   const labelsByControl = new WeakMap();
   for (const descendant of domSymbolTree.treeIterator(root)) {
     if (descendant.nodeType !== NODE_TYPE.ELEMENT_NODE ||

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -142,13 +142,11 @@ exports.isLabelable = node => {
 };
 
 function getLabelAssociations(root) {
-  const cached = root[labelAssociationsCache];
-  if (cached?.version === root._version) {
-    return cached.labelsByControl;
+  const cached = root._memoizedQueries[labelAssociationsCache];
+  if (cached) {
+    return cached;
   }
 
-  // `_modified()` bumps the root version for tree and attribute mutations. Form-associated custom element upgrades
-  // also bump it, since they can change the first labelable descendant of a label.
   const labelsByControl = new WeakMap();
   for (const descendant of domSymbolTree.treeIterator(root)) {
     if (descendant.nodeType !== NODE_TYPE.ELEMENT_NODE ||
@@ -166,7 +164,7 @@ function getLabelAssociations(root) {
     labelsByControl.set(control, labels);
   }
 
-  root[labelAssociationsCache] = { version: root._version, labelsByControl };
+  root._memoizedQueries[labelAssociationsCache] = labelsByControl;
   return labelsByControl;
 }
 

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -24,6 +24,8 @@ const { closest, firstChildWithLocalName } = require("./traversal");
 const NODE_TYPE = require("../node-type");
 const { HTML_NS } = require("./namespaces");
 
+const labelAssociationsCache = Symbol("label associations cache");
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled
 exports.isDisabled = formControl => {
   if (formControl.localName === "button" || formControl.localName === "input" || formControl.localName === "select" ||
@@ -139,6 +141,33 @@ exports.isLabelable = node => {
   return false;
 };
 
+function getLabelAssociations(root) {
+  const cached = root[labelAssociationsCache];
+  if (cached?.version === root._version) {
+    return cached.labelsByControl;
+  }
+
+  const labelsByControl = new WeakMap();
+  for (const descendant of domSymbolTree.treeIterator(root)) {
+    if (descendant.nodeType !== NODE_TYPE.ELEMENT_NODE ||
+        descendant.namespaceURI !== HTML_NS || descendant.localName !== "label") {
+      continue;
+    }
+
+    const { control } = descendant;
+    if (control === null) {
+      continue;
+    }
+
+    const labels = labelsByControl.get(control) ?? [];
+    labels.push(descendant);
+    labelsByControl.set(control, labels);
+  }
+
+  root[labelAssociationsCache] = { version: root._version, labelsByControl };
+  return labelsByControl;
+}
+
 exports.getLabelsForLabelable = labelable => {
   if (!exports.isLabelable(labelable)) {
     return null;
@@ -147,15 +176,7 @@ exports.getLabelsForLabelable = labelable => {
     const root = labelable.getRootNode({});
     labelable._labels = NodeList.createImpl(root._globalObject, [], {
       element: root,
-      query: () => {
-        const nodes = [];
-        for (const descendant of domSymbolTree.treeIterator(root)) {
-          if (descendant.control === labelable) {
-            nodes.push(descendant);
-          }
-        }
-        return nodes;
-      }
+      query: () => getLabelAssociations(root).get(labelable) ?? []
     });
   }
   return labelable._labels;

--- a/test/web-platform-tests/to-upstream/custom-elements/ElementInternals-labels.html
+++ b/test/web-platform-tests/to-upstream/custom-elements/ElementInternals-labels.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ElementInternals labels during custom element upgrades</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+setup({ allow_uncaught_exception: true });
+
+test(t => {
+  const label = document.createElement("label");
+  const customElement = document.createElement("labels-success-control");
+  const input = document.createElement("input");
+  label.append(customElement, input);
+  document.body.append(label);
+  t.add_cleanup(() => label.remove());
+
+  const { labels } = input;
+  assert_array_equals(labels, [label]);
+
+  let elementInternals;
+  customElements.define("labels-success-control", class extends HTMLElement {
+    static get formAssociated() {
+      return true;
+    }
+
+    constructor() {
+      super();
+      elementInternals = this.attachInternals();
+      assert_array_equals(elementInternals.labels, [label]);
+    }
+  });
+
+  assert_array_equals(labels, []);
+  assert_array_equals(elementInternals.labels, [label]);
+}, "ElementInternals labels are correct inside a form-associated custom element constructor");
+
+test(t => {
+  const label = document.createElement("label");
+  const customElement = document.createElement("labels-failure-control");
+  const input = document.createElement("input");
+  label.append(customElement, input);
+  document.body.append(label);
+  t.add_cleanup(() => label.remove());
+
+  customElements.define("labels-failure-control", class extends HTMLElement {
+    static get formAssociated() {
+      return true;
+    }
+
+    constructor() {
+      super();
+      this.attachInternals().labels.item(0);
+      throw new Error("Expected constructor failure");
+    }
+  });
+
+  assert_array_equals(input.labels, [label]);
+}, "Label associations are restored when a form-associated custom element constructor fails");
+</script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
@@ -358,6 +358,34 @@
       input2.remove();
     }, "The labels NodeList stays live when label associations change.");
 
+    test(function () {
+      var label = document.createElement("label");
+      var customElement = document.createElement("live-labels-control");
+      var input = document.createElement("input");
+      label.append(customElement, input);
+      document.body.append(label);
+
+      var labels = input.labels;
+      assert_array_equals(labels, [label]);
+
+      var internals;
+      customElements.define("live-labels-control", class extends HTMLElement {
+        static get formAssociated() {
+          return true;
+        }
+
+        constructor() {
+          super();
+          internals = this.attachInternals();
+        }
+      });
+
+      assert_array_equals(labels, [], "Upgrading the first descendant should update the old control's labels.");
+      assert_array_equals(internals.labels, [label], "The upgraded form-associated element should get the label.");
+
+      label.remove();
+    }, "The labels NodeList stays live when a form-associated custom element upgrades.");
+
     // form attribute
     test(function () {
       assert_equals(document.getElementById("lbl0").form, null,

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
@@ -377,6 +377,7 @@
         constructor() {
           super();
           elementInternals = this.attachInternals();
+          assert_array_equals(elementInternals.labels, [label]);
         }
       });
 
@@ -385,6 +386,36 @@
 
       label.remove();
     }, "The labels NodeList stays live when a form-associated custom element upgrades.");
+
+    test(function () {
+      var label = document.createElement("label");
+      var customElement = document.createElement("failed-labels-control");
+      var input = document.createElement("input");
+      label.append(customElement, input);
+      document.body.append(label);
+
+      function preventExpectedError(event) {
+        event.preventDefault();
+      }
+      window.addEventListener("error", preventExpectedError, { once: true });
+
+      customElements.define("failed-labels-control", class extends HTMLElement {
+        static get formAssociated() {
+          return true;
+        }
+
+        constructor() {
+          super();
+          this.attachInternals().labels.item(0);
+          throw new Error("Expected constructor failure");
+        }
+      });
+
+      window.removeEventListener("error", preventExpectedError);
+      assert_array_equals(input.labels, [label]);
+
+      label.remove();
+    }, "Label associations are restored when a form-associated custom element constructor fails.");
 
     // form attribute
     test(function () {

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
@@ -358,65 +358,6 @@
       input2.remove();
     }, "The labels NodeList stays live when label associations change.");
 
-    test(function () {
-      var label = document.createElement("label");
-      var customElement = document.createElement("live-labels-control");
-      var input = document.createElement("input");
-      label.append(customElement, input);
-      document.body.append(label);
-
-      var labels = input.labels;
-      assert_array_equals(labels, [label]);
-
-      var elementInternals;
-      customElements.define("live-labels-control", class extends HTMLElement {
-        static get formAssociated() {
-          return true;
-        }
-
-        constructor() {
-          super();
-          elementInternals = this.attachInternals();
-          assert_array_equals(elementInternals.labels, [label]);
-        }
-      });
-
-      assert_array_equals(labels, [], "Upgrading the first descendant should update the old control's labels.");
-      assert_array_equals(elementInternals.labels, [label], "The upgraded form-associated element should get the label.");
-
-      label.remove();
-    }, "The labels NodeList stays live when a form-associated custom element upgrades.");
-
-    test(function () {
-      var label = document.createElement("label");
-      var customElement = document.createElement("failed-labels-control");
-      var input = document.createElement("input");
-      label.append(customElement, input);
-      document.body.append(label);
-
-      function preventExpectedError(event) {
-        event.preventDefault();
-      }
-      window.addEventListener("error", preventExpectedError, { once: true });
-
-      customElements.define("failed-labels-control", class extends HTMLElement {
-        static get formAssociated() {
-          return true;
-        }
-
-        constructor() {
-          super();
-          this.attachInternals().labels.item(0);
-          throw new Error("Expected constructor failure");
-        }
-      });
-
-      window.removeEventListener("error", preventExpectedError);
-      assert_array_equals(input.labels, [label]);
-
-      label.remove();
-    }, "Label associations are restored when a form-associated custom element constructor fails.");
-
     // form attribute
     test(function () {
       assert_equals(document.getElementById("lbl0").form, null,

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
@@ -329,6 +329,35 @@
         "The labeled cotrol should be associated with the control whose ID is equal to the value of the 'for' attribute.");
     }, "A form control has no label 2.");
 
+    test(function () {
+      var label = document.createElement("label");
+      var input1 = document.createElement("input");
+      var input2 = document.createElement("input");
+      label.htmlFor = "live-labels-1";
+      input1.id = "live-labels-1";
+      input2.id = "live-labels-2";
+      document.body.append(label, input1, input2);
+
+      var labels1 = input1.labels;
+      var labels2 = input2.labels;
+      assert_array_equals(labels1, [label]);
+      assert_array_equals(labels2, []);
+
+      label.htmlFor = "live-labels-2";
+      assert_array_equals(labels1, [], "Changing 'for' should update the old control's labels.");
+      assert_array_equals(labels2, [label], "Changing 'for' should update the new control's labels.");
+
+      input2.id = "live-labels-3";
+      assert_array_equals(labels2, [], "Changing the control's ID should update its labels.");
+
+      input2.id = "live-labels-2";
+      assert_array_equals(labels2, [label], "Restoring the control's ID should update its labels.");
+
+      label.remove();
+      input1.remove();
+      input2.remove();
+    }, "The labels NodeList stays live when label associations change.");
+
     // form attribute
     test(function () {
       assert_equals(document.getElementById("lbl0").form, null,

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/label-attributes-dont-upstream.html
@@ -368,7 +368,7 @@
       var labels = input.labels;
       assert_array_equals(labels, [label]);
 
-      var internals;
+      var elementInternals;
       customElements.define("live-labels-control", class extends HTMLElement {
         static get formAssociated() {
           return true;
@@ -376,12 +376,12 @@
 
         constructor() {
           super();
-          internals = this.attachInternals();
+          elementInternals = this.attachInternals();
         }
       });
 
       assert_array_equals(labels, [], "Upgrading the first descendant should update the old control's labels.");
-      assert_array_equals(internals.labels, [label], "The upgraded form-associated element should get the label.");
+      assert_array_equals(elementInternals.labels, [label], "The upgraded form-associated element should get the label.");
 
       label.remove();
     }, "The labels NodeList stays live when a form-associated custom element upgrades.");


### PR DESCRIPTION
**Note**: This pr is from AI but I've iterated on it a bit and this change would improve a single expensive form test in [sentry](https://github.com/getsentry/sentry) by 35% [on this test file](https://github.com/getsentry/sentry/blob/c73856753969efc2e12f13363c4db17a3b80849c/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx).

Every control's live `labels` NodeList currently walks the full DOM root and resolves labels independently. Reading labels for many controls after a mutation repeats that root-wide work once per control.

This shows up in Testing Library tests over larger forms like this:

```html
<form>
  <label for="field-0">Field 0</label>
  <input id="field-0">

  <!-- many more labeled inputs -->

  <label for="field-99">Field 99</label>
  <input id="field-99">
</form>
```

```js
screen.getByRole("textbox", { name: "Field 99" });
```

`getByRole` computes accessible names for the candidate textboxes. Those calculations read `input.labels`, so one query can make every control rescan the same root.

Build one label-to-control index per root version and share it across those live NodeLists. Tree and attribute mutations already update the root version; form-associated custom element upgrades now update it too because they can change implicit label ownership.

Adds live-list coverage for `for`/`id` changes and custom element upgrades, plus a benchmark that shows both the cold cost and the amortized case.

`node --run benchmark -- --suite forms/labels`, latency median:

| Task | Before | After | Change |
| --- | ---: | ---: | ---: |
| Read 1 of 100 controls after mutation | 0.563 ms | 0.571 ms | +1.5% |
| Read all 100 controls after mutation | 54.64 ms | 0.644 ms | 98.8% less time (84.8x) |