### PR TITLE
Clear pending animation frame callbacks on window.close()

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -604,6 +604,9 @@ function installOwnProperties(window, options) {
   if (window._pretendToBeVisual) {
     window.requestAnimationFrame = function (callback) {
       callback = IDLFunction.convert(window, callback);
+      if (!window._document) {
+        return 0;
+      }
 
       const handle = ++animationFrameCallbackId;
       mapOfAnimationFrameCallbacks.set(handle, callback);
@@ -660,6 +663,9 @@ function installOwnProperties(window, options) {
     listOfActiveTimers.clear();
 
     clearInterval(animationFrameNodejsInterval);
+    mapOfAnimationFrameCallbacks.clear();
+    numberOfOngoingAnimationFrameCallbacks = 0;
+    animationFrameNodejsInterval = null;
   }
 
   function Option(text, value, defaultSelected, selected) {

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -25,6 +25,17 @@ describe("Test cases only possible to test from the outside", () => {
     assert.equal(ran, false);
   });
 
+  it("window.close() should prevent animation frames from registering and cause them to return 0", () => {
+    const { window } = new JSDOM("", { pretendToBeVisual: true });
+
+    window.close();
+
+    const handle = window.requestAnimationFrame(() => {});
+    window.cancelAnimationFrame(handle);
+
+    assert.equal(handle, 0);
+  });
+
   it("window.close() should stop a setInterval()", async () => {
     const { window } = new JSDOM(`<script>
       window.counter = 0;


### PR DESCRIPTION
`window.close()` stops the animation frame interval but leaves pending callbacks and related state intact. Clear that state during teardown and prevent new callbacks from being registered after the window is closed.