### PR TITLE
Avoid repeated root scans for form controls

### DIFF
--- a/benchmark/forms/form-owner.js
+++ b/benchmark/forms/form-owner.js
@@ -4,6 +4,8 @@ const { Bench } = require("tinybench");
 const { JSDOM } = require("../..");
 
 const CONTROL_COUNT = 120;
+const FORM_CONTROL_COUNTS = [1, 100];
+const OUTSIDE_ELEMENT_COUNTS = [0, 1000, 10000];
 
 module.exports = () => {
   const bench = new Bench();
@@ -21,6 +23,8 @@ module.exports = () => {
     const fragment = document.createDocumentFragment();
     for (let i = 0; i < count; i++) {
       const control = document.createElement("input");
+      control.name = `field-${i}`;
+      control.value = "value";
       if (formId !== null) {
         control.setAttribute("form", formId);
       }
@@ -68,12 +72,39 @@ module.exports = () => {
     });
   }
 
-  function addElementsTask(name, controlCount) {
-    const fixture = createExplicitOwnerFixture(100, { controlCount });
-    const { elements } = fixture.form;
-    bench.add(name, () => {
-      fixture.app.toggleAttribute("data-updated");
+  function createFormOperationsFixture(controlCount, outsideElementCount, external) {
+    const { window } = new JSDOM();
+    const { document } = window;
+    appendElements(document, document.body, outsideElementCount);
+
+    const form = document.createElement("form");
+    if (external) {
+      form.id = "settings-form";
+    }
+    document.body.append(form);
+    appendControls(document, external ? document.body : form, external ? form.id : null, controlCount);
+
+    return { body: document.body, FormData: window.FormData, form };
+  }
+
+  function addFormOperationsTasks(controlCount, outsideElementCount, external) {
+    const { body, FormData, form } = createFormOperationsFixture(controlCount, outsideElementCount, external);
+    const association = external ? "external" : "nested";
+    const controls = `${controlCount} ${association} control${controlCount === 1 ? "" : "s"}`;
+    const fixture = `${external ? "identified" : "unidentified"} form, ${controls}, ` +
+      `${outsideElementCount} unrelated elements`;
+    const { elements } = form;
+
+    bench.add(`refresh form.elements (${fixture})`, () => {
+      body.toggleAttribute("data-updated");
       return elements.length;
+    });
+    bench.add(`checkValidity() (${fixture})`, () => {
+      body.toggleAttribute("data-updated");
+      return form.checkValidity();
+    });
+    bench.add(`new FormData(form) (${fixture})`, () => {
+      return new FormData(form).get("field-0");
     });
   }
 
@@ -84,13 +115,17 @@ module.exports = () => {
     return countOwners(controls, form);
   });
 
-  addElementsTask("refresh form.elements after mutation (1 external control)", 1);
-  addElementsTask(`refresh form.elements after mutation (${CONTROL_COUNT} external controls)`, CONTROL_COUNT);
-
   addExplicitOwnerTask(`read form owners for ${CONTROL_COUNT} controls (form after 1,000 elements)`, 1000);
   addExplicitOwnerTask(`read form owners for ${CONTROL_COUNT} controls (form before 1,000 elements)`, 1000, {
     formBeforeContent: true
   });
+
+  for (const controlCount of FORM_CONTROL_COUNTS) {
+    for (const outsideElementCount of OUTSIDE_ELEMENT_COUNTS) {
+      addFormOperationsTasks(controlCount, outsideElementCount, false);
+      addFormOperationsTasks(controlCount, outsideElementCount, true);
+    }
+  }
 
   return bench;
 };

--- a/benchmark/forms/form-owner.js
+++ b/benchmark/forms/form-owner.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+const CONTROL_COUNT = 120;
+
+module.exports = () => {
+  const bench = new Bench();
+
+  function appendElements(document, parent, count) {
+    const fragment = document.createDocumentFragment();
+    for (let i = 0; i < count; i++) {
+      fragment.append(document.createElement("div"));
+    }
+    parent.append(fragment);
+  }
+
+  function appendControls(document, parent, formId, count = CONTROL_COUNT) {
+    const controls = [];
+    const fragment = document.createDocumentFragment();
+    for (let i = 0; i < count; i++) {
+      const control = document.createElement("input");
+      if (formId !== null) {
+        control.setAttribute("form", formId);
+      }
+      fragment.append(control);
+      controls.push(control);
+    }
+    parent.append(fragment);
+    return controls;
+  }
+
+  function countOwners(controls, form) {
+    let owners = 0;
+    for (const control of controls) {
+      if (control.form === form) {
+        owners++;
+      }
+    }
+    return owners;
+  }
+
+  function createExplicitOwnerFixture(contentElementCount, {
+    formBeforeContent = false,
+    controlCount = CONTROL_COUNT
+  } = {}) {
+    const { document } = (new JSDOM()).window;
+    const app = document.body.appendChild(document.createElement("main"));
+    const form = document.createElement("form");
+    form.id = "settings-form";
+    if (formBeforeContent) {
+      app.append(form);
+    }
+    appendElements(document, app, contentElementCount);
+    if (!formBeforeContent) {
+      app.append(form);
+    }
+    const controls = appendControls(document, app, form.id, controlCount);
+    return { app, controls, form };
+  }
+
+  function addExplicitOwnerTask(name, contentElementCount, options) {
+    const { controls, form } = createExplicitOwnerFixture(contentElementCount, options);
+
+    bench.add(name, () => {
+      return countOwners(controls, form);
+    });
+  }
+
+  function addElementsTask(name, controlCount) {
+    const fixture = createExplicitOwnerFixture(100, { controlCount });
+    const { elements } = fixture.form;
+    bench.add(name, () => {
+      fixture.app.toggleAttribute("data-updated");
+      return elements.length;
+    });
+  }
+
+  const { document } = (new JSDOM()).window;
+  const form = document.body.appendChild(document.createElement("form"));
+  const controls = appendControls(document, form, null);
+  bench.add(`read form owners for ${CONTROL_COUNT} nested controls`, () => {
+    return countOwners(controls, form);
+  });
+
+  addElementsTask("refresh form.elements after mutation (1 external control)", 1);
+  addElementsTask(`refresh form.elements after mutation (${CONTROL_COUNT} external controls)`, CONTROL_COUNT);
+
+  addExplicitOwnerTask(`read form owners for ${CONTROL_COUNT} controls (form after 1,000 elements)`, 1000);
+  addExplicitOwnerTask(`read form owners for ${CONTROL_COUNT} controls (form before 1,000 elements)`, 1000, {
+    formBeforeContent: true
+  });
+
+  return bench;
+};

--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -42,6 +42,8 @@ exports.changeAttribute = (element, attribute, value) => {
 
   attribute._value = value;
 
+  updateIdCache(element, attribute, _value, value);
+
   // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is changed."
   element._attrModified(attribute._qualifiedName, value, _value);
 };
@@ -78,6 +80,8 @@ exports.appendAttribute = function (element, attribute) {
     entry.push(attribute);
   }
 
+  updateIdCache(element, attribute, null, _value);
+
   // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is added."
   element._attrModified(name, _value, null);
 };
@@ -113,6 +117,8 @@ exports.removeAttribute = function (element, attribute) {
       if (entry.length === 0) {
         cache.delete(name);
       }
+
+      updateIdCache(element, attribute, _value, null);
 
       // Run jsdom hooks; roughly correspond to spec's "An attribute is removed."
       element._attrModified(name, null, attribute._value);
@@ -157,6 +163,8 @@ exports.replaceAttribute = function (element, oldAttr, newAttr) {
       }
       entry.splice(entry.indexOf(oldAttr), 1, newAttr);
 
+      updateIdCache(element, newAttr, oldAttr._value, newAttr._value);
+
       // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is changed."
       element._attrModified(name, newAttr._value, oldAttr._value);
 
@@ -164,6 +172,21 @@ exports.replaceAttribute = function (element, oldAttr, newAttr) {
     }
   }
 };
+
+// ID cache updates need the namespace, which the legacy _attrModified hooks do not receive.
+function updateIdCache(element, attribute, oldValue, value) {
+  if (attribute._localName !== "id" || attribute._namespace !== null || !element._isInDocumentTree) {
+    return;
+  }
+
+  const cache = element._ownerDocument._byIdCache;
+  if (oldValue) {
+    cache.delete(oldValue, element);
+  }
+  if (value) {
+    cache.add(value, element);
+  }
+}
 
 exports.getAttributeByName = function (element, name) {
   // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name

--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -42,10 +42,8 @@ exports.changeAttribute = (element, attribute, value) => {
 
   attribute._value = value;
 
-  updateIdCache(element, attribute, _value, value);
-
   // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is changed."
-  element._attrModified(attribute._qualifiedName, value, _value);
+  element._attrModified(attribute._qualifiedName, value, _value, _namespace);
 };
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-append
@@ -80,10 +78,8 @@ exports.appendAttribute = function (element, attribute) {
     entry.push(attribute);
   }
 
-  updateIdCache(element, attribute, null, _value);
-
   // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is added."
-  element._attrModified(name, _value, null);
+  element._attrModified(name, _value, null, _namespace);
 };
 
 exports.removeAttribute = function (element, attribute) {
@@ -118,10 +114,8 @@ exports.removeAttribute = function (element, attribute) {
         cache.delete(name);
       }
 
-      updateIdCache(element, attribute, _value, null);
-
       // Run jsdom hooks; roughly correspond to spec's "An attribute is removed."
-      element._attrModified(name, null, attribute._value);
+      element._attrModified(name, null, attribute._value, _namespace);
 
       return;
     }
@@ -163,30 +157,13 @@ exports.replaceAttribute = function (element, oldAttr, newAttr) {
       }
       entry.splice(entry.indexOf(oldAttr), 1, newAttr);
 
-      updateIdCache(element, newAttr, oldAttr._value, newAttr._value);
-
       // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is changed."
-      element._attrModified(name, newAttr._value, oldAttr._value);
+      element._attrModified(name, newAttr._value, oldAttr._value, _namespace);
 
       return;
     }
   }
 };
-
-// ID cache updates need the namespace, which the legacy _attrModified hooks do not receive.
-function updateIdCache(element, attribute, oldValue, value) {
-  if (attribute._localName !== "id" || attribute._namespace !== null || !element._isInDocumentTree) {
-    return;
-  }
-
-  const cache = element._ownerDocument._byIdCache;
-  if (oldValue) {
-    cache.delete(oldValue, element);
-  }
-  if (value) {
-    cache.add(value, element);
-  }
-}
 
 exports.getAttributeByName = function (element, name) {
   // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -310,6 +310,18 @@ exports.formOwner = formControl => {
   }
 
   const root = formControl.getRootNode({});
+  if (root.nodeType === NODE_TYPE.DOCUMENT_NODE || root.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
+    const descendant = root.getElementById(formAttr);
+    // Explicit form owners only match null-namespace ID attributes.
+    if (descendant !== null &&
+        descendant.getAttributeNS(null, "id") === formAttr &&
+        descendant.namespaceURI === HTML_NS &&
+        descendant.localName === "form") {
+      return descendant;
+    }
+    return null;
+  }
+
   let firstElementWithId;
   for (const descendant of domSymbolTree.treeIterator(root)) {
     if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&

--- a/lib/jsdom/living/helpers/form-controls.js
+++ b/lib/jsdom/living/helpers/form-controls.js
@@ -20,7 +20,7 @@ const whatwgURL = require("whatwg-url");
 
 const NodeList = require("../../../generated/idl/NodeList");
 const { domSymbolTree } = require("./internal-constants");
-const { closest, firstChildWithLocalName } = require("./traversal");
+const { closest, firstChildWithLocalName, firstElementWithId } = require("./traversal");
 const NODE_TYPE = require("../node-type");
 const { HTML_NS } = require("./namespaces");
 
@@ -309,32 +309,9 @@ exports.formOwner = formControl => {
     return closest(formControl, "form");
   }
 
-  const root = formControl.getRootNode({});
-  if (root.nodeType === NODE_TYPE.DOCUMENT_NODE || root.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
-    const descendant = root.getElementById(formAttr);
-    // Explicit form owners only match null-namespace ID attributes.
-    if (descendant !== null &&
-        descendant.getAttributeNS(null, "id") === formAttr &&
-        descendant.namespaceURI === HTML_NS &&
-        descendant.localName === "form") {
-      return descendant;
-    }
-    return null;
-  }
-
-  let firstElementWithId;
-  for (const descendant of domSymbolTree.treeIterator(root)) {
-    if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&
-      descendant.getAttributeNS(null, "id") === formAttr) {
-      firstElementWithId = descendant;
-      break;
-    }
-  }
-
-  if (firstElementWithId &&
-    firstElementWithId.namespaceURI === HTML_NS &&
-    firstElementWithId.localName === "form") {
-    return firstElementWithId;
+  const form = firstElementWithId(formControl.getRootNode({}), formAttr);
+  if (form && form.namespaceURI === HTML_NS && form.localName === "form") {
+    return form;
   }
   return null;
 };

--- a/lib/jsdom/living/helpers/traversal.js
+++ b/lib/jsdom/living/helpers/traversal.js
@@ -1,6 +1,7 @@
 "use strict";
 const { domSymbolTree } = require("./internal-constants");
 const { HTML_NS } = require("./namespaces");
+const NODE_TYPE = require("../node-type");
 
 // All these operate on and return impls, not wrappers!
 
@@ -68,5 +69,23 @@ exports.firstDescendantWithLocalName = (parent, localName, namespace = HTML_NS) 
       return descendant;
     }
   }
+  return null;
+};
+
+exports.firstElementWithId = (root, id) => {
+  if (id === "") {
+    return null;
+  }
+
+  if (root.nodeType === NODE_TYPE.DOCUMENT_NODE || root.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
+    return root.getElementById(id);
+  }
+
+  for (const node of domSymbolTree.treeIterator(root)) {
+    if (node.nodeType === NODE_TYPE.ELEMENT_NODE && node.getAttributeNS(null, "id") === id) {
+      return node;
+    }
+  }
+
   return null;
 };

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -82,16 +82,6 @@ class ElementImpl extends NodeImpl {
 
     windowProperties.elementAttributeModified(this, name, value, oldValue);
 
-    if (name === "id" && this._isInDocumentTree) {
-      const cache = this._ownerDocument._byIdCache;
-      if (oldValue) {
-        cache.delete(oldValue, this);
-      }
-      if (value) {
-        cache.add(value, this);
-      }
-    }
-
     // update classList
     if (name === "class" && this._classList !== undefined) {
       this._classList.attrModified();

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -77,20 +77,32 @@ class ElementImpl extends NodeImpl {
     }
   }
 
-  _attrModified(name, value, oldValue) {
+  _attrModified(name, value, oldValue, namespace) {
     this._modified();
 
-    windowProperties.elementAttributeModified(this, name, value, oldValue);
+    windowProperties.elementAttributeModified(this, name, value, oldValue, namespace);
+
+    if (namespace === null && name === "id" && this._isInDocumentTree) {
+      const cache = this._ownerDocument._byIdCache;
+      if (oldValue) {
+        cache.delete(oldValue, this);
+      }
+      if (value) {
+        cache.add(value, this);
+      }
+    }
 
     // update classList
-    if (name === "class" && this._classList !== undefined) {
+    if (namespace === null && name === "class" && this._classList !== undefined) {
       this._classList.attrModified();
     }
 
     // Clear domSelector cached results on attribute change.
     this._ownerDocument._clearDOMSelector();
 
-    this._attrModifiedSlotableMixin(name, value, oldValue);
+    if (namespace === null) {
+      this._attrModifiedSlotableMixin(name, value, oldValue);
+    }
   }
 
   get namespaceURI() {

--- a/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAnchorElement-impl.js
@@ -34,10 +34,10 @@ class HTMLAnchorElementImpl extends HTMLElementImpl {
     this.textContent = v;
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
-    if (name === "rel" && this._relList !== undefined) {
+    if (namespace === null && name === "rel" && this._relList !== undefined) {
       this._relList.attrModified();
     }
   }

--- a/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLAreaElement-impl.js
@@ -27,10 +27,10 @@ class HTMLAreaElementImpl extends HTMLElementImpl {
     return this._relList;
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
-    if (name === "rel" && this._relList !== undefined) {
+    if (namespace === null && name === "rel" && this._relList !== undefined) {
       this._relList.attrModified();
     }
   }

--- a/lib/jsdom/living/nodes/HTMLBaseElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLBaseElement-impl.js
@@ -20,10 +20,10 @@ class HTMLBaseElementImpl extends HTMLElementImpl {
     this.setAttributeNS(null, "href", value);
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
-    if (name === "href") {
+    if (namespace === null && name === "href") {
       this._ownerDocument._clearBaseURLCache();
     }
   }

--- a/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js
@@ -5,12 +5,12 @@ const idlUtils = require("../../../generated/idl/utils");
 const { Canvas } = require("../../utils");
 
 class HTMLCanvasElementImpl extends HTMLElementImpl {
-  _attrModified(name, value, oldValue) {
-    if (this._canvas && (name === "width" || name === "height")) {
+  _attrModified(name, value, oldValue, namespace) {
+    if (namespace === null && this._canvas && (name === "width" || name === "height")) {
       this._canvas[name] = parseInt(value, 10);
     }
 
-    super._attrModified(name, value, oldValue);
+    super._attrModified(name, value, oldValue, namespace);
   }
 
   _getCanvas() {

--- a/lib/jsdom/living/nodes/HTMLDetailsElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLDetailsElement-impl.js
@@ -17,10 +17,10 @@ class HTMLDetailsElementImpl extends HTMLElementImpl {
     fireAnEvent("toggle", this);
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
-    if (name === "open" && this._taskQueue === null) {
+    if (namespace === null && name === "open" && this._taskQueue === null) {
       // Check that the attribute is added or removed, not merely changed
       if ((value !== oldValue && value !== null && oldValue === null) ||
           (value === null && oldValue !== null)) {

--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -166,16 +166,16 @@ class HTMLElementImpl extends ElementImpl {
   }
 
   // Keep in sync with SVGElement. https://github.com/jsdom/jsdom/issues/2599
-  _attrModified(name, value, oldValue) {
-    if (name === "style" && value !== oldValue && !this._settingCssText) {
+  _attrModified(name, value, oldValue, namespace) {
+    if (namespace === null && name === "style" && value !== oldValue && !this._settingCssText) {
       this._settingCssText = true;
       this.style.cssText = value;
       this._settingCssText = false;
-    } else if (name.startsWith("on")) {
+    } else if (namespace === null && name.startsWith("on")) {
       this._globalEventChanged(name.substring(2));
     }
 
-    super._attrModified(name, value, oldValue);
+    super._attrModified(name, value, oldValue, namespace);
   }
 
   get offsetParent() {

--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -49,7 +49,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   _getSubmittableElementNodes() {
-    return domSymbolTree.treeToArray(this.getRootNode({}), {
+    return domSymbolTree.treeToArray(this._getFormControlSearchRoot(), {
       filter: node => {
         if (!isSubmittable(node)) {
           return false;
@@ -61,7 +61,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   }
 
   _getElementNodes() {
-    return domSymbolTree.treeToArray(this.getRootNode({}), {
+    return domSymbolTree.treeToArray(this._getFormControlSearchRoot(), {
       filter: node => {
         if (!isListed(node) || (node._localName === "input" && node.type === "image")) {
           return false;
@@ -70,6 +70,12 @@ class HTMLFormElementImpl extends HTMLElementImpl {
         return formOwner(node) === this;
       }
     });
+  }
+
+  _getFormControlSearchRoot() {
+    // formOwner() only associates controls outside this form's subtree through a non-empty ID.
+    const id = this.getAttributeNS(null, "id");
+    return id === null || id === "" ? this : this.getRootNode({});
   }
 
   // https://html.spec.whatwg.org/multipage/forms.html#dom-form-elements

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -217,9 +217,9 @@ class HTMLFrameElementImpl extends HTMLElementImpl {
     super(globalObject, args, privateData);
     this._contentDocument = null;
   }
-  _attrModified(name, value, oldVal) {
-    super._attrModified(name, value, oldVal);
-    if (name === "src") {
+  _attrModified(name, value, oldVal, namespace) {
+    super._attrModified(name, value, oldVal, namespace);
+    if (namespace === null && name === "src") {
       // iframe should never load in a document without a Window
       // (e.g. implementation.createHTMLDocument)
       if (this.isConnected && this._ownerDocument._defaultView) {

--- a/lib/jsdom/living/nodes/HTMLImageElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLImageElement-impl.js
@@ -10,13 +10,14 @@ class HTMLImageElementImpl extends HTMLElementImpl {
     this._currentRequestState = "unavailable";
   }
 
-  _attrModified(name, value, oldVal) {
+  _attrModified(name, value, oldVal, namespace) {
     // TODO: handle crossorigin
-    if (name === "src" || ((name === "srcset" || name === "width" || name === "sizes") && value !== oldVal)) {
+    if (namespace === null &&
+        (name === "src" || ((name === "srcset" || name === "width" || name === "sizes") && value !== oldVal))) {
       this._updateTheImageData();
     }
 
-    super._attrModified(name, value, oldVal);
+    super._attrModified(name, value, oldVal, namespace);
   }
 
   get _accept() {

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -11,6 +11,7 @@ const { mixin } = require("../../utils");
 const { domSymbolTree, cloningSteps } = require("../helpers/internal-constants");
 const { getLabelsForLabelable, formOwner } = require("../helpers/form-controls");
 const { fireAnEvent } = require("../helpers/events");
+const { firstElementWithId } = require("../helpers/traversal");
 const {
   isDisabled,
   isValidEmailAddress,
@@ -227,25 +228,25 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     }
   }
 
-  _attrModified(name, value, oldVal) {
+  _attrModified(name, value, oldVal, namespace) {
     const wrapper = idlUtils.wrapperForImpl(this);
-    if (!this._dirtyValue && name === "value") {
+    if (namespace === null && !this._dirtyValue && name === "value") {
       this._value = sanitizeValueByType(this, wrapper.defaultValue);
     }
-    if (!this._dirtyCheckedness && name === "checked") {
+    if (namespace === null && !this._dirtyCheckedness && name === "checked") {
       this._checkedness = wrapper.defaultChecked;
       if (this._checkedness) {
         this._removeOtherRadioCheckedness();
       }
     }
 
-    if (name === "name" || name === "type") {
+    if (namespace === null && (name === "name" || name === "type")) {
       if (this._checkedness) {
         this._removeOtherRadioCheckedness();
       }
     }
 
-    if (name === "type") {
+    if (namespace === null && name === "type") {
       const prevType = getTypeFromAttribute(oldVal);
       const curType = getTypeFromAttribute(value);
       // When an input element's type attribute changes state…
@@ -276,7 +277,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
       }
     }
 
-    super._attrModified(name, value, oldVal);
+    super._attrModified(name, value, oldVal, namespace);
   }
 
   // https://html.spec.whatwg.org/multipage/input.html#signal-a-type-change
@@ -734,7 +735,7 @@ class HTMLInputElementImpl extends HTMLElementImpl {
       return null;
     }
 
-    const el = this.getRootNode({}).getElementById(id);
+    const el = firstElementWithId(this.getRootNode({}), id);
 
     if (el && el.localName === "datalist") {
       return el;

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -3,10 +3,10 @@
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const MouseEvent = require("../../../generated/idl/MouseEvent");
 const { domSymbolTree } = require("../helpers/internal-constants");
-const NODE_TYPE = require("../node-type");
 const { isLabelable, isDisabled, isInteractiveContent } = require("../helpers/form-controls");
 const { isInclusiveAncestor } = require("../helpers/node");
 const { fireAnEvent } = require("../helpers/events");
+const { firstElementWithId } = require("../helpers/traversal");
 
 function sendClickToAssociatedNode(node) {
   fireAnEvent("click", node, MouseEvent, {
@@ -36,18 +36,8 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
       if (forValue === "") {
         return null;
       }
-      const root = this.getRootNode({});
-      if (root.nodeType === NODE_TYPE.DOCUMENT_NODE || root.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
-        const descendant = root.getElementById(forValue);
-        return descendant !== null && isLabelable(descendant) ? descendant : null;
-      }
-      for (const descendant of domSymbolTree.treeIterator(root)) {
-        if (descendant.nodeType === NODE_TYPE.ELEMENT_NODE &&
-          descendant.getAttributeNS(null, "id") === forValue) {
-          return isLabelable(descendant) ? descendant : null;
-        }
-      }
-      return null;
+      const firstElement = firstElementWithId(this.getRootNode({}), forValue);
+      return firstElement !== null && isLabelable(firstElement) ? firstElement : null;
     }
     for (const descendant of domSymbolTree.treeIterator(this)) {
       if (isLabelable(descendant)) {

--- a/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
@@ -37,14 +37,14 @@ class HTMLLinkElementImpl extends HTMLElementImpl {
     }
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
-    if (name === "href") { // TODO crossorigin="" or type=""
+    if (namespace === null && name === "href") { // TODO crossorigin="" or type=""
       maybeFetchAndProcess(this);
     }
 
-    if (name === "rel" && this._relList !== undefined) {
+    if (namespace === null && name === "rel" && this._relList !== undefined) {
       this._relList.attrModified();
     }
   }

--- a/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
@@ -38,15 +38,15 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     }
   }
 
-  _attrModified(name, value, oldValue) {
-    if (!this._dirtyness && name === "selected") {
+  _attrModified(name, value, oldValue, namespace) {
+    if (namespace === null && !this._dirtyness && name === "selected") {
       this._selectedness = this.hasAttributeNS(null, "selected");
       if (this._selectedness) {
         this._removeOtherSelectedness();
       }
       this._askForAReset();
     }
-    super._attrModified(name, value, oldValue);
+    super._attrModified(name, value, oldValue, namespace);
   }
 
   get _selectNode() {

--- a/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOutputElement-impl.js
@@ -16,10 +16,10 @@ class HTMLOutputElementImpl extends HTMLElementImpl {
     this._customValidityErrorMessage = "";
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
-    if (name === "for" && this._htmlFor !== undefined) {
+    if (namespace === null && name === "for" && this._htmlFor !== undefined) {
       this._htmlFor.attrModified();
     }
   }

--- a/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
@@ -124,10 +124,11 @@ class HTMLScriptElementImpl extends HTMLElementImpl {
     }, null, false, this);
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
-    if (this.isConnected && !this._startedEval && name === "src" && oldValue === null && value !== null) {
+    if (namespace === null && this.isConnected && !this._startedEval && name === "src" &&
+        oldValue === null && value !== null) {
       this._fetchExternalScript();
     }
   }

--- a/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSelectElement-impl.js
@@ -111,11 +111,11 @@ class HTMLSelectElementImpl extends HTMLElementImpl {
     super._descendantRemoved(parent, child);
   }
 
-  _attrModified(name, value, oldValue) {
-    if (name === "multiple" || name === "size") {
+  _attrModified(name, value, oldValue, namespace) {
+    if (namespace === null && (name === "multiple" || name === "size")) {
       this._askedForAReset();
     }
-    super._attrModified(name, value, oldValue);
+    super._attrModified(name, value, oldValue, namespace);
   }
 
   get _displaySize() {

--- a/lib/jsdom/living/nodes/HTMLSlotElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLSlotElement-impl.js
@@ -18,11 +18,11 @@ class HTMLSlotElementImpl extends HTMLElementImpl {
     return this.getAttributeNS(null, "name") || "";
   }
 
-  _attrModified(name, value, oldValue) {
-    super._attrModified(name, value, oldValue);
+  _attrModified(name, value, oldValue, namespace) {
+    super._attrModified(name, value, oldValue, namespace);
 
     // https://dom.spec.whatwg.org/#slot-name
-    if (name === "name") {
+    if (namespace === null && name === "name") {
       if (value === oldValue) {
         return;
       }

--- a/lib/jsdom/living/nodes/SVGElement-impl.js
+++ b/lib/jsdom/living/nodes/SVGElement-impl.js
@@ -17,16 +17,16 @@ class SVGElementImpl extends ElementImpl {
   }
 
   // Keep in sync with HTMLElement. https://github.com/jsdom/jsdom/issues/2599
-  _attrModified(name, value, oldValue) {
-    if (name === "style" && value !== oldValue && !this._settingCssText) {
+  _attrModified(name, value, oldValue, namespace) {
+    if (namespace === null && name === "style" && value !== oldValue && !this._settingCssText) {
       this._settingCssText = true;
       this.style.cssText = value;
       this._settingCssText = false;
-    } else if (name.startsWith("on")) {
+    } else if (namespace === null && name.startsWith("on")) {
       this._globalEventChanged(name.substring(2));
     }
 
-    super._attrModified(name, value, oldValue);
+    super._attrModified(name, value, oldValue, namespace);
   }
 
   get ownerSVGElement() {

--- a/lib/jsdom/living/window-properties.js
+++ b/lib/jsdom/living/window-properties.js
@@ -136,16 +136,11 @@ exports.elementDetached = element => {
   }
 };
 
-exports.elementAttributeModified = (element, attributeName, value, oldValue) => {
-  const isIdAttribute = attributeName === "id";
-  const isNameAttribute = attributeName === "name" && nameAttributeElementLocalNames.has(element._localName);
+exports.elementAttributeModified = (element, attributeName, value, oldValue, namespace) => {
+  const isIdAttribute = namespace === null && attributeName === "id";
+  const isNameAttribute = namespace === null && attributeName === "name" &&
+    nameAttributeElementLocalNames.has(element._localName);
   if ((!isIdAttribute && !isNameAttribute) || value === oldValue) {
-    return;
-  }
-
-  // A qualified name alone does not tell us the attribute's namespace. A non-null-namespace attribute cannot be the
-  // current value returned here, except for a removal; removals of attributes that were never tracked are harmless.
-  if (element.getAttributeNS(null, attributeName) !== value) {
     return;
   }
 

--- a/test/web-platform-tests/to-upstream/dom/nodes/getElementById-namespaced-id.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/getElementById-namespaced-id.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Namespaced ID attributes do not affect ID lookup</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-id">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+"use strict";
+
+const namespace = "https://example.com/attributes";
+
+for (const operation of ["append", "change", "remove", "replace"]) {
+  test(t => {
+    const form = document.createElement("form");
+    form.id = "owner";
+    if (operation !== "append") {
+      form.setAttributeNS(namespace, "id", "owner");
+    }
+    const input = document.createElement("input");
+    input.name = "field";
+    input.required = true;
+    input.setAttribute("form", "owner");
+    t.add_cleanup(() => {
+      form.remove();
+      input.remove();
+    });
+    document.body.append(form, input);
+
+    if (operation === "append" || operation === "change") {
+      form.setAttributeNS(namespace, "id", "unrelated");
+    } else if (operation === "remove") {
+      form.removeAttributeNS(namespace, "id");
+    } else {
+      const attribute = document.createAttributeNS(namespace, "id");
+      attribute.value = "unrelated";
+      form.setAttributeNodeNS(attribute);
+    }
+
+    assert_equals(document.getElementById("owner"), form);
+    assert_equals(document.getElementById("unrelated"), null);
+    assert_equals(input.form, form);
+    assert_array_equals(Array.from(form.elements), [input]);
+    assert_false(form.checkValidity());
+    assert_true(new FormData(form).has("field"));
+  }, `${operation} a namespaced ID preserves ID lookup and form association`);
+}
+</script>

--- a/test/web-platform-tests/to-upstream/dom/nodes/namespaced-attribute-mutations.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/namespaced-attribute-mutations.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Namespaced attributes do not trigger null-namespace attribute behavior</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-element-setattributens">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+"use strict";
+
+const namespace = "https://example.com/attributes";
+const svgNamespace = "http://www.w3.org/2000/svg";
+
+function mutateNamespacedAttribute(element, name, operation, beforeMutation) {
+  if (operation !== "append") {
+    element.setAttributeNS(namespace, name, "before");
+  }
+
+  beforeMutation();
+
+  if (operation === "append" || operation === "change") {
+    element.setAttributeNS(namespace, name, "after");
+  } else if (operation === "remove") {
+    element.removeAttributeNS(namespace, name);
+  } else {
+    const attribute = document.createAttributeNS(namespace, name);
+    attribute.value = "after";
+    element.setAttributeNodeNS(attribute);
+  }
+}
+
+for (const elementNamespace of ["HTML", "SVG"]) {
+  for (const operation of ["append", "change", "remove", "replace"]) {
+    test(() => {
+      const element = elementNamespace === "HTML" ?
+        document.createElement("div") :
+        document.createElementNS(svgNamespace, "g");
+
+      mutateNamespacedAttribute(element, "style", operation, () => {
+        element.setAttributeNS(null, "style", "color: green");
+      });
+
+      assert_equals(element.getAttributeNS(null, "style"), "color: green");
+      assert_equals(element.style.color, "green");
+    }, `${operation} a namespaced style attribute preserves ${elementNamespace} inline style`);
+
+    test(() => {
+      const element = elementNamespace === "HTML" ?
+        document.createElement("div") :
+        document.createElementNS(svgNamespace, "g");
+      let callCount = 0;
+      function handler() {
+        ++callCount;
+      }
+
+      mutateNamespacedAttribute(element, "onclick", operation, () => {
+        element.onclick = handler;
+      });
+
+      assert_equals(element.onclick, handler);
+      element.dispatchEvent(new Event("click"));
+      assert_equals(callCount, 1);
+    }, `${operation} a namespaced event handler attribute preserves an ${elementNamespace} event handler`);
+  }
+}
+
+test(() => {
+  const host = document.createElement("div");
+  const slot = document.createElement("slot");
+  slot.name = "target";
+  host.attachShadow({ mode: "open" }).append(slot);
+
+  const child = document.createElement("span");
+  child.setAttributeNS(namespace, "slot", "target");
+  host.append(child);
+
+  assert_equals(child.slot, "");
+  assert_equals(child.assignedSlot, null);
+  assert_array_equals(slot.assignedNodes(), []);
+}, "A namespaced slot attribute does not assign a slot");
+
+promise_test(async t => {
+  const details = document.createElement("details");
+  let toggleCount = 0;
+  details.addEventListener("toggle", () => {
+    ++toggleCount;
+  });
+
+  details.setAttributeNS(namespace, "open", "");
+  await new Promise(resolve => {
+    t.step_timeout(resolve, 0);
+  });
+
+  assert_false(details.open);
+  assert_equals(toggleCount, 0);
+}, "A namespaced open attribute does not fire a toggle event");
+
+test(t => {
+  const iframe = document.createElement("iframe");
+  t.add_cleanup(() => iframe.remove());
+  document.body.append(iframe);
+  const { contentDocument } = iframe;
+
+  iframe.setAttributeNS(namespace, "src", "data:text/html,namespaced");
+
+  assert_equals(iframe.src, "");
+  assert_equals(iframe.contentDocument, contentDocument);
+}, "A namespaced src attribute does not navigate an iframe");
+
+test(t => {
+  const script = document.createElement("script");
+  t.add_cleanup(() => {
+    script.remove();
+    delete window.namespacedScriptRan;
+  });
+  document.body.append(script);
+
+  script.setAttributeNS(namespace, "src", "data:text/javascript,window.namespacedScriptRan=true");
+
+  assert_false("namespacedScriptRan" in window);
+}, "A namespaced src attribute does not prepare a script");
+
+test(() => {
+  const input = document.createElement("input");
+  input.value = "value";
+
+  input.setAttributeNS(namespace, "type", "file");
+
+  assert_equals(input.type, "text");
+  assert_equals(input.value, "value");
+}, "A namespaced type attribute does not change an input's state");
+
+test(() => {
+  const select = document.createElement("select");
+  select.innerHTML = "<option selected>one</option><option>two</option>";
+  select.selectedIndex = -1;
+
+  select.options[0].setAttributeNS(namespace, "selected", "");
+
+  assert_equals(select.selectedIndex, -1);
+}, "A namespaced selected attribute does not change an option's selectedness");
+
+for (const name of ["multiple", "size"]) {
+  test(() => {
+    const select = document.createElement("select");
+    select.innerHTML = "<option>one</option><option>two</option>";
+    select.selectedIndex = -1;
+
+    select.setAttributeNS(namespace, name, "");
+
+    assert_equals(select.selectedIndex, -1);
+  }, `A namespaced ${name} attribute does not reset a select`);
+}
+</script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-datalist-element/input-list-detached.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-datalist-element/input-list-detached.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTMLInputElement list in a detached tree</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#the-list-attribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const root = document.createElement("div");
+  const input = document.createElement("input");
+  input.setAttribute("list", "suggestions");
+  const datalist = document.createElement("datalist");
+  datalist.id = "suggestions";
+  root.append(input, datalist);
+
+  assert_equals(input.list, datalist);
+}, "The list getter finds a datalist in a detached element tree");
+</script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-form-element/form-attribute-form-owner.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-form-element/form-attribute-form-owner.html
@@ -47,6 +47,21 @@ test(t => {
   assert_equals(input.form, null, "a namespaced ID does not associate the control");
 }, "The form attribute only matches null-namespace ID attributes");
 
+test(t => {
+  const host = document.createElement("div");
+  t.add_cleanup(() => host.remove());
+  document.body.append(host);
+
+  const root = host.attachShadow({ mode: "open" });
+  const form = document.createElement("form");
+  form.id = "shadow-form";
+  const input = document.createElement("input");
+  input.setAttribute("form", form.id);
+  root.append(form, input);
+
+  assert_equals(input.form, form);
+}, "The form attribute associates controls within a shadow root");
+
 
 async_test(t => {
 

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-form-element/form-attribute-form-owner.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-form-element/form-attribute-form-owner.html
@@ -33,6 +33,20 @@ test(() => {
   });
 }, "`form` property of elements connected via 'form' attribute is correct");
 
+test(t => {
+  const form = document.createElement("form");
+  const input = document.createElement("input");
+  t.add_cleanup(() => {
+    form.remove();
+    input.remove();
+  });
+  input.setAttribute("form", "namespaced-id");
+  document.body.append(form, input);
+
+  form.setAttributeNS("https://example.com/", "id", "namespaced-id");
+  assert_equals(input.form, null, "a namespaced ID does not associate the control");
+}, "The form attribute only matches null-namespace ID attributes");
+
 
 async_test(t => {
 

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-form-element/form-elements-form-owner.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-form-element/form-elements-form-owner.html
@@ -14,19 +14,16 @@
 "use strict";
 
 test(() => {
-  const form = document.querySelector("form");
+  const { 0: form } = document.forms;
+  const { elements } = form;
 
-  assert_equals(form.elements.length, 0);
-}, "`form.elements` should not contain elements inside form with different form owner");
-
-test(() => {
-  const form = document.querySelector("form");
-
-  assert_equals(form.elements.length, 0, "pre-condition");
+  assert_equals(elements.length, 0, "without an ID");
 
   form.id = "testForm";
+  assert_equals(elements.length, 2, "with a matching ID");
 
-  assert_equals(form.elements.length, 2);
-}, "`form.elements` should update on form.id change");
+  form.id = "";
+  assert_equals(elements.length, 0, "after changing to an empty ID");
+}, "`form.elements` should update on form ID changes");
 
 </script>


### PR DESCRIPTION
Reading `form.elements`, calling `checkValidity()`, or constructing `FormData` can scan the complete root even when most of it cannot contribute controls.

Use `getElementById()` to resolve explicit `form="id"` owners. For forms without a non-empty ID, search only the form subtree. Identified forms keep the complete-root path for external controls and duplicate IDs. ID-cache updates only track null-namespace attributes so namespaced IDs cannot disrupt form associations.

The `form.elements` and `checkValidity()` rows include an unrelated DOM mutation before each call so the live collection must refresh. `FormData` rebuilds its control list on every construction.

| Workload, 100 controls and 10,000 outside elements | `main` | This PR | Speedup |
|---|---:|---:|---:|
| `form.elements`, no ID | 294.8 μs | 8.28 μs | 35.6× |
| `checkValidity()`, no ID | 343.7 μs | 50.6 μs | 6.8× |
| `new FormData(form)`, no ID | 315.9 μs | 33.4 μs | 9.5× |
| `form.elements`, external controls | 34.48 ms | 0.309 ms | 111.5× |

The benchmark also covers one-control forms and 0, 1,000, and 10,000 outside elements. Small forms were neutral, and the new subtree path was neutral for identified forms.
