### PR TITLE
perf(dom): Avoid unnecessary classList creation

### DIFF
--- a/benchmark/dom/get-elements-by-class-name.js
+++ b/benchmark/dom/get-elements-by-class-name.js
@@ -1,0 +1,58 @@
+"use strict";
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+module.exports = () => {
+  // Setting time to zero keeps fixture setup for the first-read cases from making the suite excessively slow.
+  const bench = new Bench({ time: 0, warmupTime: 0 });
+
+  function createElements(document, count, classEvery, attributeCount = 0) {
+    const root = document.createElement("main");
+    const fragment = document.createDocumentFragment();
+
+    for (let i = 0; i < count; ++i) {
+      const element = document.createElement("div");
+      if (classEvery !== 0 && i % classEvery === 0) {
+        element.className = "item target";
+      }
+      for (let j = 0; j < attributeCount; ++j) {
+        element.setAttribute(`data-${j}`, `${j}`);
+      }
+      fragment.append(element);
+    }
+
+    root.append(fragment);
+    return root;
+  }
+
+  function addFirstReadTask(name, classEvery) {
+    const { document } = (new JSDOM()).window;
+    let root;
+
+    bench.add(name, () => root.getElementsByClassName("target").length, {
+      beforeEach() {
+        root = createElements(document, 1000, classEvery);
+      }
+    });
+  }
+
+  function addLiveRefreshTask(name, classEvery, attributeCount = 0) {
+    const { document } = (new JSDOM()).window;
+    const root = createElements(document, 5000, classEvery, attributeCount);
+    const collection = root.getElementsByClassName("target");
+    collection.item(0);
+
+    bench.add(name, () => {
+      root.toggleAttribute("data-mutated");
+      return collection.length;
+    });
+  }
+
+  addFirstReadTask("first read: 0/1000 elements have classes", 0);
+  addFirstReadTask("first read: 100/1000 elements have classes", 10);
+  addFirstReadTask("first read: 1000/1000 elements have classes", 1);
+  addLiveRefreshTask("live refresh: 500/5000 elements have classes", 10);
+  addLiveRefreshTask("live refresh: 0/5000 elements have classes and 10 other attributes", 0, 10);
+
+  return bench;
+};

--- a/lib/jsdom/living/node.js
+++ b/lib/jsdom/living/node.js
@@ -1,5 +1,5 @@
 "use strict";
-const { appendAttribute } = require("./attributes");
+const { appendAttribute, hasAttributeByName } = require("./attributes");
 const NODE_TYPE = require("./node-type");
 
 const orderedSetParse = require("./helpers/ordered-set").parse;
@@ -106,7 +106,14 @@ exports.listOfElementsWithClassNames = (classNames, root) => {
           return false;
         }
 
-        const { classList } = node;
+        let classList = node._classList;
+        if (classList === undefined) {
+          // Avoid creating and retaining a DOMTokenList for elements that cannot match.
+          if (!hasAttributeByName(node, "class")) {
+            return false;
+          }
+          classList = node.classList;
+        }
         if (isQuirksMode) {
           for (const className of classes) {
             if (!classList.tokenSet.some(cur => asciiCaseInsensitiveMatch(cur, className))) {


### PR DESCRIPTION
While profiling class-name queries over large rendered trees, I found that `getElementsByClassName()` accesses `classList` on every descendant. This creates and retains a `DOMTokenList` even for elements without a `class` attribute.

Skip that work when the attribute-name cache proves an element cannot match. Existing `classList` instances and class-bearing elements continue through the current `DOMTokenList` matching path.

On the sparse first-read case below, this reduces materialized `classList`s from 1,000 to 100. Seven-run median:

| Case | `main` | PR | Change |
| --- | ---: | ---: | ---: |
| First read, no classes | 0.196 ms | 0.041 ms | 4.77x faster |
| First read, 10% classes | 0.214 ms | 0.081 ms | 2.64x faster |
| First read, all classes | 0.334 ms | 0.351 ms | 5% slower |
| Live refresh, 10% classes | 0.178 ms | 0.161 ms | 1.11x faster |
| Live refresh, no classes and 10 other attributes | 0.198 ms | 0.184 ms | 1.08x faster |