### PR TITLE
Centralize memoized tree query caches

### DIFF
--- a/benchmark/dom/memoized-queries.js
+++ b/benchmark/dom/memoized-queries.js
@@ -1,0 +1,57 @@
+"use strict";
+const documentBench = require("../document-bench");
+
+const DEPTH = 12;
+const READS = 100;
+const TAG_NAMES = ["a", "abbr", "address", "article", "aside", "b", "blockquote", "button"];
+
+module.exports = () => {
+  const { document, bench } = documentBench();
+  const root = document.createElement("div");
+  let target = root;
+
+  for (let i = 1; i < DEPTH; ++i) {
+    const child = document.createElement("div");
+    target.append(child);
+    target = child;
+  }
+
+  const queryRoot = document.createElement("div");
+  for (const tagName of TAG_NAMES) {
+    queryRoot.append(document.createElement(tagName));
+  }
+  for (const tagName of TAG_NAMES) {
+    queryRoot.getElementsByTagName(tagName);
+  }
+  queryRoot.getElementsByTagNameNS(null, "a");
+
+  bench.add(`toggleAttribute(): depth ${DEPTH} without query reads`, () => {
+    target.toggleAttribute("data-mutated");
+  });
+
+  bench.add(`getElementsByTagName(): ${READS} cached reads`, () => {
+    for (let i = 0; i < READS; ++i) {
+      queryRoot.getElementsByTagName("a");
+    }
+  });
+
+  let tagNameIndex = 0;
+  bench.add(`getElementsByTagName(): ${READS} cached reads across eight names`, () => {
+    for (let i = 0; i < READS; ++i) {
+      queryRoot.getElementsByTagName(TAG_NAMES[tagNameIndex++ & 7]);
+    }
+  });
+
+  bench.add(`getElementsByTagNameNS(): ${READS} cached null-namespace reads`, () => {
+    for (let i = 0; i < READS; ++i) {
+      queryRoot.getElementsByTagNameNS(null, "a");
+    }
+  });
+
+  bench.add("getElementsByTagName(): mutation followed by a read", () => {
+    queryRoot.firstChild.toggleAttribute("data-mutated");
+    queryRoot.getElementsByTagName("a");
+  });
+
+  return bench;
+};

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -24,8 +24,6 @@ const { closest, firstChildWithLocalName } = require("./traversal");
 const NODE_TYPE = require("../node-type");
 const { HTML_NS } = require("./namespaces");
 
-const labelAssociationsCache = Symbol("label associations cache");
-
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled
 exports.isDisabled = formControl => {
   if (formControl.localName === "button" || formControl.localName === "input" || formControl.localName === "select" ||
@@ -142,9 +140,9 @@ exports.isLabelable = node => {
 };
 
 function getLabelAssociations(root) {
-  const cached = root._memoizedQueries[labelAssociationsCache];
-  if (cached) {
-    return cached;
+  const memoizedQueries = root._getMemoizedQueries();
+  if (memoizedQueries.labelAssociations !== null) {
+    return memoizedQueries.labelAssociations;
   }
 
   const labelsByControl = new WeakMap();
@@ -164,7 +162,7 @@ function getLabelAssociations(root) {
     labelsByControl.set(control, labels);
   }
 
-  root._memoizedQueries[labelAssociationsCache] = labelsByControl;
+  memoizedQueries.labelAssociations = labelsByControl;
   return labelsByControl;
 }
 

--- a/lib/jsdom/living/node.js
+++ b/lib/jsdom/living/node.js
@@ -85,9 +85,7 @@ exports.clone = (node, document, cloneChildren) => {
   return copy;
 };
 
-// For the following, memoization is not applied here since the memoized results are stored on `this`.
-
-exports.listOfElementsWithClassNames = (classNames, root) => {
+exports.createHTMLCollectionByClassNames = (classNames, root) => {
   // https://dom.spec.whatwg.org/#concept-getElementsByClassName
 
   const classes = orderedSetParse(classNames);
@@ -127,7 +125,7 @@ exports.listOfElementsWithClassNames = (classNames, root) => {
   });
 };
 
-exports.listOfElementsWithQualifiedName = (qualifiedName, root) => {
+exports.createHTMLCollectionByQualifiedName = (qualifiedName, root) => {
   // https://dom.spec.whatwg.org/#concept-getelementsbytagname
 
   if (qualifiedName === "*") {
@@ -174,12 +172,8 @@ exports.listOfElementsWithQualifiedName = (qualifiedName, root) => {
   });
 };
 
-exports.listOfElementsWithNamespaceAndLocalName = (namespace, localName, root) => {
+exports.createHTMLCollectionByNamespaceAndLocalName = (namespace, localName, root) => {
   // https://dom.spec.whatwg.org/#concept-getelementsbytagnamens
-
-  if (namespace === "") {
-    namespace = null;
-  }
 
   if (namespace === "*" && localName === "*") {
     return HTMLCollection.createImpl(root._globalObject, [], {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -6,7 +6,7 @@ const { DOMSelector } = require("@asamuzakjp/dom-selector");
 const NodeImpl = require("./Node-impl").implementation;
 const idlUtils = require("../../../generated/idl/utils");
 const NODE_TYPE = require("../node-type");
-const { mixin, memoizeQuery } = require("../../utils");
+const { mixin } = require("../../utils");
 const { firstChildWithLocalName, firstChildWithLocalNames, firstDescendantWithLocalName } =
   require("../helpers/traversal");
 const whatwgURL = require("whatwg-url");
@@ -40,8 +40,7 @@ const GlobalEventHandlersImpl = require("./GlobalEventHandlers-impl").implementa
 const NonElementParentNodeImpl = require("./NonElementParentNode-impl").implementation;
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
 
-const { clone, listOfElementsWithQualifiedName, listOfElementsWithNamespaceAndLocalName,
-  listOfElementsWithClassNames } = require("../node");
+const { clone } = require("../node");
 const generatedAttr = require("../../../generated/idl/Attr");
 const Comment = require("../../../generated/idl/Comment");
 const ProcessingInstruction = require("../../../generated/idl/ProcessingInstruction");
@@ -136,7 +135,6 @@ const eventInterfaceTable = {
 class DocumentImpl extends NodeImpl {
   #domSelector = null;
   #namedPropertyCollections;
-  #namedPropertyElementsCache;
 
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
@@ -606,14 +604,14 @@ class DocumentImpl extends NodeImpl {
   }
 
   /**
-   * Named property name to the elements contributing it, in tree order, cached against the tree
-   * version. `_modified()` bumps a node's version and all its ancestors' for both tree and
-   * attribute mutations, so the document's version covers every change that can invalidate this.
+   * Named property name to the elements contributing it, in tree order. This is cached with the
+   * other memoized tree queries, so `_modified()` clears it after any relevant tree or attribute mutation.
    *
    * https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem-filter
    */
   get #namedPropertyElements() {
-    if (this.#namedPropertyElementsCache?.version !== this._version) {
+    const memoizedQueries = this._getMemoizedQueries();
+    if (memoizedQueries.documentNamedPropertyElements === null) {
       const map = new Map();
 
       function add(name, element) {
@@ -644,10 +642,10 @@ class DocumentImpl extends NodeImpl {
         }
       }
 
-      this.#namedPropertyElementsCache = { version: this._version, map };
+      memoizedQueries.documentNamedPropertyElements = map;
     }
 
-    return this.#namedPropertyElementsCache.map;
+    return memoizedQueries.documentNamedPropertyElements;
   }
 
   get [idlUtils.supportedPropertyNames]() {
@@ -1036,10 +1034,9 @@ class DocumentImpl extends NodeImpl {
         }
 
         // Collections built before the move captured the old document's HTML-ness, and the spec
-        // keeps those working. A fresh call has to see the new document, so drop the memoized ones.
-        // Not _clearMemoizedQueries(), which walks up to the ancestors: it is this subtree that
-        // changed document, and the old parent's collections are unaffected by the move.
-        inclusiveDescendant._memoizedQueries = Object.create(null);
+        // keeps those working. A fresh call has to see the new document, so clear the memoized ones.
+        // It is this subtree that changed document; the old parent's collections are unaffected by the move.
+        inclusiveDescendant._clearMemoizedQueries();
       }
 
       for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(node)) {
@@ -1131,18 +1128,6 @@ mixin(DocumentImpl.prototype, DocumentOrShadowRootImpl.prototype);
 mixin(DocumentImpl.prototype, GlobalEventHandlersImpl.prototype);
 mixin(DocumentImpl.prototype, NonElementParentNodeImpl.prototype);
 mixin(DocumentImpl.prototype, ParentNodeImpl.prototype);
-
-DocumentImpl.prototype.getElementsByTagName = memoizeQuery(function (qualifiedName) {
-  return listOfElementsWithQualifiedName(qualifiedName, this);
-});
-
-DocumentImpl.prototype.getElementsByTagNameNS = memoizeQuery(function (namespace, localName) {
-  return listOfElementsWithNamespaceAndLocalName(namespace, localName, this);
-});
-
-DocumentImpl.prototype.getElementsByClassName = memoizeQuery(function getElementsByClassName(classNames) {
-  return listOfElementsWithClassNames(classNames, this);
-});
 
 module.exports = {
   implementation: DocumentImpl

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -1,6 +1,6 @@
 "use strict";
 const { HTML_NS } = require("../helpers/namespaces");
-const { mixin, memoizeQuery } = require("../../utils");
+const { mixin } = require("../../utils");
 const NodeImpl = require("./Node-impl").implementation;
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
 const ChildNodeImpl = require("./ChildNode-impl").implementation;
@@ -16,8 +16,6 @@ const DOMTokenList = require("../../../generated/idl/DOMTokenList");
 const NamedNodeMap = require("../../../generated/idl/NamedNodeMap");
 const validateNames = require("../helpers/validate-names");
 const { asciiLowercase, asciiUppercase } = require("../helpers/strings");
-const { listOfElementsWithQualifiedName, listOfElementsWithNamespaceAndLocalName,
-  listOfElementsWithClassNames } = require("../node");
 const SlotableMixinImpl = require("./Slotable-impl").implementation;
 const NonDocumentTypeChildNode = require("./NonDocumentTypeChildNode-impl").implementation;
 const ShadowRoot = require("../../../generated/idl/ShadowRoot");
@@ -566,18 +564,6 @@ mixin(ElementImpl.prototype, ParentNodeImpl.prototype);
 mixin(ElementImpl.prototype, ChildNodeImpl.prototype);
 mixin(ElementImpl.prototype, SlotableMixinImpl.prototype);
 mixin(ElementImpl.prototype, InnerHTMLImpl.prototype);
-
-ElementImpl.prototype.getElementsByTagName = memoizeQuery(function (qualifiedName) {
-  return listOfElementsWithQualifiedName(qualifiedName, this);
-});
-
-ElementImpl.prototype.getElementsByTagNameNS = memoizeQuery(function (namespace, localName) {
-  return listOfElementsWithNamespaceAndLocalName(namespace, localName, this);
-});
-
-ElementImpl.prototype.getElementsByClassName = memoizeQuery(function (classNames) {
-  return listOfElementsWithClassNames(classNames, this);
-});
 
 module.exports = {
   implementation: ElementImpl

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -6,7 +6,14 @@ const EventTargetImpl = require("../events/EventTarget-impl").implementation;
 const { simultaneousIterators } = require("../../utils");
 const NODE_TYPE = require("../node-type");
 const NODE_DOCUMENT_POSITION = require("../node-document-position");
-const { clone, locateNamespacePrefix, locateNamespace } = require("../node");
+const {
+  clone,
+  createHTMLCollectionByClassNames,
+  createHTMLCollectionByQualifiedName,
+  createHTMLCollectionByNamespaceAndLocalName,
+  locateNamespacePrefix,
+  locateNamespace
+} = require("../node");
 const { setAnExistingAttributeValue } = require("../attributes");
 
 const NodeList = require("../../../generated/idl/NodeList");
@@ -97,6 +104,17 @@ function attributeListsEqual(elementA, elementB) {
   return true;
 }
 
+function createMemoizedQueries() {
+  // These all derive from a node's subtree and are discarded together after any tree or attribute mutation.
+  return {
+    collectionsByClassNames: null,
+    collectionsByQualifiedName: null,
+    collectionsByNamespaceAndLocalName: null,
+    labelAssociations: null,
+    documentNamedPropertyElements: null
+  };
+}
+
 // https://dom.spec.whatwg.org/#concept-tree-host-including-inclusive-ancestor
 function isHostInclusiveAncestor(nodeImplA, nodeImplB) {
   for (const ancestor of domSymbolTree.ancestorsIterator(nodeImplB)) {
@@ -114,6 +132,8 @@ function isHostInclusiveAncestor(nodeImplA, nodeImplB) {
 }
 
 class NodeImpl extends EventTargetImpl {
+  #memoizedQueries = null;
+
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
 
@@ -125,7 +145,6 @@ class NodeImpl extends EventTargetImpl {
     this._childrenList = null;
     this._version = 0;
     this._cachedRoot = null;
-    this._memoizedQueries = Object.create(null);
     this._registeredObserverList = [];
     this._referencedRanges = null; // Lazily-created Set of WeakRef<Range>
   }
@@ -146,6 +165,75 @@ class NodeImpl extends EventTargetImpl {
         this._referencedRanges.delete(weakRef);
       }
     }
+  }
+
+  _getMemoizedQueries() {
+    if (this.#memoizedQueries === null) {
+      this.#memoizedQueries = createMemoizedQueries();
+    }
+    return this.#memoizedQueries;
+  }
+
+  _clearMemoizedQueries() {
+    this.#memoizedQueries = null;
+  }
+
+  getElementsByClassName(classNames) {
+    const memoizedQueries = this._getMemoizedQueries();
+    let collections = memoizedQueries.collectionsByClassNames;
+    if (collections === null) {
+      collections = new Map();
+      memoizedQueries.collectionsByClassNames = collections;
+    }
+
+    let collection = collections.get(classNames);
+    if (collection === undefined) {
+      collection = createHTMLCollectionByClassNames(classNames, this);
+      collections.set(classNames, collection);
+    }
+    return collection;
+  }
+
+  getElementsByTagName(qualifiedName) {
+    const memoizedQueries = this._getMemoizedQueries();
+    let collections = memoizedQueries.collectionsByQualifiedName;
+    if (collections === null) {
+      collections = new Map();
+      memoizedQueries.collectionsByQualifiedName = collections;
+    }
+
+    let collection = collections.get(qualifiedName);
+    if (collection === undefined) {
+      collection = createHTMLCollectionByQualifiedName(qualifiedName, this);
+      collections.set(qualifiedName, collection);
+    }
+    return collection;
+  }
+
+  getElementsByTagNameNS(namespace, localName) {
+    if (namespace === "") {
+      namespace = null;
+    }
+
+    const memoizedQueries = this._getMemoizedQueries();
+    let collectionsByNamespace = memoizedQueries.collectionsByNamespaceAndLocalName;
+    if (collectionsByNamespace === null) {
+      collectionsByNamespace = new Map();
+      memoizedQueries.collectionsByNamespaceAndLocalName = collectionsByNamespace;
+    }
+
+    let collectionsByLocalName = collectionsByNamespace.get(namespace);
+    if (collectionsByLocalName === undefined) {
+      collectionsByLocalName = new Map();
+      collectionsByNamespace.set(namespace, collectionsByLocalName);
+    }
+
+    let collection = collectionsByLocalName.get(localName);
+    if (collection === undefined) {
+      collection = createHTMLCollectionByNamespaceAndLocalName(namespace, localName, this);
+      collectionsByLocalName.set(localName, collection);
+    }
+    return collection;
   }
 
   _getTheParent() {
@@ -232,13 +320,14 @@ class NodeImpl extends EventTargetImpl {
 
   _modified() {
     this._version++;
+    this.#memoizedQueries = null;
     for (const ancestor of domSymbolTree.ancestorsIterator(this)) {
       ancestor._version++;
+      ancestor.#memoizedQueries = null;
     }
 
     this._childrenList?._invalidate();
     this._childNodesList?._invalidate();
-    this._clearMemoizedQueries();
     if (this._attached) {
       this._ownerDocument._clearStyleCache();
     }
@@ -247,14 +336,6 @@ class NodeImpl extends EventTargetImpl {
   _childrenChangedSteps() {
     if (this._attached) {
       this._ownerDocument._clearStyleCache();
-    }
-  }
-
-  _clearMemoizedQueries() {
-    this._memoizedQueries = Object.create(null);
-    const myParent = domSymbolTree.parent(this);
-    if (myParent) {
-      myParent._clearMemoizedQueries();
     }
   }
 

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -27,46 +27,6 @@ exports.mixin = (target, source) => {
   }
 };
 
-let memoizeQueryTypeCounter = 0;
-
-/**
- * Returns a version of a method that memoizes specific types of calls on the object
- *
- * - `fn` {Function} the method to be memozied
- */
-exports.memoizeQuery = function memoizeQuery(fn) {
-  // Only memoize query functions with arity <= 2
-  if (fn.length > 2) {
-    return fn;
-  }
-
-  const type = memoizeQueryTypeCounter++;
-
-  return function (...args) {
-    if (!this._memoizedQueries) {
-      return fn.apply(this, args);
-    }
-
-    if (!this._memoizedQueries[type]) {
-      this._memoizedQueries[type] = Object.create(null);
-    }
-
-    let key;
-    if (args.length === 1 && typeof args[0] === "string") {
-      key = args[0];
-    } else if (args.length === 2 && typeof args[0] === "string" && typeof args[1] === "string") {
-      key = args[0] + "::" + args[1];
-    } else {
-      return fn.apply(this, args);
-    }
-
-    if (!(key in this._memoizedQueries[type])) {
-      this._memoizedQueries[type][key] = fn.apply(this, args);
-    }
-    return this._memoizedQueries[type][key];
-  };
-};
-
 exports.simultaneousIterators = function* (first, second) {
   for (;;) {
     const firstResult = first.next();


### PR DESCRIPTION
Centralizes subtree-derived caches in a lazily allocated private aggregate on Node instances. This avoids making every node pay for an unused cache and prevents invalidated document named-property data from retaining removed subtrees.

Supersedes #4260.

### Benchmarks

Compared with `origin/main` at `6312bdee` using Node.js 26.3.1. Values are medians of five runs.

| Speed benchmark | `origin/main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Mutation at depth 12 without query reads | 943,396 ops/s | 1,098,901 ops/s | +16% |
| 100 cached `getElementsByTagName()` reads | 242,718 ops/s | 317,460 ops/s | +31% |
| 100 cached reads across eight tag names | 230,415 ops/s | 293,255 ops/s | +27% |
| 100 cached `getElementsByTagNameNS(null, ...)` reads | 16,795 ops/s | 265,957 ops/s | 15.8x |
| Mutation followed by a query read | 653,595 ops/s | 714,286 ops/s | +9% |

The namespace case improves especially because the old generic memoizer declines to cache calls containing `null`.

Heap measurements used `--expose-gc` and five isolated processes per revision.

| Memory benchmark | `origin/main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Heap for 100,000 retained, otherwise-unused elements | 214.6 MiB | 197.0 MiB | -8.2% |
| Heap retained after invalidating and removing a 20,000-element document named-property subtree | 62.0 MiB | 0.4 MiB | -99.3% |