### PR TITLE
docs: point Chrome DevTools inspector link at current Node.js guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ If you want to be sure to shut down a jsdom window, use `window.close()`, which 
 
 ### Debugging the DOM using Chrome DevTools
 
-In Node.js you can debug programs using Chrome DevTools. See the [official documentation](https://nodejs.org/en/docs/inspector/) for how to get started.
+In Node.js you can debug programs using Chrome DevTools. See the [official documentation](https://nodejs.org/en/learn/getting-started/debugging) for how to get started.
 
 By default jsdom elements are formatted as plain old JS objects in the console. To make it easier to debug, you can use [jsdom-devtools-formatter](https://github.com/jsdom/jsdom-devtools-formatter), which lets you inspect them like real DOM elements.
 


### PR DESCRIPTION
## Problem

The "Debugging the DOM using Chrome DevTools" section of the README links to:

https://nodejs.org/en/docs/inspector/

A curl -L GET of that URL returns 404. The old Node.js inspector landing page was removed when the docs moved under /learn.

## Solution

Point the link at the current Node.js debugging guide, which covers Chrome DevTools / inspector setup and returns 200:

https://nodejs.org/en/learn/getting-started/debugging

## Verification

```
curl -sL -o /dev/null -w "%{http_code}\n" https://nodejs.org/en/docs/inspector/
# 404

curl -sL -o /dev/null -w "%{http_code}\n" https://nodejs.org/en/learn/getting-started/debugging
# 200
```
