### PR TITLE
Keep document.hasFocus() true during a same-document focus transfer

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -243,6 +243,7 @@ class DocumentImpl extends NodeImpl {
     this._currentDocumentReadiness = privateData.options.readyState || "complete";
 
     this._lastFocusedElement = null;
+    this._transferringFocus = false;
 
     this._resourceLoader = new PerDocumentResourceLoader(this);
 
@@ -428,7 +429,10 @@ class DocumentImpl extends NodeImpl {
   }
 
   hasFocus() {
-    return Boolean(this._lastFocusedElement);
+    // A within-document focus transfer momentarily leaves no element focused
+    // (activeElement is <body>) while the blur/focusout events fire, but the
+    // document itself never loses focus during that window (GH-3794).
+    return Boolean(this._lastFocusedElement) || this._transferringFocus;
   }
 
   _descendantAdded(parent, child) {

--- a/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOrSVGElement-impl.js
@@ -54,8 +54,16 @@ class HTMLOrSVGElementImpl {
 
     ownerDocument._lastFocusedElement = null;
     if (previous) {
-      focusing.fireFocusEventWithTargetAdjustment("blur", previous, this);
-      focusing.fireFocusEventWithTargetAdjustment("focusout", previous, this, { bubbles: true });
+      // Focus is moving between two elements of the same document, so the
+      // document keeps focus even though no element is focused while these
+      // events run. Keep document.hasFocus() true for that window (GH-3794).
+      ownerDocument._transferringFocus = true;
+      try {
+        focusing.fireFocusEventWithTargetAdjustment("blur", previous, this);
+        focusing.fireFocusEventWithTargetAdjustment("focusout", previous, this, { bubbles: true });
+      } finally {
+        ownerDocument._transferringFocus = false;
+      }
     } else {
       const frameElement = ownerDocument._defaultView._frameElement;
       if (frameElement) {

--- a/test/api/focus.js
+++ b/test/api/focus.js
@@ -1,0 +1,32 @@
+"use strict";
+const assert = require("node:assert/strict");
+const { describe, it } = require("mocha-sugar-free");
+
+const { JSDOM } = require("../..");
+
+describe("document.hasFocus() during a within-document focus transfer (GH-3794)", () => {
+  it("stays true inside the blur and focus handlers when focus moves between elements", () => {
+    const { window: { document } } = new JSDOM(`<input id="one" /><input id="two" />`);
+    const one = document.getElementById("one");
+    const two = document.getElementById("two");
+    one.focus();
+
+    const seen = [];
+    document.addEventListener("blur", () => {
+      seen.push(["blur", document.hasFocus(), document.activeElement]);
+    }, { capture: true });
+    document.addEventListener("focus", () => {
+      seen.push(["focus", document.hasFocus()]);
+    }, { capture: true });
+
+    two.focus();
+
+    // The document keeps focus throughout the transfer...
+    assert.deepEqual(seen.map(([type, has]) => [type, has]), [["blur", true], ["focus", true]]);
+    // ...even though no element is focused while the blur runs: activeElement is
+    // <body> at that point, per the HTML focus update steps.
+    assert.equal(seen[0][2], document.body);
+    assert.equal(document.activeElement, two);
+    assert.equal(document.hasFocus(), true);
+  });
+});


### PR DESCRIPTION
Fixes #3794. Supersedes #4283, which fixed the symptom the wrong way (it changed `activeElement` timing and broke `focus-management/focus-events.html`).

When focus moves between two elements of the same document, `focus()` momentarily sets `_lastFocusedElement` to null while the blur/focusout events fire. That part is correct: `document.activeElement` should be `<body>` at that point, per the focus update steps and as asserted by `focus-events.html`. But `document.hasFocus()` is `Boolean(_lastFocusedElement)`, so it wrongly returned false inside a blur/focus handler during the transfer, even though the document never lost focus.

This keeps a `_transferringFocus` flag set while those events fire so `hasFocus()` stays true, without touching `activeElement` timing.

Added a `test/api` regression test (hasFocus() stays true in both handlers; activeElement is `<body>` inside the blur). `npm run test:api` passes, and the WPT focus suite (`html/interaction/focus/**`, including `focus-events.html` and `document-level-apis.html`) passes.
