### PR TITLE
Reduce MutationObserver bookkeeping allocations

### DIFF
--- a/benchmark/dom/mutation-observer.js
+++ b/benchmark/dom/mutation-observer.js
@@ -2,11 +2,37 @@
 const { Bench } = require("tinybench");
 const { JSDOM } = require("../..");
 
-const RECORDS_PER_RUN = 1000;
+const MUTATIONS_PER_QUEUE_RUN = 100;
+const RECORDS_PER_DELIVERY_RUN = 1000;
 const recordsPerDeliveryValues = [1, 10, 100, 1000];
 
 module.exports = () => {
   const bench = new Bench();
+
+  addQueueBenchmark(bench, "queue 100 attribute records, no observers", () => []);
+  addQueueBenchmark(bench, "queue 100 attribute records, one observer", (window, ancestor, target) => {
+    const observer = new window.MutationObserver(() => {});
+    observer.observe(target, { attributes: true });
+    return [observer];
+  });
+  addQueueBenchmark(
+    bench,
+    "queue 100 attribute records, one observer on target and ancestor",
+    (window, ancestor, target) => {
+      const observer = new window.MutationObserver(() => {});
+      observer.observe(target, { attributes: true });
+      observer.observe(ancestor, { attributes: true, attributeOldValue: true, subtree: true });
+      return [observer];
+    }
+  );
+  addQueueBenchmark(bench, "queue 100 attribute records, two observers", (window, ancestor, target) => {
+    const targetObserver = new window.MutationObserver(() => {});
+    targetObserver.observe(target, { attributes: true });
+
+    const ancestorObserver = new window.MutationObserver(() => {});
+    ancestorObserver.observe(ancestor, { attributes: true, attributeOldValue: true, subtree: true });
+    return [targetObserver, ancestorObserver];
+  });
 
   for (const recordsPerDelivery of recordsPerDeliveryValues) {
     addDeliveryBenchmark(bench, recordsPerDelivery);
@@ -15,11 +41,31 @@ module.exports = () => {
   return bench;
 };
 
+function addQueueBenchmark(bench, name, setupObservers) {
+  const { window } = new JSDOM();
+  const ancestor = window.document.createElement("div");
+  const target = ancestor.appendChild(window.document.createElement("div"));
+  window.document.body.append(ancestor);
+  const observers = setupObservers(window, ancestor, target);
+
+  bench.add(name, () => {
+    for (let i = 0; i < MUTATIONS_PER_QUEUE_RUN; ++i) {
+      target.setAttribute("data-value", i & 1 ? "a" : "b");
+    }
+  }, {
+    afterEach() {
+      for (const observer of observers) {
+        observer.takeRecords();
+      }
+    }
+  });
+}
+
 function addDeliveryBenchmark(bench, recordsPerDelivery) {
   const { document, MutationObserver } = (new JSDOM()).window;
   const target = document.createElement("div");
   document.body.append(target);
-  const deliveryCount = RECORDS_PER_RUN / recordsPerDelivery;
+  const deliveryCount = RECORDS_PER_DELIVERY_RUN / recordsPerDelivery;
 
   let resolveDelivery;
   const observer = new MutationObserver(() => {
@@ -28,7 +74,7 @@ function addDeliveryBenchmark(bench, recordsPerDelivery) {
   observer.observe(target, { attributes: true });
 
   let value = 0;
-  bench.add(`queue and deliver ${RECORDS_PER_RUN} records, ${recordsPerDelivery} per callback`, async () => {
+  bench.add(`queue and deliver ${RECORDS_PER_DELIVERY_RUN} records, ${recordsPerDelivery} per callback`, async () => {
     for (let batch = 0; batch < deliveryCount; ++batch) {
       const delivery = Promise.withResolvers();
       resolveDelivery = delivery.resolve;

--- a/benchmark/dom/mutation-observer.js
+++ b/benchmark/dom/mutation-observer.js
@@ -1,0 +1,43 @@
+"use strict";
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+const RECORDS_PER_RUN = 1000;
+const recordsPerDeliveryValues = [1, 10, 100, 1000];
+
+module.exports = () => {
+  const bench = new Bench();
+
+  for (const recordsPerDelivery of recordsPerDeliveryValues) {
+    addDeliveryBenchmark(bench, recordsPerDelivery);
+  }
+
+  return bench;
+};
+
+function addDeliveryBenchmark(bench, recordsPerDelivery) {
+  const { document, MutationObserver } = (new JSDOM()).window;
+  const target = document.createElement("div");
+  document.body.append(target);
+  const deliveryCount = RECORDS_PER_RUN / recordsPerDelivery;
+
+  let resolveDelivery;
+  const observer = new MutationObserver(() => {
+    resolveDelivery();
+  });
+  observer.observe(target, { attributes: true });
+
+  let value = 0;
+  bench.add(`queue and deliver ${RECORDS_PER_RUN} records, ${recordsPerDelivery} per callback`, async () => {
+    for (let batch = 0; batch < deliveryCount; ++batch) {
+      const delivery = Promise.withResolvers();
+      resolveDelivery = delivery.resolve;
+
+      for (let i = 0; i < recordsPerDelivery; ++i) {
+        target.setAttribute("data-value", String(value++));
+      }
+
+      await delivery.promise;
+    }
+  });
+}

--- a/benchmark/dom/mutation-observer.js
+++ b/benchmark/dom/mutation-observer.js
@@ -9,15 +9,15 @@ const recordsPerDeliveryValues = [1, 10, 100, 1000];
 module.exports = () => {
   const bench = new Bench();
 
-  addQueueBenchmark(bench, "queue 100 attribute records, no observers", () => []);
-  addQueueBenchmark(bench, "queue 100 attribute records, one observer", (window, ancestor, target) => {
+  addQueueBenchmark(bench, "setAttribute(): 100 mutations, no observers", () => []);
+  addQueueBenchmark(bench, "setAttribute(): 100 mutations, one observer", (window, ancestor, target) => {
     const observer = new window.MutationObserver(() => {});
     observer.observe(target, { attributes: true });
     return [observer];
   });
   addQueueBenchmark(
     bench,
-    "queue 100 attribute records, one observer on target and ancestor",
+    "setAttribute(): 100 mutations, one observer on target and ancestor",
     (window, ancestor, target) => {
       const observer = new window.MutationObserver(() => {});
       observer.observe(target, { attributes: true });
@@ -25,7 +25,7 @@ module.exports = () => {
       return [observer];
     }
   );
-  addQueueBenchmark(bench, "queue 100 attribute records, two observers", (window, ancestor, target) => {
+  addQueueBenchmark(bench, "setAttribute(): 100 mutations, two observers", (window, ancestor, target) => {
     const targetObserver = new window.MutationObserver(() => {});
     targetObserver.observe(target, { attributes: true });
 

--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -55,7 +55,12 @@ function queueMutationRecord(
   let interestedObservers = null;
 
   for (let node = target; node !== null; node = domSymbolTree.parent(node)) {
-    for (const registered of node._registeredObserverList) {
+    const registeredObserverList = node._registeredObserverList;
+    if (registeredObserverList === null) {
+      continue;
+    }
+
+    for (const registered of registeredObserverList) {
       const { options, observer: mo } = registered;
 
       if (

--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -29,6 +29,12 @@ const activeMutationObservers = new Set();
 // https://dom.spec.whatwg.org/#signal-slot-list
 const signalSlotList = [];
 
+function appendMutationRecord(observer, recordData) {
+  const record = MutationRecord.createImpl(recordData.target._globalObject, [], recordData);
+  observer._recordQueue.push(record);
+  activeMutationObservers.add(observer);
+}
+
 // https://dom.spec.whatwg.org/#queue-a-mutation-record
 function queueMutationRecord(
   type,
@@ -41,11 +47,12 @@ function queueMutationRecord(
   previousSibling,
   nextSibling
 ) {
-  const interestedObservers = new Map();
+  // Avoid allocating the spec's interested-observers map until a second distinct observer matches.
+  let firstInterestedObserver = null;
+  let firstMappedOldValue = null;
+  let interestedObservers = null;
 
-  const nodes = domSymbolTree.ancestorsToArray(target);
-
-  for (const node of nodes) {
+  for (let node = target; node !== null; node = domSymbolTree.parent(node)) {
     for (const registered of node._registeredObserverList) {
       const { options, observer: mo } = registered;
 
@@ -57,35 +64,54 @@ function queueMutationRecord(
         !(type === MUTATION_TYPE.CHARACTER_DATA && options.characterData !== true) &&
         !(type === MUTATION_TYPE.CHILD_LIST && options.childList === false)
       ) {
-        if (!interestedObservers.has(mo)) {
-          interestedObservers.set(mo, null);
-        }
-
-        if (
+        const requestsOldValue =
           (type === MUTATION_TYPE.ATTRIBUTES && options.attributeOldValue === true) ||
-          (type === MUTATION_TYPE.CHARACTER_DATA && options.characterDataOldValue === true)
-        ) {
-          interestedObservers.set(mo, oldValue);
+          (type === MUTATION_TYPE.CHARACTER_DATA && options.characterDataOldValue === true);
+
+        if (interestedObservers !== null) {
+          if (!interestedObservers.has(mo)) {
+            interestedObservers.set(mo, null);
+          }
+          if (requestsOldValue) {
+            interestedObservers.set(mo, oldValue);
+          }
+        } else if (firstInterestedObserver === null) {
+          firstInterestedObserver = mo;
+          firstMappedOldValue = requestsOldValue ? oldValue : null;
+        } else if (firstInterestedObserver === mo) {
+          if (requestsOldValue) {
+            firstMappedOldValue = oldValue;
+          }
+        } else {
+          interestedObservers = new Map();
+          interestedObservers.set(firstInterestedObserver, firstMappedOldValue);
+          interestedObservers.set(mo, requestsOldValue ? oldValue : null);
         }
       }
     }
   }
 
-  for (const [observer, mappedOldValue] of interestedObservers.entries()) {
-    const record = MutationRecord.createImpl(target._globalObject, [], {
+  if (firstInterestedObserver !== null) {
+    const recordData = {
       type,
       target,
       attributeName: name,
       attributeNamespace: namespace,
-      oldValue: mappedOldValue,
+      oldValue: firstMappedOldValue,
       addedNodes,
       removedNodes,
       previousSibling,
       nextSibling
-    });
+    };
 
-    observer._recordQueue.push(record);
-    activeMutationObservers.add(observer);
+    if (interestedObservers === null) {
+      appendMutationRecord(firstInterestedObserver, recordData);
+    } else {
+      for (const [observer, mappedOldValue] of interestedObservers) {
+        recordData.oldValue = mappedOldValue;
+        appendMutationRecord(observer, recordData);
+      }
+    }
   }
 
   queueMutationObserverMicrotask();

--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -145,8 +145,8 @@ function notifyMutationObservers() {
   signalSlotList.splice(0, signalSlotList.length);
 
   for (const mo of notifyList) {
-    // Transfer the internal queue instead of cloning it. Replacing it before invoking the callback preserves the
-    // spec's clone-and-empty behavior.
+    // This is a hot path, and replacing the record queue before invoking the callback makes it safe to avoid cloning:
+    // https://github.com/jsdom/jsdom/pull/4269
     const records = mo._recordQueue;
     mo._recordQueue = [];
 

--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -47,7 +47,9 @@ function queueMutationRecord(
   previousSibling,
   nextSibling
 ) {
-  // Avoid allocating the spec's interested-observers map until a second distinct observer matches.
+  // This is a hot path, and measurements show that avoiding the spec's interested-observers map for zero or one
+  // matching observer is worthwhile:
+  // https://github.com/jsdom/jsdom/pull/4269
   let firstInterestedObserver = null;
   let firstMappedOldValue = null;
   let interestedObservers = null;

--- a/lib/jsdom/living/helpers/mutation-observers.js
+++ b/lib/jsdom/living/helpers/mutation-observers.js
@@ -145,7 +145,9 @@ function notifyMutationObservers() {
   signalSlotList.splice(0, signalSlotList.length);
 
   for (const mo of notifyList) {
-    const records = [...mo._recordQueue];
+    // Transfer the internal queue instead of cloning it. Replacing it before invoking the callback preserves the
+    // spec's clone-and-empty behavior.
+    const records = mo._recordQueue;
     mo._recordQueue = [];
 
     for (const node of mo._nodeList) {

--- a/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
+++ b/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
@@ -48,7 +48,7 @@ class MutationObserverImpl {
         "true or not present.");
     }
 
-    const existingRegisteredObserver = target._registeredObserverList.find(registeredObserver => {
+    const existingRegisteredObserver = target._registeredObserverList?.find(registeredObserver => {
       return registeredObserver.observer === this;
     });
 
@@ -66,7 +66,7 @@ class MutationObserverImpl {
         options
       };
 
-      if (target._registeredObserverList.length === 0) {
+      if (target._registeredObserverList === null) {
         target._registeredObserverList = [registeredObserver];
       } else {
         target._registeredObserverList.push(registeredObserver);

--- a/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
+++ b/lib/jsdom/living/mutation-observer/MutationObserver-impl.js
@@ -61,10 +61,16 @@ class MutationObserverImpl {
 
       existingRegisteredObserver.options = options;
     } else {
-      target._registeredObserverList.push({
+      const registeredObserver = {
         observer: this,
         options
-      });
+      };
+
+      if (target._registeredObserverList.length === 0) {
+        target._registeredObserverList = [registeredObserver];
+      } else {
+        target._registeredObserverList.push(registeredObserver);
+      }
 
       this._nodeList.append(target);
     }

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -27,9 +27,6 @@ const {
   shadowIncludingInclusiveDescendantsIterator, shadowIncludingDescendantsIterator
 } = require("../helpers/shadow-dom");
 
-// `observe()` replaces this before adding an entry. This is intentionally not frozen; every mutation iterates it.
-const emptyRegisteredObserverList = [];
-
 function nodeEquals(a, b) {
   if (a.nodeType !== b.nodeType) {
     return false;
@@ -149,7 +146,8 @@ class NodeImpl extends EventTargetImpl {
     this._cachedRoot = null;
     // This cached flag deliberately excludes shadow trees. Use `isConnected` for shadow-including connectedness.
     this._isInDocumentTree = false;
-    this._registeredObserverList = emptyRegisteredObserverList;
+    // Most nodes are never observed, so allocate their registration lists lazily.
+    this._registeredObserverList = null;
     this._referencedRanges = null; // Lazily-created Set of WeakRef<Range>
   }
 

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -27,6 +27,9 @@ const {
   shadowIncludingInclusiveDescendantsIterator, shadowIncludingDescendantsIterator
 } = require("../helpers/shadow-dom");
 
+// `observe()` replaces this before adding an entry. This is intentionally not frozen; every mutation iterates it.
+const emptyRegisteredObserverList = [];
+
 function nodeEquals(a, b) {
   if (a.nodeType !== b.nodeType) {
     return false;
@@ -146,7 +149,7 @@ class NodeImpl extends EventTargetImpl {
     this._cachedRoot = null;
     // This cached flag deliberately excludes shadow trees. Use `isConnected` for shadow-including connectedness.
     this._isInDocumentTree = false;
-    this._registeredObserverList = [];
+    this._registeredObserverList = emptyRegisteredObserverList;
     this._referencedRanges = null; // Lazily-created Set of WeakRef<Range>
   }
 

--- a/test/web-platform-tests/to-upstream/dom/nodes/MutationObserver-overlapping-registrations.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/MutationObserver-overlapping-registrations.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>MutationObserver overlapping registrations</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  "use strict";
+
+  test(() => {
+    for (const [targetRequestsOldValue, ancestorRequestsOldValue] of [[false, true], [true, false]]) {
+      const ancestor = document.createElement("div");
+      const target = ancestor.appendChild(document.createElement("div"));
+      target.setAttribute("data-value", "before");
+
+      const observer = new MutationObserver(() => {});
+      observer.observe(target, { attributes: true, attributeOldValue: targetRequestsOldValue });
+      observer.observe(ancestor, {
+        attributes: true,
+        attributeOldValue: ancestorRequestsOldValue,
+        subtree: true
+      });
+
+      target.setAttribute("data-value", "after");
+      const records = observer.takeRecords();
+      assert_equals(records.length, 1, "the observer receives one record");
+      assert_equals(records[0].oldValue, "before", "the record includes the requested old value");
+      observer.disconnect();
+    }
+  }, "An observer matching through multiple registrations receives one record with the requested old value");
+
+  test(() => {
+    const ancestor = document.createElement("div");
+    const target = ancestor.appendChild(document.createElement("div"));
+    target.setAttribute("data-value", "before");
+
+    const overlappingObserver = new MutationObserver(() => {});
+    overlappingObserver.observe(target, { attributes: true });
+
+    const ancestorObserver = new MutationObserver(() => {});
+    ancestorObserver.observe(ancestor, { attributes: true, subtree: true });
+
+    overlappingObserver.observe(ancestor, { attributes: true, attributeOldValue: true, subtree: true });
+
+    target.setAttribute("data-value", "after");
+    const overlappingRecords = overlappingObserver.takeRecords();
+    const ancestorRecords = ancestorObserver.takeRecords();
+
+    assert_equals(overlappingRecords.length, 1, "the overlapping observer receives one record");
+    assert_equals(overlappingRecords[0].oldValue, "before", "the overlapping observer receives the old value");
+    assert_equals(ancestorRecords.length, 1, "the ancestor observer receives one record");
+    assert_equals(ancestorRecords[0].oldValue, null, "the ancestor observer does not receive the old value");
+
+    overlappingObserver.disconnect();
+    ancestorObserver.disconnect();
+  }, "Distinct observers matching the same mutation receive records using their own options");
+</script>

--- a/test/web-platform-tests/to-upstream/dom/nodes/MutationObserver-overlapping-registrations.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/MutationObserver-overlapping-registrations.html
@@ -7,6 +7,23 @@
   "use strict";
 
   test(() => {
+    const firstTarget = document.createElement("div");
+    const secondTarget = document.createElement("div");
+    const firstObserver = new MutationObserver(() => {});
+    const secondObserver = new MutationObserver(() => {});
+
+    firstObserver.observe(firstTarget, { attributes: true });
+    secondObserver.observe(secondTarget, { attributes: true });
+
+    firstTarget.setAttribute("data-value", "after");
+    assert_equals(firstObserver.takeRecords().length, 1, "the first observer receives the mutation");
+    assert_equals(secondObserver.takeRecords().length, 0, "the second observer does not receive the mutation");
+
+    firstObserver.disconnect();
+    secondObserver.disconnect();
+  }, "Observers registered on separate targets do not share registrations");
+
+  test(() => {
     for (const [targetRequestsOldValue, ancestorRequestsOldValue] of [[false, true], [true, false]]) {
       const ancestor = document.createElement("div");
       const target = ancestor.appendChild(document.createElement("div"));


### PR DESCRIPTION
This removes several short-lived allocations from MutationObserver bookkeeping.

- Nodes share an empty registration list until the first `observe()`.
- Mutations walk the parent chain directly instead of creating an ancestor array. The first matching observer is stored directly, with the existing `Map` path used when another observer matches.
- Delivery replaces the record queue before calling the observer and uses the old queue directly instead of cloning it.

The `Map` fallback preserves deduplication and each observer's `oldValue` options. Replacing the record queue first keeps records created by the callback in the next delivery.

Testing Library's `waitFor()` normally observes one subtree, so the zero- and one-observer paths are common during DOM updates.

Median throughput from six runs:

| 100 attribute mutations | `main` | This PR | Change |
|---|---:|---:|---:|
| No observers | 31,915 ops/s | 34,042 ops/s | +6.4% |
| One observer | 21,858 ops/s | 23,857 ops/s | +8.8% |
| One observer on the target and an ancestor | 20,735 ops/s | 22,945 ops/s | +11.0% |
| Two observers | 16,388 ops/s | 16,575 ops/s | +1.6% |

Queue-and-delivery throughput improved 6.1–9.4% across batches of 1 to 1,000 records.

| Benchmark | `main` | This PR | Change |
|---|---:|---:|---:|
| 30,000-element tree, retained heap | 52.12 MB | 51.17 MB | -1.84% |
| 2,000-row React mount, retained heap | 54.47 MB | 53.51 MB | -1.77% |
