### PR TITLE
fix: keep document.hasFocus() true while focus moves within a document

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -52,8 +52,12 @@ class HTMLOrSVGElementImpl {
       return;
     }
 
-    ownerDocument._lastFocusedElement = null;
     if (previous) {
+      // Per the focus update steps, the currently focused area of the document is only changed to the
+      // new focus target after the unfocusing steps (the blur/focusout events) have run. Keeping
+      // _lastFocusedElement pointing at `previous` until then means that, while focus transfers
+      // between two elements of the same document, document.hasFocus() stays true and
+      // document.activeElement still reflects the element being blurred inside the blur handler.
       focusing.fireFocusEventWithTargetAdjustment("blur", previous, this);
       focusing.fireFocusEventWithTargetAdjustment("focusout", previous, this, { bubbles: true });
     } else {

--- a/test/api/focus-hasfocus.js
+++ b/test/api/focus-hasfocus.js
@@ -1,0 +1,54 @@
+"use strict";
+const assert = require("node:assert/strict");
+const { describe, it } = require("mocha-sugar-free");
+
+const { JSDOM } = require("../..");
+
+// Regression test for https://github.com/jsdom/jsdom/issues/3794
+// While focus transfers between two elements of the same document, the document never loses
+// focus, so document.hasFocus() must stay true inside the blur handler of the element losing
+// focus and the focus handler of the element gaining it.
+describe("document.hasFocus() while focus moves within the document (GH-3794)", () => {
+  it("stays true inside the blur and focus handlers during a focus transfer", () => {
+    const { window: { document } } = new JSDOM(`<input id="one" /><input id="two" />`);
+    const events = [];
+
+    document.addEventListener("blur", () => {
+      events.push(`blur ${document.hasFocus()}`);
+    }, { capture: true });
+    document.addEventListener("focus", () => {
+      events.push(`focus ${document.hasFocus()}`);
+    }, { capture: true });
+
+    document.getElementById("one").focus();
+    document.getElementById("two").focus();
+
+    assert.deepEqual(events, ["focus true", "blur true", "focus true"]);
+  });
+
+  it("still reports the blurred element as document.activeElement inside its blur handler", () => {
+    const { window: { document } } = new JSDOM(`<input id="one" /><input id="two" />`);
+    let activeIdDuringBlur = null;
+
+    document.getElementById("one").addEventListener("blur", () => {
+      activeIdDuringBlur = document.activeElement.id;
+    });
+
+    document.getElementById("one").focus();
+    document.getElementById("two").focus();
+
+    assert.equal(activeIdDuringBlur, "one");
+  });
+
+  it("becomes false after the sole focused element is blurred", () => {
+    const { window: { document } } = new JSDOM(`<input id="one" />`);
+    const one = document.getElementById("one");
+
+    one.focus();
+    assert.equal(document.hasFocus(), true);
+
+    one.blur();
+    assert.equal(document.hasFocus(), false);
+    assert.equal(document.activeElement, document.body);
+  });
+});


### PR DESCRIPTION
Fixes #3794.

`focus()` cleared `ownerDocument._lastFocusedElement` before dispatching the `blur`/`focusout` events on the previously focused element. Since `document.hasFocus()` is `Boolean(_lastFocusedElement)` (and `activeElement` derives from the same field), both reported the document had lost focus inside a `blur`/`focusout` handler when focus was merely moving between two elements of the same document:

```js
const { window: { document } } = new JSDOM(`<input id="one" /><input id="two" />`);
document.addEventListener("blur", () => console.log("blur", document.hasFocus()), { capture: true });
document.addEventListener("focus", () => console.log("focus", document.hasFocus()), { capture: true });
document.getElementById("one").focus();
document.getElementById("two").focus();
// before: focus true / blur false / focus true — after: focus true / blur true / focus true
```

Per the [focus update steps](https://html.spec.whatwg.org/multipage/interaction.html#focus-update-steps) the currently focused area only changes to the new target after the unfocusing steps run, so `_lastFocusedElement` should stay pointing at the previous element until `blur`/`focusout` have fired. `activeElement` now also correctly reports the element being blurred inside its own handler; the iframe path and `blur()` (a genuine focus drop) are unchanged.

Added a `test/api` regression test covering `hasFocus()` during the transfer, `activeElement` inside the blur handler, and `hasFocus()` becoming false after the sole focused element is blurred — it fails before and passes after. `npm run test:api` passes (580).
