### PR TITLE
Avoid repeated event path work

### DIFF
--- a/benchmark/dom/event-target.js
+++ b/benchmark/dom/event-target.js
@@ -1,0 +1,51 @@
+"use strict";
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+const depths = [10, 50, 100];
+const listenerPatterns = ["none", "delegated", "every tree node"];
+
+// Build each tree and its listeners once, then time dispatch alone. Varying both depth and listener density separates
+// the event-path target lookup from the work of invoking callbacks.
+module.exports = () => {
+  const bench = new Bench();
+
+  for (const depth of depths) {
+    for (const listenerPattern of listenerPatterns) {
+      addDispatchBenchmark(bench, depth, listenerPattern);
+    }
+  }
+
+  return bench;
+};
+
+function addDispatchBenchmark(bench, depth, listenerPattern) {
+  const { document, Event } = (new JSDOM()).window;
+  const root = document.createElement("div");
+  document.body.append(root);
+
+  const elements = [root];
+  let target = root;
+  for (let i = 0; i < depth; i++) {
+    const child = document.createElement("div");
+    target.appendChild(child);
+    elements.push(child);
+    target = child;
+  }
+
+  function listener() {}
+  if (listenerPattern === "delegated") {
+    root.addEventListener("test", listener, true);
+    root.addEventListener("test", listener);
+  } else if (listenerPattern === "every tree node") {
+    for (const element of elements) {
+      element.addEventListener("test", listener, true);
+      element.addEventListener("test", listener);
+    }
+  }
+
+  const event = new Event("test", { bubbles: true });
+  bench.add(`dispatchEvent: depth ${depth}, listeners ${listenerPattern}`, () => {
+    target.dispatchEvent(event);
+  });
+}

--- a/benchmark/dom/root-node.js
+++ b/benchmark/dom/root-node.js
@@ -23,25 +23,6 @@ module.exports = () => {
     });
   }
 
-  // Event dispatch (bubbling) on a deep tree.
-  // Event dispatch calls nodeRoot internally multiple times per ancestor
-  // in the event path, making it O(depth^2) without caching.
-  {
-    const DEPTH = 100;
-    const { document, Event } = (new JSDOM()).window;
-    let deepest = document.body;
-    for (let i = 0; i < DEPTH; i++) {
-      const child = document.createElement("div");
-      deepest.appendChild(child);
-      deepest = child;
-    }
-    const event = new Event("test", { bubbles: true });
-
-    bench.add(`dispatchEvent (bubbling): depth ${DEPTH}`, () => {
-      deepest.dispatchEvent(event);
-    });
-  }
-
   // isConnected on a deep static tree.
   // isConnected uses shadowIncludingRoot -> nodeRoot internally.
   // Common in frameworks to check if an element is still in the DOM.

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -201,14 +201,15 @@ class EventTargetImpl {
 
       let clearTargetsStructIndex = -1;
       for (let i = eventImpl._path.length - 1; i >= 0 && clearTargetsStructIndex === -1; i--) {
-        if (eventImpl._path[i].target !== null) {
+        if (eventImpl._path[i].shadowAdjustedTarget !== null) {
           clearTargetsStructIndex = i;
         }
       }
       const clearTargetsStruct = eventImpl._path[clearTargetsStructIndex];
 
       clearTargets =
-        (isNode(clearTargetsStruct.target) && isShadowRoot(nodeRoot(clearTargetsStruct.target))) ||
+        (isNode(clearTargetsStruct.shadowAdjustedTarget) &&
+          isShadowRoot(nodeRoot(clearTargetsStruct.shadowAdjustedTarget))) ||
           (isNode(clearTargetsStruct.relatedTarget) && isShadowRoot(nodeRoot(clearTargetsStruct.relatedTarget)));
 
       if (activationTarget !== null && activationTarget._legacyPreActivationBehavior) {
@@ -218,7 +219,7 @@ class EventTargetImpl {
       for (let i = eventImpl._path.length - 1; i >= 0; --i) {
         const struct = eventImpl._path[i];
 
-        if (struct.target !== null) {
+        if (struct.shadowAdjustedTarget !== null) {
           eventImpl.eventPhase = EVENT_PHASE.AT_TARGET;
         } else {
           eventImpl.eventPhase = EVENT_PHASE.CAPTURING_PHASE;
@@ -227,10 +228,11 @@ class EventTargetImpl {
         invokeEventListeners(struct, eventImpl, "capturing");
       }
 
+      let finalStruct;
       for (let i = 0; i < eventImpl._path.length; i++) {
         const struct = eventImpl._path[i];
 
-        if (struct.target !== null) {
+        if (struct.shadowAdjustedTarget !== null) {
           eventImpl.eventPhase = EVENT_PHASE.AT_TARGET;
         } else {
           if (!eventImpl.bubbles) {
@@ -240,15 +242,12 @@ class EventTargetImpl {
           eventImpl.eventPhase = EVENT_PHASE.BUBBLING_PHASE;
         }
 
+        finalStruct = struct;
         invokeEventListeners(struct, eventImpl, "bubbling");
       }
 
-      // Listenerless path entries skip invocation, so apply the final retargeted state explicitly.
-      const finalStruct = eventImpl.bubbles ?
-        eventImpl._path[eventImpl._path.length - 1] :
-        eventImpl._path.findLast(struct => struct.target !== null);
-      eventImpl.target = finalStruct.shadowAdjustedTarget;
-      eventImpl.relatedTarget = idlUtils.wrapperForImpl(finalStruct.relatedTarget);
+      // Listenerless path entries skip target updates, so apply the state from the last entry selected for invocation.
+      updateEventTargets(eventImpl, finalStruct);
     }
 
     eventImpl.eventPhase = EVENT_PHASE.NONE;
@@ -287,9 +286,7 @@ function invokeEventListeners(struct, eventImpl, phase) {
     return;
   }
 
-  eventImpl.target = struct.shadowAdjustedTarget;
-
-  eventImpl.relatedTarget = idlUtils.wrapperForImpl(struct.relatedTarget);
+  updateEventTargets(eventImpl, struct);
 
   if (eventImpl._stopPropagationFlag) {
     return;
@@ -298,6 +295,11 @@ function invokeEventListeners(struct, eventImpl, phase) {
   eventImpl.currentTarget = idlUtils.wrapperForImpl(struct.item);
 
   innerInvokeEventListeners(eventImpl, listeners, phase, struct.itemInShadowTree);
+}
+
+function updateEventTargets(eventImpl, struct) {
+  eventImpl.target = struct.effectiveTarget;
+  eventImpl.relatedTarget = idlUtils.wrapperForImpl(struct.relatedTarget);
 }
 
 // https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke
@@ -426,17 +428,27 @@ function defaultPassiveValue(type, eventTarget) {
 }
 
 // https://dom.spec.whatwg.org/#concept-event-path-append
-function appendToEventPath(eventImpl, target, targetOverride, relatedTarget, touchTargets, slotInClosedTree) {
-  const itemInShadowTree = isNode(target) && isShadowRoot(nodeRoot(target));
-  const rootOfClosedTree = isShadowRoot(target) && target.mode === "closed";
+function appendToEventPath(
+  eventImpl,
+  invocationTarget,
+  shadowAdjustedTarget,
+  relatedTarget,
+  touchTargets,
+  slotInClosedTree
+) {
+  const itemInShadowTree = isNode(invocationTarget) && isShadowRoot(nodeRoot(invocationTarget));
+  const rootOfClosedTree = isShadowRoot(invocationTarget) && invocationTarget.mode === "closed";
   const previousStruct = eventImpl._path[eventImpl._path.length - 1];
-  const shadowAdjustedTarget = targetOverride === null ? previousStruct.shadowAdjustedTarget : targetOverride;
+
+  // The invoke algorithm searches backward for the closest non-null shadow-adjusted target. Cache that result while
+  // building the path so that each invocation can use it directly.
+  const effectiveTarget = shadowAdjustedTarget === null ? previousStruct.effectiveTarget : shadowAdjustedTarget;
 
   eventImpl._path.push({
-    item: target,
+    item: invocationTarget,
     itemInShadowTree,
-    target: targetOverride,
     shadowAdjustedTarget,
+    effectiveTarget,
     relatedTarget,
     touchTargets,
     rootOfClosedTree,

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -242,6 +242,13 @@ class EventTargetImpl {
 
         invokeEventListeners(struct, eventImpl, "bubbling");
       }
+
+      // Listenerless path entries skip invocation, so apply the final retargeted state explicitly.
+      const finalStruct = eventImpl.bubbles ?
+        eventImpl._path[eventImpl._path.length - 1] :
+        eventImpl._path.findLast(struct => struct.target !== null);
+      eventImpl.target = finalStruct.shadowAdjustedTarget;
+      eventImpl.relatedTarget = idlUtils.wrapperForImpl(finalStruct.relatedTarget);
     }
 
     eventImpl.eventPhase = EVENT_PHASE.NONE;
@@ -275,14 +282,12 @@ module.exports = {
 
 // https://dom.spec.whatwg.org/#concept-event-listener-invoke
 function invokeEventListeners(struct, eventImpl, phase) {
-  const structIndex = eventImpl._path.indexOf(struct);
-  for (let i = structIndex; i >= 0; i--) {
-    const t = eventImpl._path[i];
-    if (t.target) {
-      eventImpl.target = t.target;
-      break;
-    }
+  const listeners = struct.item._eventListeners;
+  if (!listeners[eventImpl.type]) {
+    return;
   }
+
+  eventImpl.target = struct.shadowAdjustedTarget;
 
   eventImpl.relatedTarget = idlUtils.wrapperForImpl(struct.relatedTarget);
 
@@ -292,7 +297,6 @@ function invokeEventListeners(struct, eventImpl, phase) {
 
   eventImpl.currentTarget = idlUtils.wrapperForImpl(struct.item);
 
-  const listeners = struct.item._eventListeners;
   innerInvokeEventListeners(eventImpl, listeners, phase, struct.itemInShadowTree);
 }
 
@@ -425,11 +429,14 @@ function defaultPassiveValue(type, eventTarget) {
 function appendToEventPath(eventImpl, target, targetOverride, relatedTarget, touchTargets, slotInClosedTree) {
   const itemInShadowTree = isNode(target) && isShadowRoot(nodeRoot(target));
   const rootOfClosedTree = isShadowRoot(target) && target.mode === "closed";
+  const previousStruct = eventImpl._path[eventImpl._path.length - 1];
+  const shadowAdjustedTarget = targetOverride === null ? previousStruct.shadowAdjustedTarget : targetOverride;
 
   eventImpl._path.push({
     item: target,
     itemInShadowTree,
     target: targetOverride,
+    shadowAdjustedTarget,
     relatedTarget,
     touchTargets,
     rootOfClosedTree,

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -299,7 +299,7 @@ function invokeEventListeners(struct, eventImpl, phase) {
 
 function updateEventTargets(eventImpl, struct) {
   eventImpl.target = struct.effectiveTarget;
-  eventImpl.relatedTarget = idlUtils.wrapperForImpl(struct.relatedTarget);
+  eventImpl.relatedTarget = struct.relatedTarget;
 }
 
 // https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke

--- a/test/web-platform-tests/to-upstream/shadow-dom/event-post-dispatch-listenerless.html
+++ b/test/web-platform-tests/to-upstream/shadow-dom/event-post-dispatch-listenerless.html
@@ -45,4 +45,31 @@ test(t => {
   assert_equals(event.target, host, "target is retargeted to the host");
   assert_equals(event.relatedTarget, relatedTarget, "relatedTarget retains its final retargeted value");
 }, "relatedTarget is preserved after listenerless dispatch");
+
+test(t => {
+  const { host: firstHost, target: firstTarget } = createShadowTree();
+  const { host: secondHost, target: secondTarget } = createShadowTree();
+  const reachedTargets = [];
+  function recordCurrentTarget(event) {
+    reachedTargets.push(event.currentTarget);
+  }
+  t.add_cleanup(() => {
+    firstHost.remove();
+    secondHost.remove();
+    document.removeEventListener("test", recordCurrentTarget);
+  });
+
+  const event = new MouseEvent("test", { bubbles: true, composed: true, relatedTarget: secondTarget });
+  firstTarget.dispatchEvent(event);
+  assert_equals(event.relatedTarget, secondHost, "relatedTarget is initially retargeted to the second host");
+
+  secondTarget.addEventListener("test", recordCurrentTarget);
+  secondHost.addEventListener("test", recordCurrentTarget);
+  document.addEventListener("test", recordCurrentTarget);
+  secondTarget.dispatchEvent(event);
+
+  assert_array_equals(reachedTargets, [secondTarget], "redispatched event stops before its relatedTarget");
+  assert_equals(event.target, null, "shadow-tree target is cleared after redispatch");
+  assert_equals(event.relatedTarget, null, "relatedTarget is cleared with the shadow-tree target");
+}, "relatedTarget remains retargetable after listenerless dispatch");
 </script>

--- a/test/web-platform-tests/to-upstream/shadow-dom/event-post-dispatch-listenerless.html
+++ b/test/web-platform-tests/to-upstream/shadow-dom/event-post-dispatch-listenerless.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event properties after listenerless shadow DOM dispatch</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-event-dispatch">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+function createShadowTree() {
+  const host = document.createElement("div");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  const target = document.createElement("div");
+  shadowRoot.append(target);
+  document.body.append(host);
+  return { host, target };
+}
+
+test(t => {
+  const { host, target } = createShadowTree();
+  t.add_cleanup(() => host.remove());
+
+  const event = new Event("test", { bubbles: false, composed: true });
+  target.dispatchEvent(event);
+
+  assert_equals(event.target, host, "target is retargeted to the host");
+  assert_equals(event.currentTarget, null, "currentTarget is cleared");
+  assert_equals(event.eventPhase, Event.NONE, "eventPhase is reset");
+}, "Non-bubbling composed event is retargeted after listenerless dispatch");
+
+test(t => {
+  const { host, target } = createShadowTree();
+  const relatedTarget = document.createElement("div");
+  document.body.append(relatedTarget);
+  t.add_cleanup(() => {
+    host.remove();
+    relatedTarget.remove();
+  });
+
+  const event = new MouseEvent("test", { bubbles: true, composed: true, relatedTarget });
+  target.dispatchEvent(event);
+
+  assert_equals(event.target, host, "target is retargeted to the host");
+  assert_equals(event.relatedTarget, relatedTarget, "relatedTarget retains its final retargeted value");
+}, "relatedTarget is preserved after listenerless dispatch");
+</script>


### PR DESCRIPTION
When jsdom dispatches an event, it builds a path from the target up through its ancestors. Today, every stop on that path searches backward through the same path to work out what `event.target` should be. It also prepares to call listeners even when that element has no listener for the event.

That makes events on deeply nested elements do more work than they need to:

```html
<div>
  <!-- many nested elements -->
  <button>Save</button>
</div>
```

```js
fireEvent.click(screen.getByRole("button", { name: "Save" }));
```

This change records the correct target for each entry while building the event path. Dispatch can then use that value directly and skip the listener work when there is no matching listener.

This only changes how jsdom finds the target internally. The target seen by listeners and the final state of the event still match the DOM Standard and browser behavior, including events dispatched from shadow DOM with no listeners.

## Three-run median

| Depth | Listeners | `main` | PR | Change |
|---:|---|---:|---:|---:|
| 10 | none | 228,571 ops/s | 311,721 ops/s | 1.36x |
| 10 | root only | 218,198 ops/s | 282,326 ops/s | 1.29x |
| 10 | every element | 171,438 ops/s | 191,975 ops/s | 1.12x |
| 50 | none | 23,415 ops/s | 30,927 ops/s | 1.32x |
| 50 | root only | 22,727 ops/s | 29,740 ops/s | 1.31x |
| 50 | every element | 20,185 ops/s | 23,392 ops/s | 1.16x |
| 100 | none | 6,740 ops/s | 8,596 ops/s | 1.28x |
| 100 | root only | 6,749 ops/s | 8,553 ops/s | 1.27x |
| 100 | every element | 6,219 ops/s | 7,173 ops/s | 1.15x |
