### PR TITLE
Stop AbortSignal from retaining removed event listeners

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -835,7 +835,7 @@ function installOwnProperties(window, options) {
     }
 
     // Clear out all listeners. Any in-flight or upcoming events should not get delivered.
-    idlUtils.implForWrapper(window)._eventListeners = null;
+    idlUtils.implForWrapper(window)._removeAllEventListeners();
 
     if (window._document) {
       if (window._document.body) {
@@ -845,7 +845,7 @@ function installOwnProperties(window, options) {
       if (window._document.close) {
         // It's especially important to clear out the listeners here because document.close() causes a "load" event to
         // fire.
-        idlUtils.implForWrapper(window._document)._eventListeners = null;
+        idlUtils.implForWrapper(window._document)._removeAllEventListeners();
         window._document.close();
       }
       const doc = idlUtils.implForWrapper(window._document);

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -58,18 +58,21 @@ class EventTargetImpl {
       }
     }
 
-    this._eventListeners[type].push({
+    const listener = {
       callback,
       capture,
       once,
       passive,
-      signal
-    });
+      signal,
+      abortAlgorithm: null
+    };
+    this._eventListeners[type].push(listener);
 
     if (signal !== null) {
-      signal._addAlgorithm(() => {
+      listener.abortAlgorithm = () => {
         this.removeEventListener(type, callback, options);
-      });
+      };
+      signal._addAlgorithm(listener.abortAlgorithm);
     }
   }
 
@@ -92,7 +95,7 @@ class EventTargetImpl {
         listener.callback.objectReference === callback.objectReference &&
         listener.capture === capture
       ) {
-        this._eventListeners[type].splice(i, 1);
+        removeEventListenerFromList(this._eventListeners[type], listener);
         break;
       }
     }
@@ -337,7 +340,7 @@ function innerInvokeEventListeners(eventImpl, listeners, phase, itemInShadowTree
     }
 
     if (once) {
-      listeners[type].splice(listeners[type].indexOf(listener), 1);
+      removeEventListenerFromList(listeners[type], listener);
     }
 
     const window = target._globalObject;
@@ -375,6 +378,13 @@ function innerInvokeEventListeners(eventImpl, listeners, phase, itemInShadowTree
   }
 
   return found;
+}
+
+function removeEventListenerFromList(listeners, listener) {
+  listeners.splice(listeners.indexOf(listener), 1);
+  if (listener.signal !== null) {
+    listener.signal._removeAlgorithm(listener.abortAlgorithm);
+  }
 }
 
 function flattenMoreEventListenerOptions(options) {

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -58,19 +58,21 @@ class EventTargetImpl {
       }
     }
 
+    const listeners = this._eventListeners[type];
     const listener = {
       callback,
       capture,
       once,
       passive,
-      signal,
-      abortAlgorithm: null
+      signal
     };
-    this._eventListeners[type].push(listener);
+    listeners.push(listener);
 
     if (signal !== null) {
+      // The signal stores abort algorithms by identity. Keep the exact function on the listener record so removing the
+      // listener can also discard its now-redundant abort algorithm instead of retaining the record and its callback.
       listener.abortAlgorithm = () => {
-        this.removeEventListener(type, callback, options);
+        removeEventListenerFromList(listeners, listener);
       };
       signal._addAlgorithm(listener.abortAlgorithm);
     }
@@ -99,6 +101,22 @@ class EventTargetImpl {
         break;
       }
     }
+  }
+
+  // https://dom.spec.whatwg.org/#concept-event-listener-remove-all
+  _removeAllEventListeners() {
+    if (this._eventListeners === null) {
+      return;
+    }
+
+    // The listener map can be discarded at once, but signal-bound listeners also have a backlink from their signal.
+    for (const listeners of Object.values(this._eventListeners)) {
+      for (const listener of listeners) {
+        removeAbortAlgorithm(listener);
+      }
+    }
+
+    this._eventListeners = null;
   }
 
   dispatchEvent(eventImpl) {
@@ -382,7 +400,12 @@ function innerInvokeEventListeners(eventImpl, listeners, phase, itemInShadowTree
 
 function removeEventListenerFromList(listeners, listener) {
   listeners.splice(listeners.indexOf(listener), 1);
+  removeAbortAlgorithm(listener);
+}
+
+function removeAbortAlgorithm(listener) {
   if (listener.signal !== null) {
+    // This registration is going away, so aborting its signal no longer needs to remove it.
     listener.signal._removeAlgorithm(listener.abortAlgorithm);
   }
 }

--- a/lib/jsdom/living/websockets/WebSocket-impl.js
+++ b/lib/jsdom/living/websockets/WebSocket-impl.js
@@ -177,7 +177,7 @@ class WebSocketImpl extends EventTargetImpl {
   // https://websockets.spec.whatwg.org/#make-disappear
   // But with additional work from jsdom to remove all event listeners.
   _makeDisappear() {
-    this._eventListeners = null;
+    this._removeAllEventListeners();
     if (this._ws.readyState === this._ws.OPEN || this._ws.readyState === this._ws.CONNECTING) {
       // Close without a code - undici doesn't allow reserved codes like 1001
       this._ws.close();

--- a/test/api/fixtures/event-listener-signal-with-gc.js
+++ b/test/api/fixtures/event-listener-signal-with-gc.js
@@ -8,32 +8,51 @@ const { JSDOM } = require("../../..");
   const { window } = new JSDOM();
   const controller = new window.AbortController();
   let manuallyRemovedTarget = new window.EventTarget();
+  let manuallyRemovedListener = () => {};
   let onceTarget = new window.EventTarget();
+  let onceListener = () => {};
+  let closedWindowListener = () => {};
+  let closedDocument = window.document;
+  let closedDocumentListener = () => {};
 
-  const manuallyRemovedTargetRef = new WeakRef(manuallyRemovedTarget);
-  const onceTargetRef = new WeakRef(onceTarget);
-  function listener() {}
+  const references = new Map([
+    ["manually removed target", new WeakRef(manuallyRemovedTarget)],
+    ["manually removed listener", new WeakRef(manuallyRemovedListener)],
+    ["once target", new WeakRef(onceTarget)],
+    ["once listener", new WeakRef(onceListener)],
+    ["closed window listener", new WeakRef(closedWindowListener)],
+    ["closed document listener", new WeakRef(closedDocumentListener)]
+  ]);
 
-  manuallyRemovedTarget.addEventListener("test", listener, { signal: controller.signal });
-  manuallyRemovedTarget.removeEventListener("test", listener);
+  manuallyRemovedTarget.addEventListener("test", manuallyRemovedListener, { signal: controller.signal });
+  manuallyRemovedTarget.removeEventListener("test", manuallyRemovedListener);
 
-  onceTarget.addEventListener("test", listener, { once: true, signal: controller.signal });
+  onceTarget.addEventListener("test", onceListener, { once: true, signal: controller.signal });
   onceTarget.dispatchEvent(new window.Event("test"));
 
-  manuallyRemovedTarget = undefined;
-  onceTarget = undefined;
+  window.addEventListener("test", closedWindowListener, { signal: controller.signal });
+  closedDocument.addEventListener("test", closedDocumentListener, { signal: controller.signal });
+  window.close();
 
-  let collected = false;
+  manuallyRemovedTarget = undefined;
+  manuallyRemovedListener = undefined;
+  onceTarget = undefined;
+  onceListener = undefined;
+  closedWindowListener = undefined;
+  closedDocument = undefined;
+  closedDocumentListener = undefined;
+
+  let retained;
   for (let i = 0; i < 10; ++i) {
     await setImmediate();
     global.gc();
-    if (manuallyRemovedTargetRef.deref() === undefined && onceTargetRef.deref() === undefined) {
-      collected = true;
+    retained = [...references].filter(([, reference]) => reference.deref() !== undefined);
+    if (retained.length === 0) {
       break;
     }
   }
 
   // Keep the controller and its un-aborted signal reachable throughout the test.
   assert.equal(controller.signal.aborted, false);
-  console.log(collected ? "collected" : "retained");
+  console.log(retained.length === 0 ? "collected" : `retained: ${retained.map(([name]) => name).join(", ")}`);
 })();

--- a/test/api/fixtures/event-listener-signal-with-gc.js
+++ b/test/api/fixtures/event-listener-signal-with-gc.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { setImmediate } = require("node:timers/promises");
+const { JSDOM } = require("../../..");
+
+(async () => {
+  const { window } = new JSDOM();
+  const controller = new window.AbortController();
+  let manuallyRemovedTarget = new window.EventTarget();
+  let onceTarget = new window.EventTarget();
+
+  const manuallyRemovedTargetRef = new WeakRef(manuallyRemovedTarget);
+  const onceTargetRef = new WeakRef(onceTarget);
+  function listener() {}
+
+  manuallyRemovedTarget.addEventListener("test", listener, { signal: controller.signal });
+  manuallyRemovedTarget.removeEventListener("test", listener);
+
+  onceTarget.addEventListener("test", listener, { once: true, signal: controller.signal });
+  onceTarget.dispatchEvent(new window.Event("test"));
+
+  manuallyRemovedTarget = undefined;
+  onceTarget = undefined;
+
+  let collected = false;
+  for (let i = 0; i < 10; ++i) {
+    await setImmediate();
+    global.gc();
+    if (manuallyRemovedTargetRef.deref() === undefined && onceTargetRef.deref() === undefined) {
+      collected = true;
+      break;
+    }
+  }
+
+  // Keep the controller and its un-aborted signal reachable throughout the test.
+  assert.equal(controller.signal.aborted, false);
+  console.log(collected ? "collected" : "retained");
+})();

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -82,6 +82,14 @@ describe("Test cases only possible to test from the outside", () => {
     assert.equal(stdout.trim(), "collected");
   });
 
+  it("does not retain targets of removed signal-bound event listeners", { timeout: 5000 }, () => {
+    const fixturePath = path.resolve(__dirname, "./fixtures/event-listener-signal-with-gc.js");
+    const { status, stderr, stdout } = spawnSync("node", ["--expose-gc", fixturePath], { encoding: "utf-8" });
+
+    assert.equal(status, 0, stderr);
+    assert.equal(stdout.trim(), "collected");
+  });
+
   it("window.close() should work from within a load event listener", async () => {
     const errors = [];
     const virtualConsole = new VirtualConsole().forwardTo(console);

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -82,7 +82,7 @@ describe("Test cases only possible to test from the outside", () => {
     assert.equal(stdout.trim(), "collected");
   });
 
-  it("does not retain targets of removed signal-bound event listeners", { timeout: 5000 }, () => {
+  it("does not retain targets or callbacks of removed signal-bound event listeners", { timeout: 5000 }, () => {
     const fixturePath = path.resolve(__dirname, "./fixtures/event-listener-signal-with-gc.js");
     const { status, stderr, stdout } = spawnSync("node", ["--expose-gc", fixturePath], { encoding: "utf-8" });
 


### PR DESCRIPTION
Listeners added with `{ signal }` leave their abort cleanup registered after `removeEventListener()` or a `{ once: true }` listener runs. When the signal outlives those listeners, it keeps their targets and callbacks alive.

Store the cleanup on the listener record and remove both together. With 2,000 removed listeners and the signal kept alive, retained heap dropped from 41.8 MB to 0.1 MB.