### PR TITLE
Drop memoized queries when a node changes document

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -1028,6 +1028,10 @@ class DocumentImpl extends NodeImpl {
     if (oldDocument !== newDocument) {
       for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {
         inclusiveDescendant._ownerDocument = newDocument;
+
+        // Collections built before the move captured the old document's HTML-ness, and the spec
+        // keeps those working. A fresh call has to see the new document, so drop the memoized ones.
+        inclusiveDescendant._memoizedQueries = {};
       }
 
       for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -1031,7 +1031,9 @@ class DocumentImpl extends NodeImpl {
 
         // Collections built before the move captured the old document's HTML-ness, and the spec
         // keeps those working. A fresh call has to see the new document, so drop the memoized ones.
-        inclusiveDescendant._memoizedQueries = {};
+        // Not _clearMemoizedQueries(), which walks up to the ancestors: it is this subtree that
+        // changed document, and the old parent's collections are unaffected by the move.
+        inclusiveDescendant._memoizedQueries = Object.create(null);
       }
 
       for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -125,7 +125,7 @@ class NodeImpl extends EventTargetImpl {
     this._childrenList = null;
     this._version = 0;
     this._cachedRoot = null;
-    this._memoizedQueries = {};
+    this._memoizedQueries = Object.create(null);
     this._registeredObserverList = [];
     this._referencedRanges = new Set(); // Set of WeakRef<Range>
   }
@@ -251,7 +251,7 @@ class NodeImpl extends EventTargetImpl {
   }
 
   _clearMemoizedQueries() {
-    this._memoizedQueries = {};
+    this._memoizedQueries = Object.create(null);
     const myParent = domSymbolTree.parent(this);
     if (myParent) {
       myParent._clearMemoizedQueries();

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -1057,7 +1057,6 @@ Document-createEvent.https.html:
   "createEvent('TEXTEVENT') should be initialized correctly.": [fail, Interface not implemented]
 Element-firstElementChild-entity-xhtml.xhtml: [fail, Unknown]
 Element-firstElementChild-entity.svg: [fail, Unknown]
-Element-getElementsByTagName-change-document-HTMLNess.html: [fail, Unknown]
 MutationObserver-cross-realm-callback-report-exception.html: [fail, No relevant realm support for callbacks in webidl2js]
 MutationObserver-document.html: [fail, Usage of external scripts doesn't block HTML parsing, https://github.com/jsdom/jsdom/issues/2413]
 Node-cloneNode-document-allow-declarative-shadow-roots.window.html: [fail, Unknown]


### PR DESCRIPTION
`getElementsByTagName` bakes the document's HTML-ness into the collection it returns, and per the spec a collection that already exists keeps behaving that way after its root moves to a document of the other kind. A *new* call has to reflect the new document, but the memoized collection was handed back instead, so it kept lowercasing.

Adoption now drops the memoized queries on the nodes it moves. Collections already handed out are untouched, which is what `Element-getElementsByTagName-change-document-HTMLNess.html` checks.

Note this touches the same loop in `_adoptNode` as #4245, so whichever lands second will need a trivial rebase.

Motivation: still working through the failures recorded in `to-run.yaml` rather than hitting this in an application.
