### PR TITLE
Defer SymbolTree bookkeeping allocation

### DIFF
--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -136,7 +136,7 @@ class NodeImpl extends EventTargetImpl {
   constructor(globalObject, args, privateData) {
     super(globalObject, args, privateData);
 
-    domSymbolTree.initialize(this);
+    this[domSymbolTree.symbol] = null;
 
     this._ownerDocument = privateData.ownerDocument;
 


### PR DESCRIPTION
Defer SymbolTree bookkeeping until a node uses it. Attributes inherit from Node but usually don't need tree bookkeeping; initializing the symbol slot to null keeps the property in place without allocating the object.

For a React/Testing Library form with 2,000 rows and 28,000 attributes:

| Incremental mounted heap after GC | Before | After |
| --- | --- | --- |
| Retained heap | 45.91 MB | 42.77 MB (−6.84%) |

The memory reduction repeated in two rounds of seven alternating fresh-process pairs. Mount and rerender CPU were slightly lower; unmount was noisy, with no repeatable CPU regression.
