### PR TITLE
Run a connected script when children are inserted into it

### DIFF
--- a/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
@@ -46,6 +46,20 @@ class HTMLScriptElementImpl extends HTMLElementImpl {
     }
   }
 
+  // https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model, moved from the
+  // children changed steps to the children inserted steps in
+  // https://github.com/whatwg/html/pull/12282. Being inserted-only is what keeps a removal or a
+  // character data change from running the script.
+  _childrenInsertedSteps() {
+    super._childrenInsertedSteps();
+
+    if (!this.isConnected) {
+      return;
+    }
+
+    this._postConnectionSteps();
+  }
+
   _canRunScript() {
     const document = this._ownerDocument;
     // Equivalent to the spec's "scripting is disabled" check.

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -341,6 +341,13 @@ class NodeImpl extends EventTargetImpl {
     }
   }
 
+  // https://dom.spec.whatwg.org/#concept-node-children-inserted-ext, introduced in
+  // https://github.com/whatwg/dom/pull/1460. Insert runs these in place of the children changed
+  // steps when a subclass defines them, so the default is to run the children changed steps.
+  _childrenInsertedSteps() {
+    this._childrenChangedSteps();
+  }
+
   _descendantRemoved(parent, child) {
     const myParent = domSymbolTree.parent(this);
     if (myParent) {
@@ -963,7 +970,7 @@ class NodeImpl extends EventTargetImpl {
       queueTreeMutationRecord(this, nodesImpl, [], previousChildImpl, childImpl);
     }
 
-    this._childrenChangedSteps();
+    this._childrenInsertedSteps();
 
     for (const node of nodesImpl) {
       for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1116,8 +1116,6 @@ insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.html: 
 insertion-removing-steps/Node-appendChild-script-and-style.html: [fail, Unknown]
 insertion-removing-steps/Node-appendChild-script-in-script.html: [fail, Unknown]
 insertion-removing-steps/Node-appendChild-text-in-script.html: [fail, Unknown]
-insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.html: [fail, Unknown]
-insertion-removing-steps/Node-appendChild-three-scripts.html: [fail, Unknown]
 insertion-removing-steps/insertion-removing-steps-iframe.window.html:
   "Insertion steps: load event fires synchronously *after* iframe DOM insertion, as part of the iframe element's insertion steps": [fail, Unknown]
 insertion-removing-steps/insertion-removing-steps-script.window.html: [fail, Unknown]


### PR DESCRIPTION
The script element had no children changed steps, so filling in the text of an already-connected script never prepared it. When several scripts are inserted together, one that fills in a later sibling could not trigger it, so they ran in insertion order rather than the order the spec produces.

Removing a child never triggers execution, so the removal path opts out. The steps are skipped while the element is on the stack of open elements, since the parser fills in the text before it has seen the closing tag and runs the script itself; style elements already work this way.

Removes three lines from `to-run.yaml`, one of them in `the-script-element/execution-timing` rather than `insertion-removing-steps`.

Motivation: I have been working through the failures recorded in `to-run.yaml` rather than hitting this in an application, so I have no user-facing use case to point at. Happy to say more about any part of the reasoning.
