### PR TITLE
perf(css): Avoid unused getComputedStyle() calculations

### DIFF
--- a/benchmark/style/get-computed-style-property-access.js
+++ b/benchmark/style/get-computed-style-property-access.js
@@ -5,6 +5,7 @@ const documentBench = require("../document-bench");
 // properties via getPropertyValue after getComputedStyle.
 
 const FEW_PROPERTIES = ["color", "display", "visibility", "opacity"];
+const NON_COLOR_OR_LENGTH_PROPERTIES = ["display", "visibility", "opacity", "position"];
 const MANY_PROPERTIES = [
   "color", "display", "visibility", "opacity",
   "background-color", "font-size", "font-weight", "font-style",
@@ -29,6 +30,13 @@ module.exports = () => {
   bench.add("few properties (4)", () => {
     const cs = window.getComputedStyle(document.body.firstChild);
     for (const prop of FEW_PROPERTIES) {
+      cs.getPropertyValue(prop);
+    }
+  });
+
+  bench.add("without color or length context (4)", () => {
+    const cs = window.getComputedStyle(document.body.firstChild);
+    for (const prop of NON_COLOR_OR_LENGTH_PROPERTIES) {
       cs.getPropertyValue(prop);
     }
   });

--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -421,7 +421,14 @@ class CSSStyleDeclarationImpl {
   }
 
   #resolveLonghand(property, value, { caseSensitive, dimensionTypes, isColor }) {
-    const options = this.#prepareComputedValueOpts();
+    const { length: lengthType } = dimensionTypes;
+    let options = { format: "computedValue" };
+
+    // Color and dimension options resolve inherited styles, so only prepare them when needed.
+    if (isColor || lengthType) {
+      options = this.#prepareComputedValueOpts();
+    }
+
     const parsedValue = cssValues.parsePropertyValue(property, value, {
       caseSensitive,
       ...options
@@ -432,30 +439,28 @@ class CSSStyleDeclarationImpl {
       if (resolvedValue) {
         return resolvedValue;
       }
-    } else if (dimensionTypes) {
-      const { length: lengthType } = dimensionTypes;
-      if (lengthType) {
-        const isFontSize = property === "font-size";
-        const dimension =
-          this.#ownerNode !== this.#ownerNode._ownerDocument.documentElement &&
-          options.dimension ?
-            { ...options.dimension } :
-            {};
-        // Use the element's own font-size for em units if the property is not "font-size".
-        if (!isFontSize) {
-          const ownFontSize = this.getPropertyValue("font-size");
-          if (ownFontSize) {
-            const parsedOwnFontSize = parseFloat(ownFontSize);
-            if (!Number.isNaN(parsedOwnFontSize)) {
-              dimension.em = parsedOwnFontSize;
-            }
+    } else if (lengthType) {
+      const isFontSize = property === "font-size";
+      const { documentElement } = this.#ownerNode._ownerDocument;
+      const dimension = {};
+      if (this.#ownerNode !== documentElement) {
+        Object.assign(dimension, options.dimension);
+      }
+
+      // Use the element's own font-size for em units if the property is not "font-size".
+      if (!isFontSize) {
+        const ownFontSize = this.getPropertyValue("font-size");
+        if (ownFontSize) {
+          const parsedOwnFontSize = parseFloat(ownFontSize);
+          if (!Number.isNaN(parsedOwnFontSize)) {
+            dimension.em = parsedOwnFontSize;
           }
         }
-        const resolvedValue =
-          fontSizes.resolveLengthInPixels(this.#ownerNode, value, dimension, isFontSize);
-        if (typeof resolvedValue === "number" && !Number.isNaN(resolvedValue)) {
-          return `${Number(resolvedValue.toPrecision(6))}px`;
-        }
+      }
+      const resolvedValue =
+        fontSizes.resolveLengthInPixels(this.#ownerNode, value, dimension, isFontSize);
+      if (typeof resolvedValue === "number" && !Number.isNaN(resolvedValue)) {
+        return `${Number(resolvedValue.toPrecision(6))}px`;
       }
     }
 


### PR DESCRIPTION
`getComputedStyle()` currently calculates inherited color and font-size values for every property, even when reading something unrelated like `visibility`.

Only prepare that context for color and length properties. Everything still goes through `parsePropertyValue()` with `format: "computedValue"`.

Local benchmark reading `display`, `visibility`, `opacity`, and `position`:

| Before | After | Speedup |
|---:|---:|---:|
| 186k ops/s | 224k ops/s | 1.21x |