### PR TITLE
Stop retaining nodes after MutationObserver.disconnect()

### DIFF
--- a/lib/jsdom/living/helpers/iterable-weak-list.js
+++ b/lib/jsdom/living/helpers/iterable-weak-list.js
@@ -1,0 +1,27 @@
+"use strict";
+
+module.exports = class IterableWeakList {
+  #refs = [];
+
+  append(value) {
+    this.#refs.push(new WeakRef(value));
+  }
+
+  clear() {
+    this.#refs = [];
+  }
+
+  * [Symbol.iterator]() {
+    const liveRefs = [];
+
+    for (const ref of this.#refs) {
+      const value = ref.deref();
+      if (value !== undefined) {
+        liveRefs.push(ref);
+        yield value;
+      }
+    }
+
+    this.#refs = liveRefs;
+  }
+};

--- a/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
+++ b/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
@@ -78,6 +78,7 @@ class MutationObserverImpl {
     }
 
     this._recordQueue = [];
+    this._nodeList = [];
   }
 
   // https://dom.spec.whatwg.org/#dom-mutationobserver-takerecords

--- a/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
+++ b/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { wrapperForImpl } = require("../../../generated/idl/utils");
+const IterableWeakList = require("../helpers/iterable-weak-list");
 
 // If we were to implement the MutationObserver by spec, the MutationObservers will not be collected by the GC because
 // all the MO are kept in a mutation observer list (https://github.com/jsdom/jsdom/pull/2398/files#r238123889). The
@@ -17,7 +18,7 @@ class MutationObserverImpl {
     const [callback] = args;
 
     this._callback = callback;
-    this._nodeList = [];
+    this._nodeList = new IterableWeakList();
     this._recordQueue = [];
 
     this._id = ++mutationObserverId;
@@ -65,7 +66,7 @@ class MutationObserverImpl {
         options
       });
 
-      this._nodeList.push(target);
+      this._nodeList.append(target);
     }
   }
 
@@ -78,7 +79,7 @@ class MutationObserverImpl {
     }
 
     this._recordQueue = [];
-    this._nodeList = [];
+    this._nodeList.clear();
   }
 
   // https://dom.spec.whatwg.org/#dom-mutationobserver-takerecords

--- a/test/api/fixtures/mutation-observer-with-gc.js
+++ b/test/api/fixtures/mutation-observer-with-gc.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { setImmediate } = require("node:timers/promises");
+const { JSDOM } = require("../../..");
+
+(async () => {
+  const { window } = new JSDOM();
+  let target = window.document.createElement("div");
+
+  const targetRef = new WeakRef(target);
+  const observer = new window.MutationObserver(() => {});
+  observer.observe(target, { attributes: true });
+  target = undefined;
+
+  let collected = false;
+  for (let i = 0; i < 10; ++i) {
+    await setImmediate();
+    global.gc();
+    if (targetRef.deref() === undefined) {
+      collected = true;
+      break;
+    }
+  }
+
+  // Keep the observer reachable throughout the test.
+  assert.deepEqual(observer.takeRecords(), []);
+  console.log(collected ? "collected" : "retained");
+})();

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -2,7 +2,6 @@
 const path = require("path");
 const { spawnSync } = require("child_process");
 const assert = require("node:assert/strict");
-const { queryObjects } = require("node:v8");
 const { describe, it } = require("mocha-sugar-free");
 const { JSDOM, VirtualConsole } = require("../..");
 const delay = require("node:timers/promises").setTimeout;
@@ -74,29 +73,6 @@ describe("Test cases only possible to test from the outside", () => {
     assert.equal(status, 0, stderr);
     assert.equal(stdout.trim(), "collected");
   });
-
-  it("MutationObserver.disconnect() should release observed nodes", () => {
-    class Payload {}
-
-    function createObserver() {
-      const { window } = new JSDOM();
-      const target = window.document.createElement("div");
-      target.payload = new Payload();
-
-      const observer = new window.MutationObserver(() => {});
-      observer.observe(target, { attributes: true });
-      observer.disconnect();
-
-      return observer;
-    }
-
-    const observer = createObserver();
-
-    assert.equal(queryObjects(Payload, { format: "count" }), 0);
-    // Keep the observer alive until after the collection so only the target's lifetime is tested.
-    assert.deepEqual(observer.takeRecords(), []);
-  });
-
   it("window.close() should work from within a load event listener", async () => {
     const errors = [];
     const virtualConsole = new VirtualConsole().forwardTo(console);

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -73,6 +73,15 @@ describe("Test cases only possible to test from the outside", () => {
     assert.equal(status, 0, stderr);
     assert.equal(stdout.trim(), "collected");
   });
+
+  it("does not retain observed nodes through MutationObserver instances", { timeout: 5000 }, () => {
+    const fixturePath = path.resolve(__dirname, "./fixtures/mutation-observer-with-gc.js");
+    const { status, stderr, stdout } = spawnSync("node", ["--expose-gc", fixturePath], { encoding: "utf-8" });
+
+    assert.equal(status, 0, stderr);
+    assert.equal(stdout.trim(), "collected");
+  });
+
   it("window.close() should work from within a load event listener", async () => {
     const errors = [];
     const virtualConsole = new VirtualConsole().forwardTo(console);

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -2,6 +2,7 @@
 const path = require("path");
 const { spawnSync } = require("child_process");
 const assert = require("node:assert/strict");
+const { queryObjects } = require("node:v8");
 const { describe, it } = require("mocha-sugar-free");
 const { JSDOM, VirtualConsole } = require("../..");
 const delay = require("node:timers/promises").setTimeout;
@@ -72,6 +73,28 @@ describe("Test cases only possible to test from the outside", () => {
 
     assert.equal(status, 0, stderr);
     assert.equal(stdout.trim(), "collected");
+  });
+
+  it("MutationObserver.disconnect() should release observed nodes", () => {
+    class Payload {}
+
+    function createObserver() {
+      const { window } = new JSDOM();
+      const target = window.document.createElement("div");
+      target.payload = new Payload();
+
+      const observer = new window.MutationObserver(() => {});
+      observer.observe(target, { attributes: true });
+      observer.disconnect();
+
+      return observer;
+    }
+
+    const observer = createObserver();
+
+    assert.equal(queryObjects(Payload, { format: "count" }), 0);
+    // Keep the observer alive until after the collection so only the target's lifetime is tested.
+    assert.deepEqual(observer.takeRecords(), []);
   });
 
   it("window.close() should work from within a load event listener", async () => {


### PR DESCRIPTION
`MutationObserver`’s node list is specified to contain weak references. jsdom represents it as a strong array and currently retains every observed node after `disconnect()`.

Clear the array after removing the observer registrations which prevents keeping observed dom in memory.

Could move `MutationObserver` to use weakrefs but that would be a larger change.