### PR TITLE
Avoid unnecessary radio group root lookups

### DIFF
--- a/benchmark/forms/radio-groups.js
+++ b/benchmark/forms/radio-groups.js
@@ -1,0 +1,32 @@
+"use strict";
+const documentBench = require("../document-bench");
+
+const RADIO_COUNT = 200;
+
+module.exports = () => {
+  const { document, bench } = documentBench();
+
+  function addTask(name, groupName) {
+    const form = document.createElement("form");
+    const radios = [];
+
+    for (let i = 0; i < RADIO_COUNT; ++i) {
+      const radio = document.createElement("input");
+      radio.type = "radio";
+      radio.name = groupName(i);
+      form.append(radio);
+      radios.push(radio);
+    }
+
+    bench.add(name, () => {
+      for (const radio of radios) {
+        radio.checked = true;
+      }
+    });
+  }
+
+  addTask("check 200 radios across 100 groups", i => `group-${Math.floor(i / 2)}`);
+  addTask("check 200 radios in one group", () => "group");
+
+  return bench;
+};

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -103,6 +103,19 @@ function getTypeFromAttribute(typeAttribute) {
   return inputAllowedTypes.has(type) ? type : "text";
 }
 
+function getRadioButtonGroupRoot(input) {
+  let element = domSymbolTree.parent(input);
+  while (element) {
+    const parent = domSymbolTree.parent(element);
+    // Root node of this home subtree or the form element we belong to.
+    if (!parent || element._localName === "form") {
+      return element;
+    }
+    element = parent;
+  }
+  return null;
+}
+
 class HTMLInputElementImpl extends HTMLElementImpl {
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
@@ -291,28 +304,28 @@ class HTMLInputElementImpl extends HTMLElementImpl {
   }
 
   get _otherRadioGroupElements() {
-    const wrapper = idlUtils.wrapperForImpl(this);
-    const root = this._radioButtonGroupRoot;
-    if (!root) {
+    const name = this.getAttributeNS(null, "name");
+    if (this.type !== "radio" || !name) {
       return [];
     }
 
+    const root = getRadioButtonGroupRoot(this);
+    if (!root) {
+      return [];
+    }
     const result = [];
 
     const descendants = domSymbolTree.treeIterator(root);
     for (const candidate of descendants) {
-      if (candidate._radioButtonGroupRoot !== root) {
+      if (candidate === this || candidate._localName !== "input" || candidate.type !== "radio") {
         continue;
       }
 
-      const candidateWrapper = idlUtils.wrapperForImpl(candidate);
-      if (!candidateWrapper.name || candidateWrapper.name !== wrapper.name) {
+      if (candidate.getAttributeNS(null, "name") !== name || getRadioButtonGroupRoot(candidate) !== root) {
         continue;
       }
 
-      if (candidate !== this) {
-        result.push(candidate);
-      }
+      result.push(candidate);
     }
     return result;
   }
@@ -321,24 +334,6 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     for (const radioGroupElement of this._otherRadioGroupElements) {
       radioGroupElement._checkedness = false;
     }
-  }
-
-  get _radioButtonGroupRoot() {
-    const wrapper = idlUtils.wrapperForImpl(this);
-    if (this.type !== "radio" || !wrapper.name) {
-      return null;
-    }
-
-    let e = domSymbolTree.parent(this);
-    while (e) {
-      // root node of this home sub tree
-      // or the form element we belong to
-      if (!domSymbolTree.parent(e) || e._localName === "form") {
-        return e;
-      }
-      e = domSymbolTree.parent(e);
-    }
-    return null;
   }
 
   _someInRadioGroup(name) {


### PR DESCRIPTION
Setting `radio.checked = true` makes jsdom scan its group to clear the other radios. It currently finds every candidate's group root before checking its type and name, so radios from unrelated groups still walk their ancestors.

Check type and name first, then find the group root only for possible matches. This preserves the existing grouping behavior.

`benchmark/forms/radio-groups.js`:

| Case | `main` | PR |
| --- | ---: | ---: |
| 200 radios across 100 groups | 212 ops/s | 461 ops/s |
| 200 radios in one group | 208 ops/s | 322 ops/s |

As a downstream example, React temporarily clears and restores `name` when updating controlled radios. That repeatedly enters this group scan; five rerenders improved from 99.0 ms to 44.6 ms.
