### PR TITLE
Allocate memoized query caches on first use

### DIFF
--- a/benchmark/dom/memoized-queries.js
+++ b/benchmark/dom/memoized-queries.js
@@ -1,0 +1,22 @@
+"use strict";
+const documentBench = require("../document-bench");
+
+const DEPTH = 12;
+
+module.exports = () => {
+  const { document, bench } = documentBench();
+  const root = document.createElement("div");
+  let target = root;
+
+  for (let i = 1; i < DEPTH; ++i) {
+    const child = document.createElement("div");
+    target.append(child);
+    target = child;
+  }
+
+  bench.add(`toggleAttribute(): depth ${DEPTH} without query reads`, () => {
+    target.toggleAttribute("data-mutated");
+  });
+
+  return bench;
+};

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -142,7 +142,8 @@ exports.isLabelable = node => {
 };
 
 function getLabelAssociations(root) {
-  const cached = root._memoizedQueries[labelAssociationsCache];
+  const cache = root._memoizedQueries ??= Object.create(null);
+  const cached = cache[labelAssociationsCache];
   if (cached) {
     return cached;
   }
@@ -164,7 +165,7 @@ function getLabelAssociations(root) {
     labelsByControl.set(control, labels);
   }
 
-  root._memoizedQueries[labelAssociationsCache] = labelsByControl;
+  cache[labelAssociationsCache] = labelsByControl;
   return labelsByControl;
 }
 

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -1037,9 +1037,8 @@ class DocumentImpl extends NodeImpl {
 
         // Collections built before the move captured the old document's HTML-ness, and the spec
         // keeps those working. A fresh call has to see the new document, so drop the memoized ones.
-        // Not _clearMemoizedQueries(), which walks up to the ancestors: it is this subtree that
-        // changed document, and the old parent's collections are unaffected by the move.
-        inclusiveDescendant._memoizedQueries = Object.create(null);
+        // It is this subtree that changed document; the old parent's collections are unaffected by the move.
+        inclusiveDescendant._memoizedQueries = null;
       }
 
       for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -125,7 +125,7 @@ class NodeImpl extends EventTargetImpl {
     this._childrenList = null;
     this._version = 0;
     this._cachedRoot = null;
-    this._memoizedQueries = Object.create(null);
+    this._memoizedQueries = null;
     this._registeredObserverList = [];
     this._referencedRanges = new Set(); // Set of WeakRef<Range>
   }
@@ -228,13 +228,14 @@ class NodeImpl extends EventTargetImpl {
 
   _modified() {
     this._version++;
+    this._memoizedQueries = null;
     for (const ancestor of domSymbolTree.ancestorsIterator(this)) {
       ancestor._version++;
+      ancestor._memoizedQueries = null;
     }
 
     this._childrenList?._invalidate();
     this._childNodesList?._invalidate();
-    this._clearMemoizedQueries();
     if (this._attached) {
       this._ownerDocument._clearStyleCache();
     }
@@ -243,14 +244,6 @@ class NodeImpl extends EventTargetImpl {
   _childrenChangedSteps() {
     if (this._attached) {
       this._ownerDocument._clearStyleCache();
-    }
-  }
-
-  _clearMemoizedQueries() {
-    this._memoizedQueries = Object.create(null);
-    const myParent = domSymbolTree.parent(this);
-    if (myParent) {
-      myParent._clearMemoizedQueries();
     }
   }
 

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -43,12 +43,9 @@ exports.memoizeQuery = function memoizeQuery(fn) {
   const type = memoizeQueryTypeCounter++;
 
   return function (...args) {
-    if (!this._memoizedQueries) {
+    // `undefined` means memoization is unsupported; `null` is a supported cache that has not been allocated yet.
+    if (this._memoizedQueries === undefined) {
       return fn.apply(this, args);
-    }
-
-    if (!this._memoizedQueries[type]) {
-      this._memoizedQueries[type] = Object.create(null);
     }
 
     let key;
@@ -60,10 +57,12 @@ exports.memoizeQuery = function memoizeQuery(fn) {
       return fn.apply(this, args);
     }
 
-    if (!(key in this._memoizedQueries[type])) {
-      this._memoizedQueries[type][key] = fn.apply(this, args);
+    const memoizedQueries = this._memoizedQueries ??= Object.create(null);
+    const typeQueries = memoizedQueries[type] ??= Object.create(null);
+    if (!(key in typeQueries)) {
+      typeQueries[key] = fn.apply(this, args);
     }
-    return this._memoizedQueries[type][key];
+    return typeQueries[key];
   };
 };
 

--- a/test/api/memoized-queries.js
+++ b/test/api/memoized-queries.js
@@ -1,0 +1,73 @@
+"use strict";
+const assert = require("node:assert/strict");
+const { describe, it } = require("mocha-sugar-free");
+
+const { JSDOM } = require("../..");
+const idlUtils = require("../../lib/generated/idl/utils.js");
+const { domSymbolTree } = require("../../lib/jsdom/living/helpers/internal-constants.js");
+const { memoizeQuery } = require("../../lib/jsdom/utils.js");
+
+describe("Memoized queries", () => {
+  it("leaves objects without memoized-query storage unsupported", () => {
+    const object = {};
+    let calls = 0;
+    const query = memoizeQuery(value => {
+      ++calls;
+      return value;
+    });
+
+    assert.equal(query.call(object, "value"), "value");
+    assert.equal(query.call(object, "value"), "value");
+    assert.equal(calls, 2);
+    assert.equal(object._memoizedQueries, undefined);
+  });
+
+  it("allocates on first use and invalidates without breaking the old live collection", () => {
+    const { document } = (new JSDOM()).window;
+    const root = document.createElement("div");
+    const rootImpl = idlUtils.implForWrapper(root);
+    const first = document.createElement("span");
+
+    assert.equal(rootImpl._memoizedQueries, null);
+
+    const oldCollection = root.getElementsByTagName("span");
+    assert.notEqual(rootImpl._memoizedQueries, null);
+    assert.equal(root.getElementsByTagName("span"), oldCollection);
+
+    root.append(first);
+    assert.equal(rootImpl._memoizedQueries, null);
+    assert.deepEqual([...oldCollection], [first]);
+
+    const newCollection = root.getElementsByTagName("span");
+    assert.notEqual(newCollection, oldCollection);
+    assert.equal(root.getElementsByTagName("span"), newCollection);
+  });
+
+  it("allocates label associations lazily", () => {
+    const { document } = (new JSDOM()).window;
+    const label = document.createElement("label");
+    const input = document.createElement("input");
+    label.htmlFor = "first";
+    input.id = "first";
+    document.body.append(label, input);
+
+    const documentImpl = idlUtils.implForWrapper(document);
+    assert.equal(documentImpl._memoizedQueries, null);
+
+    assert.deepEqual([...input.labels], [label]);
+    assert.notEqual(documentImpl._memoizedQueries, null);
+  });
+
+  it("does not recurse through a second ancestor walk during invalidation", () => {
+    const depth = 20_000;
+    const { document } = (new JSDOM()).window;
+    const nodes = Array.from({ length: depth }, () => document.createElement("div"));
+
+    // Build the chain directly so test setup does not call _modified() once for every level.
+    for (let i = 1; i < depth; ++i) {
+      domSymbolTree.appendChild(idlUtils.implForWrapper(nodes[i - 1]), idlUtils.implForWrapper(nodes[i]));
+    }
+
+    assert.doesNotThrow(() => nodes.at(-1).toggleAttribute("data-mutated"));
+  });
+});


### PR DESCRIPTION
Most nodes never use `_memoizedQueries`, but every Node currently allocates an empty cache. Each mutation also walks the ancestor chain twice and replaces every cache with another empty object.

Keep the cache `null` until a memoized query or labels lookup needs it, and clear caches during the existing ancestor-version walk in `_modified()`. Cross-document adoption continues to clear only the moved subtree.

This is similar to [#4249](https://github.com/jsdom/jsdom/pull/4249), which removed eager live-collection rebuilding from the same mutation path.

In a separate 500,000-mutation depth-12 run, cumulative allocation dropped from 2.25 GB to 1.10 GB and GC runs dropped from 67 to 32. The added benchmark improved from 875 ns to 750 ns per mutation, 14.3% faster.

A 2,000-row React mount retained 64.26 MB before and 59.47 MB after GC, 7.4% less. Element construction and read-heavy query controls remained effectively unchanged.