### PR TITLE
Avoid unnecessary Document named-property rebuilds

### DIFF
--- a/benchmark/dom/named-properties.js
+++ b/benchmark/dom/named-properties.js
@@ -35,6 +35,28 @@ module.exports = () => {
     }
   });
 
+  bench.add("document.body: Read after every irrelevant attribute mutation", () => {
+    let body;
+    for (let i = 0; i < NODES; ++i) {
+      nodes[i].toggleAttribute("data-state");
+      body = document.body;
+    }
+    if (body === null) {
+      throw new Error("Document body unexpectedly missing");
+    }
+  }, {
+    beforeEach() {
+      createSubtree();
+      document.body.appendChild(parent);
+      if (document.body === null) {
+        throw new Error("Document body unexpectedly missing");
+      }
+    },
+    afterEach() {
+      parent.remove();
+    }
+  });
+
   bench.add("appendChild()/remove(): Attach and remove an irrelevant subtree", () => {
     document.body.appendChild(parent);
     parent.remove();

--- a/benchmark/dom/named-properties.js
+++ b/benchmark/dom/named-properties.js
@@ -5,6 +5,7 @@ const NODES = 1000;
 
 module.exports = () => {
   const { document, bench } = documentBench();
+  const { defaultView: window } = document;
 
   let nodes, parent;
 
@@ -80,6 +81,33 @@ module.exports = () => {
     },
     afterEach() {
       parent.remove();
+    }
+  });
+
+  bench.add("Window named access: Read single matches", () => {
+    for (let i = 0; i < NODES; ++i) {
+      if (window["named" + i] !== nodes[i]) {
+        throw new Error("Window named property unexpectedly missing");
+      }
+    }
+  }, {
+    beforeEach() {
+      createSubtree();
+      for (let i = 0; i < NODES; ++i) {
+        nodes[i].id = "named" + i;
+      }
+      document.body.appendChild(parent);
+    },
+    afterEach() {
+      parent.remove();
+    }
+  });
+
+  bench.add("Window named access: Read misses without tracked names", () => {
+    for (let i = 0; i < NODES; ++i) {
+      if (window["missingNamedProperty" + i] !== undefined) {
+        throw new Error("Unexpected Window named property");
+      }
     }
   });
 

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -433,7 +433,15 @@ class DocumentImpl extends NodeImpl {
     return Boolean(this._lastFocusedElement);
   }
 
+  _descendantAdded(parent, child) {
+    this.#namedPropertyElementsCache = null;
+
+    super._descendantAdded(parent, child);
+  }
+
   _descendantRemoved(parent, child) {
+    this.#namedPropertyElementsCache = null;
+
     if (child.tagName === "STYLE") {
       this.styleSheets._remove(child.sheet);
     }
@@ -684,10 +692,6 @@ class DocumentImpl extends NodeImpl {
     if (this.#namedPropertyElementsCache !== null && attributeAffectsNamedProperties(element, name, value, oldValue)) {
       this.#namedPropertyElementsCache = null;
     }
-  }
-
-  _clearNamedPropertyElementsCache() {
-    this.#namedPropertyElementsCache = null;
   }
 
   get [idlUtils.supportedPropertyNames]() {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -100,6 +100,10 @@ function hasNonemptyAttribute(element, name) {
   return value !== null && value !== "";
 }
 
+function canContributeIdToNamedProperties(element, hasName) {
+  return element._localName === "object" || (element._localName === "img" && hasName);
+}
+
 function attributeAffectsNamedProperties(element, name, value, oldValue) {
   if (element._namespaceURI !== HTML_NS || value === oldValue) {
     return false;
@@ -118,9 +122,9 @@ function attributeAffectsNamedProperties(element, name, value, oldValue) {
     return false;
   }
 
-  const hasContributingId = element._localName === "object" ||
-    (element._localName === "img" && hasNonemptyAttribute(element, "name"));
-  return hasContributingId && nodeRoot(element) === element._ownerDocument;
+  const hasName = hasNonemptyAttribute(element, "name");
+  return canContributeIdToNamedProperties(element, hasName) &&
+    nodeRoot(element) === element._ownerDocument;
 }
 
 function pad(number) {
@@ -661,8 +665,7 @@ class DocumentImpl extends NodeImpl {
         // An object element contributes its id; an img element only alongside a non-empty name.
         // The id is added first: the standard orders values from id attributes before values from
         // name attributes when the same element contributes both.
-        if (id !== null && id !== "" &&
-            (element._localName === "object" || (element._localName === "img" && hasName))) {
+        if (id !== null && id !== "" && canContributeIdToNamedProperties(element, hasName)) {
           add(id, element);
         }
 

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -12,7 +12,6 @@ const { firstChildWithLocalName, firstChildWithLocalNames, firstDescendantWithLo
 const whatwgURL = require("whatwg-url");
 const StyleSheetList = require("../../../generated/idl/StyleSheetList.js");
 const { domSymbolTree } = require("../helpers/internal-constants");
-const { nodeRoot } = require("../helpers/node");
 const eventAccessors = require("../helpers/create-event-accessor");
 const { asciiLowercase, stripAndCollapseASCIIWhitespace } = require("../helpers/strings");
 const { childTextContent } = require("../helpers/text");
@@ -105,7 +104,7 @@ function canContributeIdToNamedProperties(element, hasName) {
 }
 
 function attributeAffectsNamedProperties(element, name, value, oldValue) {
-  if (element._namespaceURI !== HTML_NS || value === oldValue) {
+  if (element._namespaceURI !== HTML_NS || !element._isInDocumentTree || value === oldValue) {
     return false;
   }
 
@@ -115,7 +114,7 @@ function attributeAffectsNamedProperties(element, name, value, oldValue) {
   }
 
   if (name === "name") {
-    return NAMED_PROPERTY_LOCAL_NAMES.has(element._localName) && nodeRoot(element) === element._ownerDocument;
+    return NAMED_PROPERTY_LOCAL_NAMES.has(element._localName);
   }
 
   if (name !== "id") {
@@ -123,8 +122,7 @@ function attributeAffectsNamedProperties(element, name, value, oldValue) {
   }
 
   const hasName = hasNonemptyAttribute(element, "name");
-  return canContributeIdToNamedProperties(element, hasName) &&
-    nodeRoot(element) === element._ownerDocument;
+  return canContributeIdToNamedProperties(element, hasName);
 }
 
 function pad(number) {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -12,6 +12,7 @@ const { firstChildWithLocalName, firstChildWithLocalNames, firstDescendantWithLo
 const whatwgURL = require("whatwg-url");
 const StyleSheetList = require("../../../generated/idl/StyleSheetList.js");
 const { domSymbolTree } = require("../helpers/internal-constants");
+const { nodeRoot } = require("../helpers/node");
 const eventAccessors = require("../helpers/create-event-accessor");
 const { asciiLowercase, stripAndCollapseASCIIWhitespace } = require("../helpers/strings");
 const { childTextContent } = require("../helpers/text");
@@ -94,6 +95,30 @@ function isNamedPropertyElement(node) {
     NAMED_PROPERTY_LOCAL_NAMES.has(node._localName);
 }
 
+function hasNonemptyAttribute(element, name) {
+  const value = element.getAttributeNS(null, name);
+  return value !== null && value !== "";
+}
+
+function attributeAffectsNamedProperties(element, name, value, oldValue) {
+  if (element._namespaceURI !== HTML_NS || value === oldValue) {
+    return false;
+  }
+
+  const hasChangedValue = (value !== null && value !== "") || (oldValue !== null && oldValue !== "");
+  if (!hasChangedValue) {
+    return false;
+  }
+
+  const isContributor = name === "name" ?
+    NAMED_PROPERTY_LOCAL_NAMES.has(element._localName) :
+    name === "id" &&
+      (element._localName === "object" ||
+        (element._localName === "img" && hasNonemptyAttribute(element, "name")));
+
+  return isContributor && nodeRoot(element) === element._ownerDocument;
+}
+
 function pad(number) {
   if (number < 10) {
     return "0" + number;
@@ -135,6 +160,7 @@ const eventInterfaceTable = {
 class DocumentImpl extends NodeImpl {
   #domSelector = null;
   #namedPropertyCollections;
+  #namedPropertyElementsCache = null;
 
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
@@ -604,14 +630,13 @@ class DocumentImpl extends NodeImpl {
   }
 
   /**
-   * Named property name to the elements contributing it, in tree order. This is cached with the
-   * other memoized tree queries, so `_modified()` clears it after any relevant tree or attribute mutation.
+   * Named property name to the elements contributing it, in tree order. Tree insertions and removals always discard
+   * this cache; attribute changes do so only when they can change the map.
    *
    * https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem-filter
    */
   get #namedPropertyElements() {
-    const memoizedQueries = this._getMemoizedQueries();
-    if (memoizedQueries.documentNamedPropertyElements === null) {
+    if (this.#namedPropertyElementsCache === null) {
       const map = new Map();
 
       function add(name, element) {
@@ -642,10 +667,20 @@ class DocumentImpl extends NodeImpl {
         }
       }
 
-      memoizedQueries.documentNamedPropertyElements = map;
+      this.#namedPropertyElementsCache = map;
     }
 
-    return memoizedQueries.documentNamedPropertyElements;
+    return this.#namedPropertyElementsCache;
+  }
+
+  _namedPropertyElementAttributeModified(element, name, value, oldValue) {
+    if (this.#namedPropertyElementsCache !== null && attributeAffectsNamedProperties(element, name, value, oldValue)) {
+      this.#namedPropertyElementsCache = null;
+    }
+  }
+
+  _clearNamedPropertyElementsCache() {
+    this.#namedPropertyElementsCache = null;
   }
 
   get [idlUtils.supportedPropertyNames]() {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -110,13 +110,17 @@ function attributeAffectsNamedProperties(element, name, value, oldValue) {
     return false;
   }
 
-  const isContributor = name === "name" ?
-    NAMED_PROPERTY_LOCAL_NAMES.has(element._localName) :
-    name === "id" &&
-      (element._localName === "object" ||
-        (element._localName === "img" && hasNonemptyAttribute(element, "name")));
+  if (name === "name") {
+    return NAMED_PROPERTY_LOCAL_NAMES.has(element._localName) && nodeRoot(element) === element._ownerDocument;
+  }
 
-  return isContributor && nodeRoot(element) === element._ownerDocument;
+  if (name !== "id") {
+    return false;
+  }
+
+  const hasContributingId = element._localName === "object" ||
+    (element._localName === "img" && hasNonemptyAttribute(element, "name"));
+  return hasContributingId && nodeRoot(element) === element._ownerDocument;
 }
 
 function pad(number) {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -927,9 +927,6 @@ class NodeImpl extends EventTargetImpl {
       }
 
       this._modified();
-      if (this._attached) {
-        this._ownerDocument._clearNamedPropertyElementsCache();
-      }
 
       if (isSlot(this) && this._assignedNodes.length === 0 && isShadowRoot(nodeRoot(this))) {
         signalSlotChange(this);

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -110,8 +110,7 @@ function createMemoizedQueries() {
     collectionsByClassNames: null,
     collectionsByQualifiedName: null,
     collectionsByNamespaceAndLocalName: null,
-    labelAssociations: null,
-    documentNamedPropertyElements: null
+    labelAssociations: null
   };
 }
 
@@ -928,6 +927,9 @@ class NodeImpl extends EventTargetImpl {
       }
 
       this._modified();
+      if (this._attached) {
+        this._ownerDocument._clearNamedPropertyElementsCache();
+      }
 
       if (isSlot(this) && this._assignedNodes.length === 0 && isShadowRoot(nodeRoot(this))) {
         signalSlotChange(this);

--- a/lib/jsdom/living/window-properties.js
+++ b/lib/jsdom/living/window-properties.js
@@ -144,6 +144,9 @@ exports.elementAttributeModified = (element, attributeName, value, oldValue) => 
     return;
   }
 
+  // Window and Document named properties share this filtered mutation path, but have different contributors.
+  element._ownerDocument._namedPropertyElementAttributeModified(element, attributeName, value, oldValue);
+
   if (element.namespaceURI !== HTML_NS) {
     return;
   }

--- a/lib/jsdom/living/window-properties.js
+++ b/lib/jsdom/living/window-properties.js
@@ -2,14 +2,13 @@
 const idlUtils = require("../../generated/idl/utils.js");
 const HTMLCollection = require("../../generated/idl/HTMLCollection.js");
 const { HTML_NS } = require("./helpers/namespaces.js");
-const { nodeRoot } = require("./helpers/node.js");
 const { treeOrderSorter } = require("../utils.js");
 
 // We count iframe/frame here too even though it's not in the relevant part of the spec because we still need to track
 // named iframes/frames, and we'll process the element -> WindowProxy work as special cases.
 const nameAttributeElementLocalNames = new Set(["embed", "form", "img", "object", "iframe", "frame"]);
 
-const trackers = new WeakMap(); // WeakMap<WindowProperties, Map<string, Set<Element>>>
+const trackers = new WeakMap(); // WeakMap<Window, Map<string, Set<Element>>>
 
 function inAssociatedDocument(element) {
   const document = element._ownerDocument;
@@ -37,16 +36,20 @@ function remove(map, key, value) {
 
 function getNamedObject(window, name) {
   const tracker = trackers.get(window);
+  if (tracker === undefined) {
+    return undefined;
+  }
+
   const set = tracker.get(name);
   if (set === undefined) {
     return undefined;
   }
 
-  const sorted = [...set].sort(treeOrderSorter);
-  for (const element of sorted) {
-    if (element.localName === "iframe" || element.localName === "frame") {
+  const elements = set.size === 1 ? set : [...set].sort(treeOrderSorter);
+  for (const element of elements) {
+    if (element._localName === "iframe" || element._localName === "frame") {
       const { contentWindow } = element;
-      if (contentWindow && element.getAttributeNS(null, "name") === name) {
+      if (contentWindow !== null && element.getAttributeNS(null, "name") === name) {
         return contentWindow;
       }
     }
@@ -57,135 +60,142 @@ function getNamedObject(window, name) {
   }
 
   return HTMLCollection.create(window, [], {
-    element: idlUtils.implForWrapper(window._document).documentElement,
+    element: idlUtils.implForWrapper(window._document),
     query() {
-      // Do *not* reuse `sorted` or `set` from above. We need to re-get and re-iterate the set each time because it
+      // Do *not* reuse `elements` or `set` from above. We need to re-get and re-iterate the set each time because it
       // might have changed due to elements being attached, removed, or having their names changed!
-      const currentSet = tracker.get(name);
-      return [...currentSet].sort(treeOrderSorter);
+      const currentSet = trackers.get(window)?.get(name);
+      return currentSet === undefined ? [] : [...currentSet].sort(treeOrderSorter);
     }
   });
 }
 
 exports.elementAttached = element => {
-  if (element.namespaceURI !== HTML_NS) {
+  if (element._namespaceURI !== HTML_NS) {
     return;
   }
 
   const idAttr = element.getAttributeNS(null, "id");
-  const nameAttr = nameAttributeElementLocalNames.has(element.localName) ?
+  const nameAttr = nameAttributeElementLocalNames.has(element._localName) ?
     element.getAttributeNS(null, "name") :
     null;
-  if (idAttr === null && nameAttr === null) {
+  if (!idAttr && !nameAttr) {
     return;
   }
 
   const window = element._ownerDocument._globalObject;
-  if (!window) {
-    return;
-  }
-
   if (!inAssociatedDocument(element)) {
     return;
   }
 
-  if (nodeRoot(element) !== element._ownerDocument) {
-    return;
+  let tracker = trackers.get(window);
+  if (tracker === undefined) {
+    tracker = new Map();
+    trackers.set(window, tracker);
   }
 
-  const tracker = trackers.get(window);
-
-  if (nameAttr !== null) {
+  if (nameAttr) {
     upsert(tracker, nameAttr, element);
   }
 
-  if (idAttr !== null) {
+  if (idAttr) {
     upsert(tracker, idAttr, element);
   }
 };
 
 exports.elementDetached = element => {
-  if (element.namespaceURI !== HTML_NS) {
+  if (element._namespaceURI !== HTML_NS) {
     return;
   }
 
   const idAttr = element.getAttributeNS(null, "id");
-  const nameAttr = nameAttributeElementLocalNames.has(element.localName) ?
+  const nameAttr = nameAttributeElementLocalNames.has(element._localName) ?
     element.getAttributeNS(null, "name") :
     null;
-  if (idAttr === null && nameAttr === null) {
+  if (!idAttr && !nameAttr) {
     return;
   }
 
   const window = element._ownerDocument._globalObject;
-  if (!window) {
-    return;
-  }
-
   if (!inAssociatedDocument(element)) {
     return;
   }
 
   const tracker = trackers.get(window);
 
-  if (idAttr !== null) {
+  if (idAttr) {
     remove(tracker, idAttr, element);
   }
 
-  if (nameAttr !== null) {
+  if (nameAttr) {
     remove(tracker, nameAttr, element);
+  }
+
+  if (tracker.size === 0) {
+    trackers.delete(window);
   }
 };
 
 exports.elementAttributeModified = (element, attributeName, value, oldValue) => {
   const isIdAttribute = attributeName === "id";
-  const isNameAttribute = attributeName === "name" && nameAttributeElementLocalNames.has(element.localName);
-  if (!isIdAttribute && !isNameAttribute) {
+  const isNameAttribute = attributeName === "name" && nameAttributeElementLocalNames.has(element._localName);
+  if ((!isIdAttribute && !isNameAttribute) || value === oldValue) {
+    return;
+  }
+
+  // A qualified name alone does not tell us the attribute's namespace. A non-null-namespace attribute cannot be the
+  // current value returned here, except for a removal; removals of attributes that were never tracked are harmless.
+  if (element.getAttributeNS(null, attributeName) !== value) {
     return;
   }
 
   // Window and Document named properties share this filtered mutation path, but have different contributors.
   element._ownerDocument._namedPropertyElementAttributeModified(element, attributeName, value, oldValue);
 
-  if (element.namespaceURI !== HTML_NS) {
+  if (element._namespaceURI !== HTML_NS) {
     return;
   }
 
   const window = element._ownerDocument._globalObject;
-  if (!window) {
-    return;
-  }
-
   if (!inAssociatedDocument(element)) {
     return;
   }
 
-  if (nodeRoot(element) !== element._ownerDocument) {
+  if (!element._isInDocumentTree) {
     return;
   }
 
-  const tracker = trackers.get(window);
-
-  // TODO what about attribute namespace?
+  let tracker = trackers.get(window);
+  if (tracker === undefined) {
+    if (!value) {
+      return;
+    }
+    tracker = new Map();
+    trackers.set(window, tracker);
+  }
 
   if (isIdAttribute) {
-    const nameAttr = nameAttributeElementLocalNames.has(element.localName) ?
+    const nameAttr = nameAttributeElementLocalNames.has(element._localName) ?
       element.getAttributeNS(null, "name") :
       null;
-    if (nameAttr !== oldValue) {
+    if (oldValue && nameAttr !== oldValue) {
       remove(tracker, oldValue, element);
     }
-    if (value !== null) {
+    if (value) {
       upsert(tracker, value, element);
     }
   } else {
     const idAttr = element.getAttributeNS(null, "id");
-    if (idAttr !== oldValue) {
+    if (oldValue && idAttr !== oldValue) {
       remove(tracker, oldValue, element);
     }
-    if (value !== null) {
+    if (value) {
       upsert(tracker, value, element);
     }
+  }
+
+  if (tracker.size === 0) {
+    trackers.delete(window);
   }
 };
 
@@ -274,8 +284,6 @@ exports.create = (eventTargetPrototype, window) => {
       return false;
     }
   });
-
-  trackers.set(window, new Map());
 
   return windowPropertiesProxy;
 };

--- a/test/web-platform-tests/to-upstream/html/browsers/the-window-object/named-access-on-the-window-object/element-contributions.html
+++ b/test/web-platform-tests/to-upstream/html/browsers/the-window-object/named-access-on-the-window-object/element-contributions.html
@@ -62,4 +62,55 @@ test(() => {
   svgElement.remove();
   otherElement.remove();
 }, "Only HTML namespace elements contribute ids or names");
+
+test(() => {
+  const idElement = document.createElement("div");
+  const nameElement = document.createElement("form");
+  idElement.id = "";
+  nameElement.name = "";
+  document.body.append(idElement, nameElement);
+
+  assert_false("" in window);
+  assert_equals(window[""], undefined);
+
+  idElement.remove();
+  nameElement.remove();
+
+  const changedIdElement = document.createElement("div");
+  const changedNameElement = document.createElement("form");
+  document.body.append(changedIdElement, changedNameElement);
+  changedIdElement.id = "";
+  changedNameElement.name = "";
+
+  assert_false("" in window, "after setting empty values on connected elements");
+  assert_equals(window[""], undefined, "after setting empty values on connected elements");
+
+  changedIdElement.remove();
+  changedNameElement.remove();
+}, "Empty id and name attributes do not contribute to named access");
+
+test(() => {
+  const idElement = document.createElement("div");
+  const nameElement = document.createElement("form");
+  const beforeInsertionElement = document.createElement("div");
+  beforeInsertionElement.setAttributeNS("urn:example", "id", "namespacedBeforeInsertion");
+  document.body.append(idElement, nameElement, beforeInsertionElement);
+
+  idElement.setAttributeNS("urn:example", "id", "namespacedId");
+  nameElement.setAttributeNS("urn:example", "name", "namespacedName");
+
+  assert_equals(window.namespacedId, undefined, "id");
+  assert_equals(window.namespacedName, undefined, "name");
+  assert_equals(window.namespacedBeforeInsertion, undefined, "id set before insertion");
+
+  idElement.setAttributeNS(null, "id", "nullNamespaceId");
+  assert_equals(window.nullNamespaceId, idElement, "null-namespace id");
+
+  idElement.removeAttributeNS("urn:example", "id");
+  assert_equals(window.nullNamespaceId, idElement, "after removing a namespaced id");
+
+  idElement.remove();
+  nameElement.remove();
+  beforeInsertionElement.remove();
+}, "Namespaced id and name attributes do not contribute to named access");
 </script>

--- a/test/web-platform-tests/to-upstream/html/browsers/the-window-object/named-access-on-the-window-object/live-collection.html
+++ b/test/web-platform-tests/to-upstream/html/browsers/the-window-object/named-access-on-the-window-object/live-collection.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Named access collections remain live</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+test(() => {
+  const first = document.createElement("div");
+  const second = document.createElement("span");
+  first.id = "liveNamedAccess";
+  second.id = "liveNamedAccess";
+  document.body.append(first, second);
+
+  const collection = window.liveNamedAccess;
+  assert_true(collection instanceof HTMLCollection);
+  assert_array_equals([...collection], [first, second], "initial contents");
+
+  first.remove();
+  assert_array_equals([...collection], [second], "after removing one match");
+
+  second.remove();
+  assert_array_equals([...collection], [], "after removing all matches");
+
+  const third = document.createElement("p");
+  third.id = "liveNamedAccess";
+  document.body.append(third);
+  assert_array_equals([...collection], [third], "after adding a new match");
+  third.remove();
+}, "A retained named-access collection becomes empty when all matches are removed");
+
+test(t => {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  t.add_cleanup(() => iframe.remove());
+
+  const { contentDocument, contentWindow } = iframe;
+  const first = contentDocument.createElement("div");
+  const second = contentDocument.createElement("span");
+  first.id = "removedDocumentElement";
+  second.id = "removedDocumentElement";
+  contentDocument.body.append(first, second);
+
+  const collection = contentWindow.removedDocumentElement;
+  assert_true(collection instanceof contentWindow.HTMLCollection);
+  assert_array_equals([...collection], [first, second], "initial contents");
+
+  contentDocument.documentElement.remove();
+  assert_array_equals([...collection], [], "after removing the document element");
+
+  const replacementDocumentElement = contentDocument.createElement("html");
+  const replacementBody = contentDocument.createElement("body");
+  const replacementMatch = contentDocument.createElement("p");
+  replacementMatch.id = "removedDocumentElement";
+  replacementBody.append(replacementMatch);
+  replacementDocumentElement.append(replacementBody);
+  contentDocument.append(replacementDocumentElement);
+  assert_array_equals([...collection], [replacementMatch], "after adding a replacement document element");
+}, "A retained named-access collection follows removal of the document element");
+</script>

--- a/test/web-platform-tests/to-upstream/html/dom/documents/dom-tree-accessors/nameditem-tree-transitions.html
+++ b/test/web-platform-tests/to-upstream/html/dom/documents/dom-tree-accessors/nameditem-tree-transitions.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Document named properties across tree transitions</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="reorder-parent"></div>
+<div id="shadow-host"></div>
+
+<script>
+"use strict";
+
+test(() => {
+  const parent = document.querySelector("#reorder-parent");
+  const first = document.createElement("object");
+  const second = document.createElement("object");
+  first.id = "reordered";
+  second.id = "reordered";
+  parent.append(first, second);
+
+  const collection = document.reordered;
+  assert_array_equals([...collection], [first, second], "initial order");
+
+  parent.prepend(second);
+  assert_equals(document.reordered, collection, "collection identity after move");
+  assert_array_equals([...collection], [second, first], "order after move");
+}, "A named-property collection follows same-document moves.");
+
+test(() => {
+  const otherDocument = document.implementation.createHTMLDocument();
+  const object = document.createElement("object");
+  object.id = "adopted";
+  document.body.append(object);
+  assert_equals(document.adopted, object, "before adoption");
+
+  otherDocument.adoptNode(object);
+  assert_equals(document.adopted, undefined, "removed from old document by adoption");
+  assert_equals(otherDocument.adopted, undefined, "not yet inserted into new document");
+
+  otherDocument.body.append(object);
+  assert_equals(otherDocument.adopted, object, "after insertion into new document");
+}, "Named properties follow adoption between documents.");
+
+test(() => {
+  const host = document.querySelector("#shadow-host");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  const form = document.createElement("form");
+  form.name = "shadowTransition";
+  document.body.append(form);
+  assert_equals(document.shadowTransition, form, "in the document tree");
+
+  shadowRoot.append(form);
+  assert_equals(document.shadowTransition, undefined, "in the shadow tree");
+
+  document.body.append(form);
+  assert_equals(document.shadowTransition, form, "moved back into the document tree");
+}, "Named properties follow moves into and out of a shadow tree.");
+</script>


### PR DESCRIPTION
Ordinary reads such as `document.body` consult the Document named-property map. That map currently shares Node’s query cache, so unrelated attribute changes discard it.

Give the map its own private cache and invalidate it only for tree changes or relevant `id` and `name` changes. Removed elements are still released immediately.

| Case | `main` | This PR |
| --- | ---: | ---: |
| Read after unrelated attribute mutation | 30 ops/s | 1,102 ops/s |
| Unrelated attribute changes | 603 ops/s | 600 ops/s |
| Attach/remove unrelated subtree | 2,847 ops/s | 2,903 ops/s |
| Remove named IDs | 1,818 ops/s | 1,821 ops/s |