### PR TITLE
Use getElementById() to resolve label controls

### DIFF
--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -37,6 +37,10 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
         return null;
       }
       const root = this.getRootNode({});
+      if (root.nodeType === NODE_TYPE.DOCUMENT_NODE || root.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
+        const descendant = root.getElementById(forValue);
+        return descendant !== null && isLabelable(descendant) ? descendant : null;
+      }
       for (const descendant of domSymbolTree.treeIterator(root)) {
         if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&
           descendant.getAttributeNS(null, "id") === forValue) {


### PR DESCRIPTION
The label association cache added in #4237 still scans the full root for each `<label for>` when it rebuilds. #4237 avoids repeating that rebuild for every control; this makes the remaining shared rebuild cheaper.

Use `getElementById()` when supported so document lookups use the existing ID cache. Keep the current traversal for disconnected element-rooted trees.

`benchmark/forms/labels.js`, 100 controls and 100 labels:

| Reads after mutation | Before | After |
|---|---:|---:|
| 1 | 0.565 ms | 0.034 ms |
| 100 | 0.603 ms | 0.065 ms |

avoided any new tests or benches here because it all seemed duplicate