### PR TITLE
Avoid repeated option scans while building selects

### DIFF
--- a/benchmark/forms/select.js
+++ b/benchmark/forms/select.js
@@ -1,0 +1,15 @@
+"use strict";
+const documentBench = require("../document-bench");
+
+module.exports = () => {
+  const { document, bench } = documentBench();
+
+  bench.add("append 2,000 options", () => {
+    const select = document.createElement("select");
+    for (let i = 0; i < 2000; i++) {
+      select.append(document.createElement("option"));
+    }
+  });
+
+  return bench;
+};

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -87,7 +87,17 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
 
   _descendantAdded(parent, child) {
     if (child.nodeType === NODE_TYPE.ELEMENT_NODE) {
-      this._askedForAReset();
+      let canSkipReset = false;
+      if (parent === this && child._localName === "option" && !child._selectedness) {
+        const firstChild = domSymbolTree.firstChild(this);
+        // In a non-multiple select, the selected first option is the only selected option.
+        // In a multiple select, _askedForAReset() is a no-op.
+        canSkipReset = firstChild._localName === "option" && firstChild._selectedness;
+      }
+
+      if (!canSkipReset) {
+        this._askedForAReset();
+      }
     }
 
     super._descendantAdded(parent, child);

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -89,10 +89,10 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     if (child.nodeType === NODE_TYPE.ELEMENT_NODE) {
       let canSkipReset = false;
       if (parent === this && child._localName === "option" && !child._selectedness) {
-        const firstChild = domSymbolTree.firstChild(this);
+        const { firstElementChild } = this;
         // In a non-multiple select, the selected first option is the only selected option.
         // In a multiple select, _askedForAReset() is a no-op.
-        canSkipReset = firstChild._localName === "option" && firstChild._selectedness;
+        canSkipReset = firstElementChild._localName === "option" && firstElementChild._selectedness;
       }
 
       if (!canSkipReset) {

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-selected.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-selected.html
@@ -5,7 +5,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<select id="sel"><option id="opt1" value="x" data-foo="a" selected="selected">1st opt</option>
+<select id="sel">
+  <option id="opt1" value="x" data-foo="a" selected="selected">1st opt</option>
   <option id="opt2" value="y" data-foo="b">2nd opt</option>
 </select>
 

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-selected.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-select-element/select-selectedOptions-and-selected.html
@@ -5,8 +5,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<select id="sel">
-  <option id="opt1" value="x" data-foo="a" selected="selected">1st opt</option>
+<select id="sel"><option id="opt1" value="x" data-foo="a" selected="selected">1st opt</option>
   <option id="opt2" value="y" data-foo="b">2nd opt</option>
 </select>
 


### PR DESCRIPTION
Each direct `<option>` insertion currently runs the select selectedness-setting algorithm. Once the first option is selected, later unselected options cannot change selectedness, but each insertion still scans the full options collection. This makes incremental construction quadratic.

Skip the reset when an unselected direct option is inserted after an already-selected first option. Selected options, optgroups, and other insertions continue using the full algorithm.

#3404 used cached selected-option state and was reverted in #3475. This version stores no selected-option state, and the regression test added after that revert now exercises the shortcut.

`benchmark/forms/select.js`, appending 2,000 options:

| `main` | This PR |
| ---: | ---: |
| 44.7 ms | 2.74 ms |

A 2,000-option React mount improved from 71.2 ms to 35.1 ms.