### PR TITLE
Avoid custom element unused registry work and allocations

### DIFF
--- a/benchmark/dom/custom-elements.js
+++ b/benchmark/dom/custom-elements.js
@@ -1,0 +1,125 @@
+"use strict";
+const { Bench } = require("tinybench");
+const { JSDOM } = require("../..");
+
+const ELEMENTS = 1000;
+const DEFINITIONS = 500;
+const ROWS = 400;
+
+module.exports = () => {
+  const bench = new Bench();
+
+  addBenchmarks(bench, 0);
+  addBenchmarks(bench, DEFINITIONS);
+  for (const definitionCount of [0, 10, 25, 100]) {
+    addUIMountBenchmark(bench, definitionCount);
+  }
+  addCustomElementControls(bench);
+
+  return bench;
+};
+
+function addBenchmarks(bench, definitionCount) {
+  const { window } = new JSDOM();
+  const { document } = window;
+  const suffix = definitionCount === 0 ? "empty registry" : `${definitionCount} definitions`;
+
+  registerDefinitions(window, definitionCount);
+
+  bench.add(`createElement(): ${ELEMENTS} ordinary elements, ${suffix}`, () => {
+    for (let i = 0; i < ELEMENTS; ++i) {
+      document.createElement("div");
+    }
+  });
+
+  const subtree = createSubtree(document);
+  bench.add(`append()/remove(): ${ELEMENTS}-element ordinary subtree, ${suffix}`, () => {
+    document.body.append(subtree);
+    subtree.remove();
+  });
+}
+
+function addUIMountBenchmark(bench, definitionCount) {
+  const { window } = new JSDOM();
+  const { document } = window;
+  const suffix = definitionCount === 0 ? "empty registry" : `${definitionCount} definitions`;
+
+  registerDefinitions(window, definitionCount);
+
+  bench.add(`create/append/remove: ${ROWS}-row ordinary UI tree, ${suffix}`, () => {
+    const tree = createUITree(document);
+    document.body.append(tree);
+    tree.remove();
+  });
+}
+
+function addCustomElementControls(bench) {
+  const { window } = new JSDOM();
+  const { document } = window;
+
+  window.customElements.define("benchmark-element", class extends window.HTMLElement {});
+  window.customElements.define("benchmark-button", class extends window.HTMLButtonElement {}, { extends: "button" });
+
+  bench.add(`createElement(): ${ELEMENTS} defined autonomous custom elements`, () => {
+    for (let i = 0; i < ELEMENTS; ++i) {
+      document.createElement("benchmark-element");
+    }
+  });
+
+  bench.add(`createElement(): ${ELEMENTS} defined customized built-ins`, () => {
+    for (let i = 0; i < ELEMENTS; ++i) {
+      document.createElement("button", { is: "benchmark-button" });
+    }
+  });
+
+  const subtree = createSubtree(document, "unregistered-element");
+  bench.add(`append()/remove(): ${ELEMENTS}-element undefined custom subtree`, () => {
+    document.body.append(subtree);
+    subtree.remove();
+  });
+}
+
+function createSubtree(document, localName = "div") {
+  const parent = document.createElement("div");
+
+  for (let i = 0; i < ELEMENTS; ++i) {
+    parent.append(document.createElement(localName));
+  }
+
+  return parent;
+}
+
+function createUITree(document) {
+  const main = document.createElement("main");
+
+  for (let i = 0; i < ROWS; ++i) {
+    const row = document.createElement("section");
+    row.className = "row";
+
+    const label = document.createElement("label");
+    label.htmlFor = `field-${i}`;
+    label.textContent = `Field ${i}`;
+
+    const input = document.createElement("input");
+    input.id = `field-${i}`;
+    input.value = String(i);
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = "Save";
+
+    const status = document.createElement("span");
+    status.textContent = "Ready";
+
+    row.append(label, input, button, status);
+    main.append(row);
+  }
+
+  return main;
+}
+
+function registerDefinitions(window, count) {
+  for (let i = 0; i < count; ++i) {
+    window.customElements.define(`custom-element-${i}`, class extends window.HTMLElement {});
+  }
+}

--- a/lib/jsdom/living/helpers/custom-elements.js
+++ b/lib/jsdom/living/helpers/custom-elements.js
@@ -177,6 +177,10 @@ function lookupCEDefinition(document, namespace, localName, isValue) {
     return definitionByName;
   }
 
+  if (isValue === null) {
+    return definition;
+  }
+
   const definitionByIs = registry._customElementDefinitions.find(def => {
     return def.name === isValue && def.localName === localName;
   });
@@ -252,7 +256,7 @@ function enqueueCECallbackReaction(element, callbackName, args) {
     }
   }
 
-  element._ceReactionQueue.push({
+  (element._ceReactionQueue ??= []).push({
     type: "callback",
     callback,
     args
@@ -263,7 +267,7 @@ function enqueueCECallbackReaction(element, callbackName, args) {
 
 // https://html.spec.whatwg.org/#enqueue-a-custom-element-upgrade-reaction
 function enqueueCEUpgradeReaction(element, definition) {
-  element._ceReactionQueue.push({
+  (element._ceReactionQueue ??= []).push({
     type: "upgrade",
     definition
   });

--- a/lib/jsdom/living/helpers/custom-elements.js
+++ b/lib/jsdom/living/helpers/custom-elements.js
@@ -139,6 +139,10 @@ function upgradeElement(definition, element) {
 
 // https://html.spec.whatwg.org/#concept-try-upgrade
 function tryUpgradeElement(element) {
+  if (element._ceState !== "undefined") {
+    return;
+  }
+
   const { _ownerDocument, _namespaceURI, _localName, _isValue } = element;
   const definition = lookupCEDefinition(_ownerDocument, _namespaceURI, _localName, _isValue);
 
@@ -152,6 +156,11 @@ function lookupCEDefinition(document, namespace, localName, isValue) {
   const definition = null;
 
   if (namespace !== HTML_NS) {
+    return definition;
+  }
+
+  // Autonomous custom element names contain a hyphen; customized built-ins supply an `is` value.
+  if (!localName.includes("-") && isValue === null) {
     return definition;
   }
 

--- a/lib/jsdom/living/helpers/custom-elements.js
+++ b/lib/jsdom/living/helpers/custom-elements.js
@@ -153,42 +153,35 @@ function tryUpgradeElement(element) {
 
 // https://html.spec.whatwg.org/#look-up-a-custom-element-definition
 function lookupCEDefinition(document, namespace, localName, isValue) {
-  const definition = null;
-
   if (namespace !== HTML_NS) {
-    return definition;
+    return null;
   }
 
   // Autonomous custom element names contain a hyphen; customized built-ins supply an `is` value.
   if (!localName.includes("-") && isValue === null) {
-    return definition;
+    return null;
   }
 
   if (!document._defaultView) {
-    return definition;
+    return null;
   }
 
   const registry = implForWrapper(document._globalObject._customElementRegistry);
 
-  const definitionByName = registry._customElementDefinitions.find(def => {
-    return def.name === def.localName && def.localName === localName;
+  const definition = registry._customElementDefinitions.find(def => {
+    return def.name === localName && def.localName === localName;
   });
-  if (definitionByName !== undefined) {
-    return definitionByName;
-  }
-
-  if (isValue === null) {
+  if (definition !== undefined) {
     return definition;
   }
 
-  const definitionByIs = registry._customElementDefinitions.find(def => {
-    return def.name === isValue && def.localName === localName;
-  });
-  if (definitionByIs !== undefined) {
-    return definitionByIs;
+  if (isValue === null) {
+    return null;
   }
 
-  return definition;
+  return registry._customElementDefinitions.find(def => {
+    return def.name === isValue && def.localName === localName;
+  }) ?? null;
 }
 
 // https://html.spec.whatwg.org/multipage/custom-elements.html#invoke-custom-element-reactions

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -37,7 +37,7 @@ class ElementImpl extends NodeImpl {
     this._isValue = privateData.isValue;
 
     this._shadowRoot = null;
-    this._ceReactionQueue = [];
+    this._ceReactionQueue = null;
 
     this.nodeType = NODE_TYPE.ELEMENT_NODE;
     this.scrollTop = 0;


### PR DESCRIPTION
React tests that register custom elements can still render mostly ordinary HTML. Skip registry lookups when no definition can apply, and allocate custom-element reaction queues only when needed.

The registry guards reduced a 400-row ordinary UI mount benchmark from 12.60 ms to 10.95 ms with 100 registered definitions. Skipping the additional lookup when there is no `is` value reduced undefined-custom-element creation and reconnection time by another 28% and 35% with 500 definitions, compared with the guards alone.

Lazy reaction queues saved 325 KB (1.2%) of retained heap in a 2,000-row, 10,001-element form-like fixture. CPU measurements were roughly neutral across five alternating pairs.
