### PR TITLE
Fix EventTarget implementation object handling

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -172,7 +172,7 @@ class EventTargetImpl {
 
         if (
           (isNode(parent) && isShadowInclusiveAncestor(nodeRoot(targetImpl), parent)) ||
-          idlUtils.wrapperForImpl(parent).constructor.name === "Window"
+          isWindow(parent)
         ) {
           if (isActivationEvent && eventImpl.bubbles && activationTarget === null &&
               parent._hasActivationBehavior) {
@@ -307,7 +307,6 @@ function innerInvokeEventListeners(eventImpl, listeners, phase, itemInShadowTree
   let found = false;
 
   const { type, target } = eventImpl;
-  const wrapper = idlUtils.wrapperForImpl(target);
 
   if (!listeners || !listeners[type]) {
     return found;
@@ -338,17 +337,7 @@ function innerInvokeEventListeners(eventImpl, listeners, phase, itemInShadowTree
       listeners[type].splice(listeners[type].indexOf(listener), 1);
     }
 
-    let window = null;
-    if (wrapper && wrapper._document) {
-      // Triggered by Window
-      window = wrapper;
-    } else if (target._ownerDocument) {
-      // Triggered by most webidl2js'ed instances
-      window = target._ownerDocument._defaultView;
-    } else if (wrapper._ownerDocument) {
-      // Currently triggered by some non-webidl2js things
-      window = wrapper._ownerDocument._defaultView;
-    }
+    const window = target._globalObject;
 
     let currentEvent;
     if (window) {
@@ -418,8 +407,14 @@ function defaultPassiveValue(type, eventTarget) {
     case "touchmove":
     case "wheel":
     case "mousewheel":
-      return isWindow(eventTarget) ||
-        eventTarget._ownerDocument === eventTarget ||
+      if (isWindow(eventTarget)) {
+        return true;
+      }
+      if (!isNode(eventTarget)) {
+        return false;
+      }
+
+      return eventTarget._ownerDocument === eventTarget ||
         eventTarget._ownerDocument.documentElement === eventTarget ||
         eventTarget._ownerDocument.body === eventTarget;
     default:

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1017,7 +1017,6 @@ EventTarget-dispatchEvent.html:
 event-global-extra.window.html: [fail, We're supposed to check the event listener's global (not the Event's global)]
 event-global-is-still-set-when-coercing-beforeunload-result.html: [fail-slow, unknown iframe issue]
 event-global-is-still-set-when-reporting-exception-onerror.html: [fail, unknown iframe issue]
-event-global-set-before-handleEvent-lookup.window.html: [fail, unknown iframe issue]
 mouse-event-retarget.html: [fail, Requires a layout engine]
 relatedTarget.window.html: [fail, Unknown]
 scrolling/save-iframe-scroll-offset-when-display-none.html: [timeout, Unknown]

--- a/test/web-platform-tests/to-upstream/dom/events/EventTarget-window-constructor.html
+++ b/test/web-platform-tests/to-upstream/dom/events/EventTarget-window-constructor.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event dispatch with a modified Window constructor property</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-event-dispatch">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+test(t => {
+  const eventType = "window-constructor-test";
+  let targetSeenByWindowListener;
+  function listener(event) {
+    targetSeenByWindowListener = event.target;
+  }
+  function NotWindow() {}
+  window.addEventListener(eventType, listener);
+  t.add_cleanup(() => window.removeEventListener(eventType, listener));
+
+  const ownConstructorDescriptor = Object.getOwnPropertyDescriptor(window, "constructor");
+  try {
+    Object.defineProperty(window, "constructor", {
+      configurable: true,
+      writable: true,
+      value: NotWindow
+    });
+    document.body.dispatchEvent(new Event(eventType, { bubbles: true }));
+  } finally {
+    if (ownConstructorDescriptor === undefined) {
+      delete window.constructor;
+    } else {
+      Object.defineProperty(window, "constructor", ownConstructorDescriptor);
+    }
+  }
+
+  assert_equals(targetSeenByWindowListener, document.body);
+}, "Modifying window.constructor does not affect event dispatch");
+</script>

--- a/test/web-platform-tests/to-upstream/dom/events/event-global-event-targets.html
+++ b/test/web-platform-tests/to-upstream/dom/events/event-global-event-targets.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>window.event for non-Node event targets</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+const eventTargets = {
+  EventTarget: () => new EventTarget(),
+  AbortSignal: () => new AbortController().signal,
+  FileReader: () => new FileReader(),
+  Performance: () => performance
+};
+
+for (const [name, createEventTarget] of Object.entries(eventTargets)) {
+  test(t => {
+    const eventTarget = createEventTarget();
+    const event = new Event("test");
+    let currentEvent;
+    function listener() {
+      currentEvent = window.event;
+    }
+    eventTarget.addEventListener("test", listener);
+    t.add_cleanup(() => eventTarget.removeEventListener("test", listener));
+
+    eventTarget.dispatchEvent(event);
+
+    assert_equals(currentEvent, event, "window.event is set during dispatch");
+    assert_equals(window.event, undefined, "window.event is restored after dispatch");
+  }, `window.event is set when dispatching on ${name}`);
+}
+
+test(t => {
+  const eventTarget = document.createElement("div");
+  eventTarget._document = document;
+  t.add_cleanup(() => {
+    delete eventTarget._document;
+  });
+
+  const event = new Event("test");
+  let currentEvent;
+  eventTarget.addEventListener("test", () => {
+    currentEvent = window.event;
+  });
+
+  eventTarget.dispatchEvent(event);
+
+  assert_equals(currentEvent, event);
+}, "An event target's _document property does not affect window.event");
+</script>

--- a/test/web-platform-tests/to-upstream/dom/events/passive-by-default-non-node.html
+++ b/test/web-platform-tests/to-upstream/dom/events/passive-by-default-non-node.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Default passive event listeners on non-Node event targets</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#default-passive-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+const eventTargets = {
+  EventTarget: () => new EventTarget(),
+  Performance: () => performance
+};
+
+for (const [name, createEventTarget] of Object.entries(eventTargets)) {
+  test(t => {
+    const eventTarget = createEventTarget();
+    function listener(event) {
+      event.preventDefault();
+    }
+    eventTarget.addEventListener("wheel", listener);
+    t.add_cleanup(() => eventTarget.removeEventListener("wheel", listener));
+
+    const event = new Event("wheel", { cancelable: true });
+    const returnValue = eventTarget.dispatchEvent(event);
+
+    assert_true(event.defaultPrevented);
+    assert_false(returnValue);
+  }, `wheel listeners on ${name} are not passive by default`);
+}
+</script>


### PR DESCRIPTION
Use consistent implementation-side globals and type checks during event dispatch, fixing mutable wrapper properties, `window.event` on non-Node targets, and passive defaults while adding upstream-ready regression coverage.