### PR TITLE
Remove closed windows from storage event dispatch

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -834,6 +834,12 @@ function installOwnProperties(window, options) {
       window[i].close?.();
     }
 
+    const { windowsInSameOrigin } = window._currentOriginData;
+    const idx = windowsInSameOrigin.indexOf(window);
+    if (idx !== -1) {
+      windowsInSameOrigin.splice(idx, 1);
+    }
+
     // Clear out all listeners. Any in-flight or upcoming events should not get delivered.
     idlUtils.implForWrapper(window)._removeAllEventListeners();
 

--- a/test/api/fixtures/removed-iframe-with-gc.js
+++ b/test/api/fixtures/removed-iframe-with-gc.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { setImmediate } = require("node:timers/promises");
+const { JSDOM } = require("../../..");
+
+(async () => {
+  const { window } = new JSDOM("", { url: "https://example.com/" });
+  let frame = window.document.createElement("iframe");
+  window.document.body.append(frame);
+
+  let frameWindow = frame.contentWindow;
+  const frameWindowRef = new WeakRef(frameWindow);
+
+  frame.remove();
+  frame = undefined;
+  frameWindow = undefined;
+
+  let collected = false;
+  for (let i = 0; i < 10; ++i) {
+    await setImmediate();
+    global.gc();
+    if (frameWindowRef.deref() === undefined) {
+      collected = true;
+      break;
+    }
+  }
+
+  // Keep the parent window reachable throughout the test.
+  assert.equal(window.document.defaultView, window);
+  console.log(collected ? "collected" : "retained");
+})();

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -90,6 +90,42 @@ describe("Test cases only possible to test from the outside", () => {
     assert.equal(stdout.trim(), "collected");
   });
 
+  it("does not retain removed iframe windows", { timeout: 5000 }, () => {
+    const fixturePath = path.resolve(__dirname, "./fixtures/removed-iframe-with-gc.js");
+    const { status, stderr, stdout } = spawnSync("node", ["--expose-gc", fixturePath], { encoding: "utf-8" });
+
+    assert.equal(status, 0, stderr);
+    assert.equal(stdout.trim(), "collected");
+  });
+
+  it("does not dispatch storage events to removed iframe windows", async () => {
+    const dom = new JSDOM("", { url: "https://example.com/" });
+    try {
+      const removedFrame = dom.window.document.createElement("iframe");
+      const liveFrame = dom.window.document.createElement("iframe");
+      dom.window.document.body.append(removedFrame, liveFrame);
+
+      const removedWindow = removedFrame.contentWindow;
+      removedFrame.remove();
+
+      let removedWindowEvents = 0;
+      removedWindow.addEventListener("storage", () => {
+        ++removedWindowEvents;
+      });
+
+      const liveWindowEvent = new Promise(resolve => {
+        liveFrame.contentWindow.addEventListener("storage", resolve, { once: true });
+      });
+
+      dom.window.localStorage.setItem("key", "value");
+      await liveWindowEvent;
+
+      assert.equal(removedWindowEvents, 0);
+    } finally {
+      dom.window.close();
+    }
+  });
+
   it("window.close() should work from within a load event listener", async () => {
     const errors = [];
     const virtualConsole = new VirtualConsole().forwardTo(console);


### PR DESCRIPTION
This doesn't really affect me since i never render this sort of thing in jsdom.

Same-origin Windows are kept in a shared list for storage event dispatch. `window.close()` tears down the Window but leaves it in that list, retaining removed iframe Windows and continuing to target them for storage events.

Remove the Window from the list during `window.close()`, which covers both iframe removal and navigation.

| 100 iframe create/remove | Main | This PR |
|---|---:|---:|
| Retained heap | 131.85 MB | 41.48 MB |
| Removal time | 9.96 ms | 9.77 ms |