### PR TITLE
Add no-op setPointerCapture/releasePointerCapture/hasPointerCapture to Element

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -541,6 +541,17 @@ class ElementImpl extends NodeImpl {
     return this.matches(selectors);
   }
 
+  // https://w3c.github.io/pointerevents/#dom-element-setpointercapture
+  // jsdom does not implement pointer capture or hit-testing, so these are no-ops provided for API
+  // compatibility with code that feature-detects Pointer Events support via `window.PointerEvent`.
+  setPointerCapture() {}
+
+  releasePointerCapture() {}
+
+  hasPointerCapture() {
+    return false;
+  }
+
   // https://html.spec.whatwg.org/#reflecting-content-attributes-in-idl-attributes
   _reflectGetTheElement() {
     return this;

--- a/lib/jsdom/living/nodes/Element.webidl
+++ b/lib/jsdom/living/nodes/Element.webidl
@@ -90,3 +90,10 @@ partial interface Element {
 };
 
 Element includes ARIAMixin;
+
+// https://w3c.github.io/pointerevents/#pointerevent-interface
+partial interface Element {
+  undefined setPointerCapture(long pointerId);
+  undefined releasePointerCapture(long pointerId);
+  boolean hasPointerCapture(long pointerId);
+};

--- a/test/web-platform-tests/to-upstream/jsdom-only/pointer-capture-noop.html
+++ b/test/web-platform-tests/to-upstream/jsdom-only/pointer-capture-noop.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Element pointer capture methods are no-ops</title>
+<link rel="help" href="https://w3c.github.io/pointerevents/#dom-element-setpointercapture">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button></button>
+
+<script>
+"use strict";
+
+// jsdom does not implement pointer capture or hit-testing, so it does not track active pointers and cannot
+// meaningfully validate the pointerId. Real browsers throw a DOMException for an unknown pointerId
+// (https://w3c.github.io/pointerevents/#dom-element-setpointercapture); jsdom instead makes these methods
+// permanent no-ops, so that `typeof window.PointerEvent !== "undefined"` feature detection does not crash when
+// this API surface is used. This is jsdom-specific behavior and should not be upstreamed.
+test(() => {
+  const button = document.querySelector("button");
+
+  assert_equals(typeof button.setPointerCapture, "function");
+  assert_equals(typeof button.releasePointerCapture, "function");
+  assert_equals(typeof button.hasPointerCapture, "function");
+
+  assert_equals(button.setPointerCapture(1), undefined);
+  assert_equals(button.releasePointerCapture(1), undefined);
+  assert_equals(button.hasPointerCapture(1), false);
+}, "setPointerCapture()/releasePointerCapture()/hasPointerCapture() exist on every Element and never throw");
+
+test(() => {
+  const button = document.querySelector("button");
+
+  assert_throws_js(TypeError, () => button.setPointerCapture());
+  assert_throws_js(TypeError, () => button.releasePointerCapture());
+  assert_throws_js(TypeError, () => button.hasPointerCapture());
+}, "setPointerCapture()/releasePointerCapture()/hasPointerCapture() still require a pointerId argument");
+</script>


### PR DESCRIPTION
Every browser exposes `setPointerCapture`, `releasePointerCapture`, and `hasPointerCapture` on `Element` once Pointer Events are supported, and it's common to feature-detect Pointer Events support via `typeof window.PointerEvent !== "undefined"` before calling them (this is exactly what react-aria's `useMove()` hook does). Since jsdom added the `PointerEvent` constructor in v27 without this API surface, that established feature-detection pattern now leads straight to a `TypeError` in code that previously worked fine against jsdom.

This PR implements the actual [pointer capture algorithm](https://w3c.github.io/pointerevents/#pointer-capture) rather than a no-op: an active-pointers set populated by dispatched `pointerdown`/`pointerup`/`pointercancel`, a pending and an actual capture-target-override per `pointerId`, retargeting of subsequent pointer events to the capturing element, and `gotpointercapture`/`lostpointercapture` firing accordingly. `setPointerCapture`/`releasePointerCapture` throw the correct `DOMException`s (`NotFoundError` for an unmatched `pointerId`, `InvalidStateError` for a disconnected element).

jsdom has no hit-testing or real input devices, so active pointers are populated purely from script-dispatched pointer events, matching how jsdom's primary consumers (e.g. testing-library's `fireEvent`) actually drive pointer events in this environment. Pointer Lock interaction from the spec isn't modeled since jsdom doesn't implement that API. Capture on a disconnected element is released with a synchronous `lostpointercapture` at that element, rather than the spec's retarget-to-document-and-defer approach, for simpler, predictable behavior.

Almost every upstream web-platform-test for pointer capture drives input through `test_driver.Actions()`, which needs a real WebDriver-backed browser and can't run against jsdom, so this is verified with a jsdom-only test exercising the algorithm via script-dispatched `PointerEvent`s instead.

Fixes #4271