### PR TITLE
Fire volumechange and ratechange from a queued task

### DIFF
--- a/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
@@ -112,12 +112,17 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
     notImplementedMethod(this._ownerDocument._defaultView, "HTMLMediaElement", "addTextTrack");
   }
 
+  // The HTML Standard queues these events as media element tasks, so they must not fire synchronously.
   _dispatchRateChange() {
-    fireAnEvent("ratechange", this);
+    setImmediate(() => {
+      fireAnEvent("ratechange", this);
+    });
   }
 
   _dispatchVolumeChange() {
-    fireAnEvent("volumechange", this);
+    setImmediate(() => {
+      fireAnEvent("volumechange", this);
+    });
   }
 }
 

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/media-elements/volumechange-ratechange-queue-task.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/media-elements/volumechange-ratechange-queue-task.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>volumechange and ratechange are fired from a queued media element task</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-volume">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-muted">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-defaultplaybackrate">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+
+<script>
+"use strict";
+
+function testQueuedTask(eventName, mutate, description) {
+  promise_test(async t => {
+    const el = document.createElement("audio");
+    let fired = false;
+
+    const eventPromise = new Promise(resolve => {
+      el.addEventListener(eventName, t.step_func(() => {
+        fired = true;
+        resolve();
+      }), { once: true });
+    });
+
+    mutate(el);
+
+    assert_false(fired, `${eventName} must not fire synchronously`);
+
+    await Promise.resolve();
+
+    assert_false(fired, `${eventName} must be queued as a task, not a microtask`);
+
+    await eventPromise;
+  }, description);
+}
+
+testQueuedTask(
+  "volumechange",
+  el => {
+    el.muted = true;
+  },
+  "setting muted queues a task to fire volumechange"
+);
+
+testQueuedTask(
+  "volumechange",
+  el => {
+    el.volume = 0.5;
+  },
+  "setting volume queues a task to fire volumechange"
+);
+
+testQueuedTask(
+  "ratechange",
+  el => {
+    el.playbackRate = 2;
+  },
+  "setting playbackRate queues a task to fire ratechange"
+);
+
+testQueuedTask(
+  "ratechange",
+  el => {
+    el.defaultPlaybackRate = 2;
+  },
+  "setting defaultPlaybackRate queues a task to fire ratechange"
+);
+</script>


### PR DESCRIPTION
Setting `volume`, `muted`, `playbackRate`, or `defaultPlaybackRate` fires the event synchronously from inside the setter. The HTML Standard queues all four as media element tasks, so the event should not be observable before the assignment returns.

I hit this in a React 17 test suite, where setting `muted` on a `<video>` fired `volumechange` mid-commit and produced an `unstable_flushDiscreteUpdates` warning. The workaround that circulates for it is stubbing the `muted` setter on `HTMLMediaElement.prototype`, which disables `muted` for the whole suite.

`setImmediate` follows how `FileReader` already queues its tasks. `window.setTimeout` would additionally be cleared by `stopAllTimers()` on close, but it would not model `load()` removing pending tasks from the element's own task source, and it would make an internal operation depend on a script-facing API.

Upstream `event_volumechange.html` already covers the `volumechange` side, but jsdom does not currently run that test and there is no equivalent coverage for `ratechange`. The test added here focuses on the four modified setter paths and distinguishes synchronous dispatch from microtask dispatch. Full media element task-source semantics, including `load()` canceling pending tasks, require a per-element task source and are out of scope for this change.