### PR TITLE
Compute border-width as an absolute length

### DIFF
--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -6,6 +6,7 @@ const computedValueResolvers = require("../../../generated/css-property-computed
 const propertyDefinitions = require("../../../generated/css-property-definitions");
 const propertyDescriptors = require("../../../generated/css-property-descriptors");
 const propertyMetadata = require("../../../generated/css-property-metadata");
+const resolvedValueResolvers = require("../../../generated/css-property-resolved-value-resolvers");
 const { asciiLowercase } = require("../helpers/strings");
 const computedStyle = require("./helpers/computed-style");
 const cssValues = require("./helpers/css-values");
@@ -177,29 +178,55 @@ class CSSStyleDeclarationImpl {
   /**
    * Returns the value of the specified property.
    *
+   * For a computed style declaration this is the resolved value
+   * (https://drafts.csswg.org/cssom/#resolved-value), which is the computed value except for the
+   * properties in `resolvedValueResolvers`.
+   *
    * @param {string} property - The property name.
    * @returns {string} The property value, or empty string if not set.
    */
   getPropertyValue(property) {
-    const value = this.#values.get(property) ?? "";
     if (this._computed) {
-      if (this.#cachedPropertyValues.has(property)) {
-        const cachedValue = this.#cachedPropertyValues.get(property);
-        // Return the cached resolved value if the specified value haven't changed.
-        if (value === cachedValue.value) {
-          return cachedValue.resolvedValue;
-        }
+      const computedValue = this._getComputedPropertyValue(property);
+      const getResolvedValue = resolvedValueResolvers.get(property);
+      if (getResolvedValue) {
+        return getResolvedValue(computedValue, {
+          getComputedValue: otherProperty => this._getComputedPropertyValue(otherProperty)
+        });
       }
-      const resolvedValue = this.#getComputedValue(property, value);
-      if (propertyDefinitions.has(property)) {
-        const { longhands } = propertyDefinitions.get(property);
-        if (!longhands) {
-          this.#cachedPropertyValues.set(property, { resolvedValue, value });
-        }
-      }
-      return resolvedValue;
+      return computedValue;
     }
-    return value;
+    return this.#values.get(property) ?? "";
+  }
+
+  /**
+   * Returns the computed value (https://drafts.csswg.org/css-cascade/#computed) of the specified
+   * property. Only meaningful on a computed style declaration.
+   *
+   * This is the value inheritance transfers, as opposed to the resolved value that
+   * `getPropertyValue()` returns: a child inherits the 5px of `border-top: 5px none`, while the
+   * resolved value is 0px.
+   *
+   * @param {string} property - The property name.
+   * @returns {string} The computed value, or empty string if not set.
+   */
+  _getComputedPropertyValue(property) {
+    const value = this.#values.get(property) ?? "";
+    if (this.#cachedPropertyValues.has(property)) {
+      const cachedValue = this.#cachedPropertyValues.get(property);
+      // Return the cached computed value if the specified value haven't changed.
+      if (value === cachedValue.value) {
+        return cachedValue.computedValue;
+      }
+    }
+    const computedValue = this.#getComputedValue(property, value);
+    if (propertyDefinitions.has(property)) {
+      const { longhands } = propertyDefinitions.get(property);
+      if (!longhands) {
+        this.#cachedPropertyValues.set(property, { computedValue, value });
+      }
+    }
+    return computedValue;
   }
 
   /**
@@ -566,7 +593,7 @@ class CSSStyleDeclarationImpl {
       { inherit: true, initial: "normal" }
     );
     this.#cachedPropertyValues.set("color-scheme", {
-      resolvedValue: colorScheme,
+      computedValue: colorScheme,
       value: rawColorScheme
     });
     options.colorScheme = colorScheme;
@@ -596,7 +623,7 @@ class CSSStyleDeclarationImpl {
         currentColor = cssValues.resolveColor(currentColor, { format: "computedValue" });
       }
       this.#cachedPropertyValues.set("color", {
-        resolvedValue: currentColor,
+        computedValue: currentColor,
         value: rawColor
       });
     }

--- a/lib/jsdom/living/css/helpers/computed-style.js
+++ b/lib/jsdom/living/css/helpers/computed-style.js
@@ -229,19 +229,20 @@ function getInheritedPropertyValue(property, elementImpl, { inherit, initial, is
     } else {
       declaration = prepareComputedStyleDeclaration(parent, styleCache);
     }
-    // For color-related properties, unset the _computed flag to retrieve the specified value.
-    // @asamuzakjp/css-color handles the resolution of the specified value.
     if (isColor) {
+      // For color-related properties, unset the _computed flag to retrieve the specified value.
+      // @asamuzakjp/css-color handles the resolution of the specified value.
       declaration._computed = false;
-    }
-    value = declaration.getPropertyValue(property);
-    if (isColor) {
+      value = declaration.getPropertyValue(property);
       // Restore the _computed flag.
       declaration._computed = true;
       // If the value is a system color value, retrieve it again as a computed value.
       if (value && systemColors.has(asciiLowercase(value))) {
         value = declaration.getPropertyValue(property);
       }
+    } else {
+      // Inheritance transfers the computed value, not the resolved value getPropertyValue() returns.
+      value = declaration._getComputedPropertyValue(property);
     }
     if (value) {
       if (isColor && isGlobalKeyword(value)) {

--- a/lib/jsdom/living/css/helpers/font-sizes.js
+++ b/lib/jsdom/living/css/helpers/font-sizes.js
@@ -102,9 +102,12 @@ function replaceFontSizePercentages(size, em) {
 
 function resolveLengthInPixels(elementImpl, size, dimension, isFontSize) {
   const { em, rem, vh, vw } = dimension;
-  if (absoluteFontSize.has(size)) {
+  // The absolute and relative keywords below are font-size keywords. Other length
+  // properties have keywords of their own — `medium` is 3px of border, not 16px —
+  // so they must not be resolved out of these tables.
+  if (isFontSize && absoluteFontSize.has(size)) {
     return absoluteFontSize.get(size).px;
-  } else if (relativeFontSize.has(size)) {
+  } else if (isFontSize && relativeFontSize.has(size)) {
     return relativeFontSize.get(size) * em;
   } else if (cssValues.hasCalcFunc(size)) {
     let calcDimension = dimension;

--- a/lib/jsdom/living/css/helpers/line-widths.js
+++ b/lib/jsdom/living/css/helpers/line-widths.js
@@ -1,0 +1,53 @@
+"use strict";
+
+// The <line-width> keywords, as resolved by Chrome and Firefox. The values are
+// implementation-defined; the spec only requires thin <= medium <= thick.
+const lineWidthKeywords = new Map([
+  ["thin", "1px"],
+  ["medium", "3px"],
+  ["thick", "5px"]
+]);
+
+// A border with one of these styles draws nothing and reserves no width.
+const noBorderStyles = new Set(["none", "hidden"]);
+
+/**
+ * Resolves the computed value of a <line-width>: an absolute length.
+ *
+ * The computed value depends on nothing but the specified value; in particular not on the
+ * border style beside it, since it is the computed value that inheritance transfers.
+ *
+ * @param {string} value - The specified value.
+ * @param {object} resolvers - The computed value resolvers.
+ * @param {Function} resolvers.resolveDefault - Resolves the value the default way.
+ * @returns {string} The computed value.
+ */
+function resolveLineWidth(value, { resolveDefault }) {
+  if (lineWidthKeywords.has(value)) {
+    return lineWidthKeywords.get(value);
+  }
+  return resolveDefault(value);
+}
+
+/**
+ * Returns the resolved value of a border-*-width property.
+ *
+ * Per https://drafts.csswg.org/css-backgrounds/#the-border-width, the used width is 0 if the
+ * corresponding border style is none or hidden. Browsers expose that as the resolved value,
+ * while the computed value - and so what a child inherits - stays the absolute length.
+ *
+ * @param {string} computedValue - The computed value.
+ * @param {string} styleProperty - The border-*-style property beside it.
+ * @param {object} resolvers - The resolved value resolvers.
+ * @param {Function} resolvers.getComputedValue - Reads another property's computed value.
+ * @returns {string} The resolved value.
+ */
+function getResolvedBorderWidth(computedValue, styleProperty, { getComputedValue }) {
+  if (noBorderStyles.has(getComputedValue(styleProperty))) {
+    return "0px";
+  }
+  return computedValue;
+}
+
+exports.getResolvedBorderWidth = getResolvedBorderWidth;
+exports.resolveLineWidth = resolveLineWidth;

--- a/lib/jsdom/living/css/helpers/line-widths.js
+++ b/lib/jsdom/living/css/helpers/line-widths.js
@@ -1,7 +1,6 @@
 "use strict";
 
-// The <line-width> keywords, as resolved by Chrome and Firefox. The values are
-// implementation-defined; the spec only requires thin <= medium <= thick.
+// The `<line-width>` keyword values defined by CSS Backgrounds.
 const lineWidthKeywords = new Map([
   ["thin", "1px"],
   ["medium", "3px"],

--- a/lib/jsdom/living/css/properties/borderBottomWidth.js
+++ b/lib/jsdom/living/css/properties/borderBottomWidth.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const parsers = require("../helpers/css-values");
+const { getResolvedBorderWidth, resolveLineWidth } = require("../helpers/line-widths");
 
 const property = "border-bottom-width";
 const lineShorthand = "border-width";
@@ -33,6 +34,14 @@ const descriptor = {
   configurable: true
 };
 
+function resolveComputedValue(value, resolvers) {
+  return resolveLineWidth(value, resolvers);
+}
+
+function getResolvedValue(computedValue, resolvers) {
+  return getResolvedBorderWidth(computedValue, "border-bottom-style", resolvers);
+}
+
 /**
  * Parses the border-bottom-width property value.
  *
@@ -57,6 +66,8 @@ function parse(v) {
 
 module.exports = {
   descriptor,
+  getResolvedValue,
   parse,
-  property
+  property,
+  resolveComputedValue
 };

--- a/lib/jsdom/living/css/properties/borderLeftWidth.js
+++ b/lib/jsdom/living/css/properties/borderLeftWidth.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const parsers = require("../helpers/css-values");
+const { getResolvedBorderWidth, resolveLineWidth } = require("../helpers/line-widths");
 
 const property = "border-left-width";
 const lineShorthand = "border-width";
@@ -33,6 +34,14 @@ const descriptor = {
   configurable: true
 };
 
+function resolveComputedValue(value, resolvers) {
+  return resolveLineWidth(value, resolvers);
+}
+
+function getResolvedValue(computedValue, resolvers) {
+  return getResolvedBorderWidth(computedValue, "border-left-style", resolvers);
+}
+
 /**
  * Parses the border-left-width property value.
  *
@@ -57,6 +66,8 @@ function parse(v) {
 
 module.exports = {
   descriptor,
+  getResolvedValue,
   parse,
-  property
+  property,
+  resolveComputedValue
 };

--- a/lib/jsdom/living/css/properties/borderRightWidth.js
+++ b/lib/jsdom/living/css/properties/borderRightWidth.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const parsers = require("../helpers/css-values");
+const { getResolvedBorderWidth, resolveLineWidth } = require("../helpers/line-widths");
 
 const property = "border-right-width";
 const lineShorthand = "border-width";
@@ -33,6 +34,14 @@ const descriptor = {
   configurable: true
 };
 
+function resolveComputedValue(value, resolvers) {
+  return resolveLineWidth(value, resolvers);
+}
+
+function getResolvedValue(computedValue, resolvers) {
+  return getResolvedBorderWidth(computedValue, "border-right-style", resolvers);
+}
+
 /**
  * Parses the border-right-width property value.
  *
@@ -57,6 +66,8 @@ function parse(v) {
 
 module.exports = {
   descriptor,
+  getResolvedValue,
   parse,
-  property
+  property,
+  resolveComputedValue
 };

--- a/lib/jsdom/living/css/properties/borderTopWidth.js
+++ b/lib/jsdom/living/css/properties/borderTopWidth.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const parsers = require("../helpers/css-values");
+const { getResolvedBorderWidth, resolveLineWidth } = require("../helpers/line-widths");
 
 const property = "border-top-width";
 const lineShorthand = "border-width";
@@ -33,6 +34,14 @@ const descriptor = {
   configurable: true
 };
 
+function resolveComputedValue(value, resolvers) {
+  return resolveLineWidth(value, resolvers);
+}
+
+function getResolvedValue(computedValue, resolvers) {
+  return getResolvedBorderWidth(computedValue, "border-top-style", resolvers);
+}
+
 /**
  * Parses the border-top-width property value.
  *
@@ -57,6 +66,8 @@ function parse(v) {
 
 module.exports = {
   descriptor,
+  getResolvedValue,
   parse,
-  property
+  property,
+  resolveComputedValue
 };

--- a/scripts/generate-css-style-properties.js
+++ b/scripts/generate-css-style-properties.js
@@ -59,6 +59,8 @@ module.exports = new Map(${JSON.stringify([...definitions], undefined, 2)});
     const requires = [];
     const computedValueResolverRequires = [];
     const computedValueResolvers = [];
+    const resolvedValueResolverRequires = [];
+    const resolvedValueResolvers = [];
     const descriptors = [];
     const metadata = [];
     for (const [canonicalProperty, { legacyAliasOf, styleDeclaration, syntax }] of definitions) {
@@ -75,6 +77,12 @@ module.exports = new Map(${JSON.stringify([...definitions], undefined, 2)});
             `const ${camelizedProperty} = require("../jsdom/living/css/properties/${fileName}");`
           );
           computedValueResolvers.push(`["${canonicalProperty}", ${camelizedProperty}.resolveComputedValue]`);
+        }
+        if (typeof implementation.getResolvedValue === "function") {
+          resolvedValueResolverRequires.push(
+            `const ${camelizedProperty} = require("../jsdom/living/css/properties/${fileName}");`
+          );
+          resolvedValueResolvers.push(`["${canonicalProperty}", ${camelizedProperty}.getResolvedValue]`);
         }
         const opts = createDescriptorOpts(syntax);
         metadata.push([canonicalProperty, opts]);
@@ -106,6 +114,13 @@ module.exports = new Map([
   ${computedValueResolvers.join(",\n  ")}
 ]);
 `;
+    const resolvedValueResolverOutput = `"use strict";
+${resolvedValueResolverRequires.sort().join("\n")}
+
+module.exports = new Map([
+  ${resolvedValueResolvers.join(",\n  ")}
+]);
+`;
     const metadataOutput = `"use strict";
 module.exports = new Map(${JSON.stringify(metadata, undefined, 2)});
 `;
@@ -113,6 +128,10 @@ module.exports = new Map(${JSON.stringify(metadata, undefined, 2)});
       fs.writeFile(
         path.resolve(outputDir, "css-property-computed-value-resolvers.js"),
         computedValueResolverOutput
+      ),
+      fs.writeFile(
+        path.resolve(outputDir, "css-property-resolved-value-resolvers.js"),
+        resolvedValueResolverOutput
       ),
       fs.writeFile(path.resolve(outputDir, "css-property-descriptors.js"), descriptorOutput),
       fs.writeFile(path.resolve(outputDir, "css-property-metadata.js"), metadataOutput)

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -66,7 +66,7 @@ simple-requests.htm: [timeout, Maybe https://github.com/jsdom/jsdom/issues/1833 
 
 DIR: css/css-backgrounds
 
-animations/*: [fail, Not implemented]
+animations/!(border-bottom-width-composition|border-left-width-composition|border-right-width-composition|border-top-width-composition).html: [fail, Not implemented]
 background-331.html:
   "background_initial_position": [fail, background-position not resolved to computed value]
 background-332.html:
@@ -86,7 +86,6 @@ background-size-001.html:
   "background-size_percentage_auto": [fail, Unknown]
 border-image-slice-shorthand-reset.html: [fail, Not implemented]
 border-radius-css-text.html: [fail, Not implemented]
-border-width-cssom.html: [fail, Unknown]
 inheritance.sub.html: [fail, Unknown]
 parsing/background-attachment-invalid.html: [fail, Unknown]
 parsing/background-clip-computed.html: [fail, Need to fix getComputedStyle]

--- a/test/web-platform-tests/to-upstream/css/css-borders/border-width-computed.html
+++ b/test/web-platform-tests/to-upstream/css/css-borders/border-width-computed.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Computed and resolved value of border-width for a border that is not drawn</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#the-border-width">
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- The line-width keywords themselves are covered by
+     css/css-backgrounds/border-width-cssom.html. -->
+
+<div id="div"></div>
+<div id="parent"><div id="child"></div></div>
+
+<script>
+"use strict";
+
+const div = document.getElementById("div");
+const parentDiv = document.getElementById("parent");
+const childDiv = document.getElementById("child");
+
+function computedBorderTopWidth(element, cssText) {
+  element.style.cssText = cssText;
+
+  return window.getComputedStyle(element).getPropertyValue("border-top-width");
+}
+
+test(() => {
+  assert_equals(computedBorderTopWidth(div, ""), "0px", "no border at all");
+  assert_equals(computedBorderTopWidth(div, "border-style: none; border-width: medium"), "0px", "none, keyword width");
+  assert_equals(computedBorderTopWidth(div, "border-style: none; border-width: 5px"), "0px", "none, length width");
+  assert_equals(computedBorderTopWidth(div, "border-style: hidden; border-width: 5px"), "0px", "hidden, length width");
+}, "A border whose style is none or hidden resolves to zero width");
+
+test(() => {
+  assert_equals(computedBorderTopWidth(parentDiv, "border-top: 5px none"), "0px", "parent");
+  assert_equals(
+    computedBorderTopWidth(childDiv, "border-top-style: solid; border-top-width: inherit"),
+    "5px",
+    "child"
+  );
+}, "The zero width is not what a child inherits: the computed value stays the length");
+
+test(() => {
+  assert_equals(computedBorderTopWidth(parentDiv, "border-top: thick hidden"), "0px", "parent");
+  assert_equals(
+    computedBorderTopWidth(childDiv, "border-top-style: solid; border-top-width: inherit"),
+    "5px",
+    "child"
+  );
+}, "A child inherits a line-width keyword as the absolute length it computes to");
+
+test(() => {
+  assert_equals(computedBorderTopWidth(parentDiv, "border-top: 5px none"), "0px", "parent");
+  assert_equals(computedBorderTopWidth(childDiv, "border-top-width: inherit"), "0px", "child");
+}, "A child with its own border style none resolves the inherited width to zero");
+
+test(() => {
+  assert_equals(
+    computedBorderTopWidth(div, "font-size: 20px; border-style: solid; border-width: 1em"),
+    "20px"
+  );
+}, "A border-width in em computes against the element's own font size");
+
+test(() => {
+  div.style.cssText = "font-size: medium";
+
+  assert_equals(window.getComputedStyle(div).getPropertyValue("font-size"), "16px");
+}, "The font-size keyword sharing a name with a line-width keyword is unaffected");
+</script>


### PR DESCRIPTION
Fixes #4267.

Every length property is resolved through `resolveLengthInPixels`, whose first two branches read the **font-size** keyword tables without consulting `isFontSize`. `medium` is the initial value of `border-width`, so a borderless element reported 16px of border. `isFontSize` now gates those branches — it was already a parameter and already consulted for the `%` case below.

On top of that, nothing mapped the `<line-width>` keywords to lengths; `helpers/line-widths.js` now does, using the values both Chrome and Firefox use. The zero-width rule from [css-backgrounds § border-width](https://drafts.csswg.org/css-backgrounds/#the-border-width) is a *used*-value rule, which browsers expose as the resolved value while the computed value — and so what a child inherits — stays the length. Computed declarations now keep the two apart: a property file can export a `getResolvedValue` hook, collected into a generated registry like `resolveComputedValue`, which `getPropertyValue()` applies on top of the computed value. Inheritance reads the computed value through `_getComputedPropertyValue()` and never sees the resolved one.

`border-width-cssom.html` and the four `border-*-width-composition.html` tests pass now, so they come off `to-run.yaml`. The `animations` expectation has to spell out what it still covers, because the first matching pattern wins and `animations/*` sorts before any narrower one. Those upstream tests cover the keywords, so the added to-upstream test covers the zero resolved width and that a child inherits the computed length.

Motivation: a grid in our CRM frontend sizes columns to their content, adding what each container reserves to the right of it — `paddingRight + borderRightWidth`. On jsdom 30 every borderless element inside a cell contributed a phantom 16px, so measurements came out too wide by 16px per nesting level. Browsers were fine; only the test environment was wrong.

Left alone: `outline-width` and `column-rule-width` take the same keywords and are still unresolved. They want the same treatment, but `outline-width` has its own zero-if-`none` rule, so it seemed better kept separate.
