### PR TITLE
Distinguish document tree membership from connectedness

### DIFF
--- a/lib/jsdom/living/css/helpers/stylesheets.js
+++ b/lib/jsdom/living/css/helpers/stylesheets.js
@@ -19,8 +19,8 @@ exports.fetchStyleSheet = (elementImpl, urlString, importRule) => {
       throw new Error("Status code: " + response.status);
     }
 
-    // if the element was detached before the load could finish, don't process the data
-    if (!elementImpl._attached) {
+    // If the element was disconnected before the load could finish, don't process the data.
+    if (!elementImpl.isConnected) {
       return;
     }
 

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -165,7 +165,7 @@ class DocumentImpl extends NodeImpl {
     this._defaultView = privateData.options.defaultView || null;
     this._global = privateData.options.global;
     this._byIdCache = new ByIdCache(this);
-    this._attached = true;
+    this._isInDocumentTree = true;
     this._currentScript = null;
     this._pageShowingFlag = false;
     this._cookieJar = privateData.options.cookieJar;

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -82,7 +82,7 @@ class ElementImpl extends NodeImpl {
 
     windowProperties.elementAttributeModified(this, name, value, oldValue);
 
-    if (name === "id" && this._attached) {
+    if (name === "id" && this._isInDocumentTree) {
       const cache = this._ownerDocument._byIdCache;
       if (oldValue) {
         cache.delete(oldValue, this);

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -222,7 +222,7 @@ class HTMLFrameElementImpl extends HTMLElementImpl {
     if (name === "src") {
       // iframe should never load in a document without a Window
       // (e.g. implementation.createHTMLDocument)
-      if (this._attached && this._ownerDocument._defaultView) {
+      if (this.isConnected && this._ownerDocument._defaultView) {
         loadFrame(this);
       }
     }

--- a/lib/jsdom/living/nodes/HTMLStyleElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLStyleElement-impl.js
@@ -28,8 +28,7 @@ class HTMLStyleElementImpl extends HTMLElementImpl {
     }
   }
 
-  _detach() {
-    super._detach();
+  _removingSteps() {
     if (!this._isOnStackOfOpenElements) {
       this._updateAStyleBlock();
     }

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -145,6 +145,8 @@ class NodeImpl extends EventTargetImpl {
     this._childrenList = null;
     this._version = 0;
     this._cachedRoot = null;
+    // This cached flag deliberately excludes shadow trees. Use `isConnected` for shadow-including connectedness.
+    this._isInDocumentTree = false;
     this._registeredObserverList = [];
     this._referencedRanges = null; // Lazily-created Set of WeakRef<Range>
   }
@@ -328,13 +330,13 @@ class NodeImpl extends EventTargetImpl {
 
     this._childrenList?._invalidate();
     this._childNodesList?._invalidate();
-    if (this._attached) {
+    if (this.isConnected) {
       this._ownerDocument._clearStyleCache();
     }
   }
 
   _childrenChangedSteps() {
-    if (this._attached) {
+    if (this.isConnected) {
       this._ownerDocument._clearStyleCache();
     }
   }
@@ -354,7 +356,7 @@ class NodeImpl extends EventTargetImpl {
   }
 
   _attach() {
-    this._attached = true;
+    this._isInDocumentTree = true;
 
     for (const child of domSymbolTree.childrenIterator(this)) {
       if (child._attach) {
@@ -364,7 +366,7 @@ class NodeImpl extends EventTargetImpl {
   }
 
   _detach() {
-    this._attached = false;
+    this._isInDocumentTree = false;
 
     if (this._ownerDocument && this._ownerDocument._lastFocusedElement === this) {
       this._ownerDocument._lastFocusedElement = null;
@@ -936,7 +938,7 @@ class NodeImpl extends EventTargetImpl {
         assignSlotableForTree(root);
       }
 
-      if (this._attached) {
+      if (this._isInDocumentTree) {
         node._attach();
       }
 
@@ -1114,9 +1116,16 @@ class NodeImpl extends EventTargetImpl {
     }
 
     this._modified();
-    if (nodeImpl._attached) {
+    if (nodeImpl._isInDocumentTree) {
       nodeImpl._detach();
     }
+
+    for (const inclusiveDescendant of shadowIncludingInclusiveDescendantsIterator(nodeImpl)) {
+      if (inclusiveDescendant._removingSteps) {
+        inclusiveDescendant._removingSteps(this);
+      }
+    }
+
     this._descendantRemoved(this, nodeImpl);
 
     if (this.isConnected) {

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -420,7 +420,6 @@ set-selector-text.html: [fail, Unknown]
 
 DIR: css/css-shadow
 
-css-scoping-shadow-dynamic-remove-style-detached.html: [fail-slow, Unknown]
 font-face-001.html: [fail, Not implemented]
 font-face-002.html: [fail, Not implemented]
 font-face-003.html: [fail, Not implemented]


### PR DESCRIPTION
This makes the attachment cache’s light-tree semantics explicit and fixes stale computed styles when a shadow-tree stylesheet is removed while its host is disconnected.