### PR TITLE
fix: create <search> element with the HTMLElement interface

### DIFF
--- a/lib/jsdom/living/helpers/create-element.js
+++ b/lib/jsdom/living/helpers/create-element.js
@@ -23,7 +23,7 @@ const INTERFACE_TAG_MAPPING = {
     HTMLElement: [
       "abbr", "address", "article", "aside", "b", "bdi", "bdo", "cite", "code", "dd", "dfn", "dt", "em", "figcaption",
       "figure", "footer", "header", "hgroup", "i", "kbd", "main", "mark", "nav", "noscript", "rp", "rt", "ruby", "s",
-      "samp", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr"
+      "samp", "search", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr"
     ],
     HTMLAnchorElement: ["a"],
     HTMLAreaElement: ["area"],

--- a/test/api/element-type-search.js
+++ b/test/api/element-type-search.js
@@ -1,0 +1,26 @@
+"use strict";
+const assert = require("node:assert/strict");
+const { describe, it } = require("mocha-sugar-free");
+
+const { JSDOM } = require("../..");
+
+// Regression test for https://github.com/jsdom/jsdom/issues/3882
+// The <search> element is grouping content and uses the HTMLElement interface,
+// not HTMLUnknownElement.
+describe("<search> element type (GH-3882)", () => {
+  it("should be an HTMLElement when created via createElement", () => {
+    const { window } = new JSDOM();
+    const el = window.document.createElement("search");
+
+    assert.equal(el.constructor, window.HTMLElement);
+    assert.notEqual(el.constructor, window.HTMLUnknownElement);
+  });
+
+  it("should be an HTMLElement when produced by the HTML parser", () => {
+    const { window } = new JSDOM(`<search></search>`);
+    const el = window.document.querySelector("search");
+
+    assert.equal(el.constructor, window.HTMLElement);
+    assert.notEqual(el.constructor, window.HTMLUnknownElement);
+  });
+});

--- a/test/web-platform-tests/to-upstream/html/semantics/element-type-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/element-type-dont-upstream.html
@@ -42,7 +42,7 @@ test(() => {
 }, "Known elements should have their respective types");
 
 const nonInheritedTags = [
-  "article", "section", "nav", "aside", "hgroup", "header", "footer", "address",
+  "article", "section", "nav", "aside", "hgroup", "header", "footer", "address", "search",
   "dt", "dd", "figure", "figcaption", "main", "em", "strong", "small", "s",
   "cite", "abbr", "code", "i", "b", "u"
 ];


### PR DESCRIPTION
The `<search>` element is [grouping content](https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element) in the WHATWG HTML Standard and uses the `HTMLElement` interface, but it was missing from the `HTMLElement` tag list in `lib/jsdom/living/helpers/create-element.js`, so both `document.createElement("search")` and the HTML parser produced an `HTMLUnknownElement`.

Adding `"search"` to that grouping-content list fixes it. I also added `"search"` to the `nonInheritedTags` list in the `element-type-dont-upstream.html` test alongside the other grouping-content elements, and a focused `test/api` regression test for both the `createElement` and parser paths — it fails before the one-line change and passes after. `npm run test:api` passes (579).

Closes #3882
