### PR TITLE
Lazily allocate event handler storage

### DIFF
--- a/lib/jsdom/living/helpers/create-event-accessor.js
+++ b/lib/jsdom/living/helpers/create-event-accessor.js
@@ -82,13 +82,16 @@ exports.setupForSimpleEventAccessors = (prototype, events) => {
   };
 
   prototype._setEventHandlerFor = function (event, handler) {
-    if (!this._registeredHandlers) {
-      this._registeredHandlers = new Set();
-      this._eventHandlers = Object.create(null);
-    }
+    const isRegistered = this._eventHandlers !== undefined && event in this._eventHandlers;
+    if (!isRegistered) {
+      if (handler === null) {
+        return;
+      }
 
-    if (!this._registeredHandlers.has(event) && handler !== null) {
-      this._registeredHandlers.add(event);
+      if (this._eventHandlers === undefined) {
+        this._eventHandlers = Object.create(null);
+      }
+
       exports.appendHandler(this, event);
     }
     this._eventHandlers[event] = handler;

--- a/lib/jsdom/living/nodes/GlobalEventHandlers-impl.js
+++ b/lib/jsdom/living/nodes/GlobalEventHandlers-impl.js
@@ -9,8 +9,7 @@ const windowReflectingBodyElementEvents = new Set(["blur", "error", "focus", "lo
 
 class GlobalEventHandlersImpl {
   _initGlobalEvents() {
-    this._registeredHandlers = new Set();
-    this._eventHandlers = Object.create(null);
+    this._eventHandlers = null;
   }
 
   _getEventHandlerTarget(event) {
@@ -37,6 +36,10 @@ class GlobalEventHandlersImpl {
       return null;
     }
 
+    if (target._eventHandlers === null) {
+      return null;
+    }
+
     return target._eventHandlers[event];
   }
 
@@ -46,8 +49,16 @@ class GlobalEventHandlersImpl {
       return;
     }
 
-    if (!target._registeredHandlers.has(event) && handler !== null) {
-      target._registeredHandlers.add(event);
+    const isRegistered = target._eventHandlers !== null && event in target._eventHandlers;
+    if (!isRegistered) {
+      if (handler === null) {
+        return;
+      }
+
+      if (target._eventHandlers === null) {
+        target._eventHandlers = Object.create(null);
+      }
+
       appendHandler(target, event);
     }
     target._eventHandlers[event] = handler;


### PR DESCRIPTION
Every HTML and SVG element currently allocates an event-handler object and a Set, even when no `on*` property is used.

Leave the handler storage null until first use and use its keys to track installed listeners instead of keeping a separate Set. Apply the same registration tracking to the simple event accessors used by `AbortSignal`, `FileReader`, `WebSocket`, and `XMLHttpRequest`. This preserves handler reassignment and listener ordering.

With 20,000 retained elements and `onclick` on one in fourteen, median heap after GC fell from 43.32 MB to 36.70 MB (-15.3%). Speed was neutral.