### PR TITLE
Avoid overallocating attribute cache arrays

### DIFF
--- a/benchmark/dom/attributes.js
+++ b/benchmark/dom/attributes.js
@@ -1,0 +1,21 @@
+"use strict";
+const documentBench = require("../document-bench");
+
+const ELEMENTS_PER_RUN = 100;
+
+module.exports = () => {
+  const { document, bench } = documentBench();
+
+  bench.add("create 100 elements with attributes", () => {
+    for (let i = 0; i < ELEMENTS_PER_RUN; ++i) {
+      const element = document.createElement("div");
+      element.setAttribute("id", "row-1");
+      element.setAttribute("class", "row selected");
+      element.setAttribute("data-index", "1");
+      element.setAttribute("aria-label", "Row 1");
+      element.setAttribute("title", "Row 1");
+    }
+  });
+
+  return bench;
+};

--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -69,6 +69,8 @@ exports.appendAttribute = function (element, attribute) {
   // Sync name cache
   const name = attribute._qualifiedName;
   const cache = element._attributesByNameMap;
+  // This is a hot path, and measurements show that branching to avoid `push()` in the common case is worthwhile:
+  // https://github.com/jsdom/jsdom/pull/4266
   const entry = cache.get(name);
   if (entry === undefined) {
     cache.set(name, [attribute]);

--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -69,12 +69,12 @@ exports.appendAttribute = function (element, attribute) {
   // Sync name cache
   const name = attribute._qualifiedName;
   const cache = element._attributesByNameMap;
-  let entry = cache.get(name);
-  if (!entry) {
-    entry = [];
-    cache.set(name, entry);
+  const entry = cache.get(name);
+  if (entry === undefined) {
+    cache.set(name, [attribute]);
+  } else {
+    entry.push(attribute);
   }
-  entry.push(attribute);
 
   // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is added."
   element._attrModified(name, _value, null);


### PR DESCRIPTION
This is very much a v8 optimization.

Attribute cache entries are arrays because attributes from different namespaces can have the same qualified name. New entries are currently created as an empty array and then immediately pushed into, which causes V8 to reserve unnecessary capacity for the common single-attribute case.

Initialize new entries with `[attribute]` while continuing to push into existing entries. This keeps the cache representation and duplicate-name behavior unchanged.

Results from six alternating fresh-process runs:

| Benchmark | `main` | This PR | Change |
|---|---:|---:|---:|
| Parse 10,000 elements with 50,000 attributes - retained heap | 58.67 MB | 52.28 MB | -10.9% |
| Create 100 elements with five common attributes | 3,968 ops/s | 4,061 ops/s | +2.4% |