### PR TITLE
Absolutize lengths inside math functions containing percentages - close #4224

### DIFF
--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -478,6 +478,18 @@ class CSSStyleDeclarationImpl {
       if (typeof resolvedValue === "number" && !Number.isNaN(resolvedValue)) {
         return `${Number(resolvedValue.toPrecision(6))}px`;
       }
+      // A percentage prevents the math function from being fully reduced, e.g.
+      // width: calc(100% - 1rem) computes to calc(100% - 16px). Only serialize the partially
+      // reduced string when the math function is the whole value, because reducing it
+      // lowercases the value, which would destroy case-sensitive tokens surrounding it, e.g.
+      // the line names in grid-template-rows: [Foo] minmax(1rem, calc(100% - 2rem)) [Bar].
+      if (
+        typeof resolvedValue === "string" && resolvedValue &&
+        Array.isArray(parsedValue) && parsedValue.length === 1 &&
+        parsedValue[0].type === cssValues.AST_TYPES.CALC
+      ) {
+        return resolvedValue;
+      }
     }
 
     // TODO: Resolve special cases other than color.

--- a/lib/jsdom/living/css/helpers/font-sizes.js
+++ b/lib/jsdom/living/css/helpers/font-sizes.js
@@ -5,6 +5,7 @@ const cssValues = require("./css-values");
 
 const FONT_SIZE_REGEXP = /^((?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?)(%|[a-z]+)$/;
 const LENGTH_REGEXP = /^([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?)(%|[a-z]*)$/;
+const PERCENTAGE_REGEXP = /([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?)%/g;
 
 // Absolute font size mapping table.
 const absoluteFontSize = new Map([
@@ -89,6 +90,16 @@ function resolveFontSizeInPixels(elementImpl, size, root, parent) {
   return Number.NaN;
 }
 
+// Replaces the percentages in a font-size math function with their pixel equivalent.
+// Percentages in font-size are relative to the parent's font size, which is the em unit here.
+function replaceFontSizePercentages(size, em) {
+  if (cssValues.hasVarFunc(size)) {
+    return size;
+  }
+  const pxSize = em ?? absoluteFontSize.get("medium").px;
+  return size.replace(PERCENTAGE_REGEXP, (_, value) => `${value * relativeLength.get("%") * pxSize}px`);
+}
+
 function resolveLengthInPixels(elementImpl, size, dimension, isFontSize) {
   const { em, rem, vh, vw } = dimension;
   if (absoluteFontSize.has(size)) {
@@ -96,27 +107,33 @@ function resolveLengthInPixels(elementImpl, size, dimension, isFontSize) {
   } else if (relativeFontSize.has(size)) {
     return relativeFontSize.get(size) * em;
   } else if (cssValues.hasCalcFunc(size)) {
-    let resolvedSize;
+    let calcDimension = dimension;
     if (elementImpl === elementImpl._ownerDocument.documentElement) {
-      resolvedSize = cssValues.resolveCalc(size, {
-        dimension: {
-          em: absoluteFontSize.get("medium").px,
-          rem: absoluteFontSize.get("medium").px,
-          vh: elementImpl._globalObject.innerHeight / 100,
-          vw: elementImpl._globalObject.innerWidth / 100
-        },
-        format: "computedValue"
-      });
-    } else {
-      resolvedSize = cssValues.resolveCalc(size, {
-        dimension,
-        format: "computedValue"
-      });
+      calcDimension = {
+        em: absoluteFontSize.get("medium").px,
+        rem: absoluteFontSize.get("medium").px,
+        vh: elementImpl._globalObject.innerHeight / 100,
+        vw: elementImpl._globalObject.innerWidth / 100
+      };
     }
+    // Percentages in font-size resolve against the parent's font size at computed-value time,
+    // so substitute them before reducing the math function.
+    const sizeToResolve = isFontSize ? replaceFontSizePercentages(size, calcDimension.em) : size;
+    const resolvedSize = cssValues.resolveCalc(sizeToResolve, {
+      dimension: calcDimension,
+      format: "computedValue"
+    });
     const matchLength = LENGTH_REGEXP.exec(resolvedSize);
     if (matchLength) {
       const [, value] = matchLength;
       return Number(value);
+    }
+
+    // A percentage of something other than a font size prevents full reduction, e.g.
+    // width: calc(100% - 1rem) resolves to calc(100% - 16px). The lengths within the math
+    // function are still absolutized at computed-value time.
+    if (typeof resolvedSize === "string" && resolvedSize) {
+      return resolvedSize;
     }
 
     // Return as-is as a fallback.

--- a/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-math-function-percentage.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-math-function-percentage.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>getComputedStyle() returns computed values for math functions containing percentages</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-computed-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- regression test for https://github.com/jsdom/jsdom/issues/4224 -->
+
+<div id="target" style="display: none; font-size: 20px">
+  <div id="child"></div>
+</div>
+
+<script>
+"use strict";
+
+// display: none keeps layout out of the picture, so getComputedStyle() returns the computed
+// value rather than a used value. Lengths inside math functions absolutize at computed-value
+// time; only the percentage has to remain for layout.
+const cases = [
+  ["width", "calc(100% - 1rem)", "calc(100% - 16px)"],
+  ["width", "calc(100% - 1em)", "calc(100% - 20px)"],
+  ["margin-left", "calc(50% - 0.5rem)", "calc(50% - 8px)"],
+  ["width", "min(20rem, 100%)", "min(320px, 100%)"],
+  ["width", "max(20rem, 100%)", "max(320px, 100%)"],
+  ["width", "clamp(10rem, 50%, 20rem)", "clamp(160px, 50%, 320px)"],
+  ["width", "calc(2rem + 8px)", "40px"],
+  ["width", "50%", "50%"]
+];
+
+for (const [property, specified, computed] of cases) {
+  test(() => {
+    const div = document.getElementById("target");
+    div.style.setProperty(property, specified);
+    const res = window.getComputedStyle(div).getPropertyValue(property);
+    div.style.removeProperty(property);
+    assert_equals(res, computed);
+  }, `getComputedStyle() returns computed value for ${property}: ${specified}`);
+}
+
+// Percentages in font-size are relative to the parent's font size and resolve at
+// computed-value time, so they must not survive into the computed value.
+const fontSizeCases = [
+  ["calc(100% + 20px)", "40px"],
+  ["max(1rem, 150%)", "30px"],
+  ["calc(50% + 1rem)", "26px"]
+];
+
+for (const [specified, computed] of fontSizeCases) {
+  test(() => {
+    const div = document.getElementById("child");
+    div.style.fontSize = specified;
+    const res = window.getComputedStyle(div).fontSize;
+    div.style.removeProperty("font-size");
+    assert_equals(res, computed);
+  }, `getComputedStyle() returns computed value for font-size: ${specified}`);
+}
+
+test(() => {
+  const div = document.getElementById("target");
+  div.style.gridTemplateRows = "[Foo] minmax(1rem, calc(100% - 2rem)) [Bar]";
+  const res = window.getComputedStyle(div).gridTemplateRows;
+  div.style.removeProperty("grid-template-rows");
+  // Line names are <custom-ident>s, so their case survives computed-value time, whether or
+  // not the lengths inside the math function have been absolutized.
+  assert_true(res.startsWith("[Foo] "), `"${res}" starts with the [Foo] line name`);
+  assert_true(res.endsWith(" [Bar]"), `"${res}" ends with the [Bar] line name`);
+}, "getComputedStyle() preserves the case of line names around a math function");
+</script>


### PR DESCRIPTION
getComputedStyle() left math functions entirely unresolved whenever a percentage prevented full reduction, so font-relative units survived into the computed value. Lengths absolutize at computed-value time; only the percentage has to remain for layout, e.g. calc(100% - 1rem) now computes to calc(100% - 16px).

Fixes #4224.