### PR TITLE
Cache serialized style declarations

### DIFF
--- a/benchmark/style/style-property.js
+++ b/benchmark/style/style-property.js
@@ -42,5 +42,22 @@ module.exports = () => {
     }
   });
 
+  bench.add("createElement + visually hidden input styles", () => {
+    for (let i = 0; i < 20; i++) {
+      const input = document.createElement("input");
+      Object.assign(input.style, {
+        clipPath: "inset(50%)",
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        border: "0",
+        padding: "0",
+        width: "1px",
+        height: "1px",
+        margin: "-1px",
+        position: "absolute"
+      });
+    }
+  });
+
   return bench;
 };

--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -36,6 +36,7 @@ class CSSStyleDeclarationImpl {
   // Internal private fields.
   #computedValueOpts = new Map();
   #cachedPropertyValues = new Map();
+  #cachedCssText = null;
 
   constructor(globalObject, args, { computed, ownerNode, parentRule } = {}) {
     this._globalObject = globalObject;
@@ -52,6 +53,9 @@ class CSSStyleDeclarationImpl {
   get cssText() {
     if (this._computed) {
       return "";
+    }
+    if (this.#cachedCssText !== null) {
+      return this.#cachedCssText;
     }
     const properties = new Map();
     for (const property of this.#values.keys()) {
@@ -76,7 +80,8 @@ class CSSStyleDeclarationImpl {
         parts.push(`${property}: ${value};`);
       }
     }
-    return parts.join(" ");
+    this.#cachedCssText = parts.join(" ");
+    return this.#cachedCssText;
   }
 
   /**
@@ -92,6 +97,7 @@ class CSSStyleDeclarationImpl {
         "NoModificationAllowedError"
       ]);
     }
+    this.#cachedCssText = null;
     this.#values.clear();
     this._priorities.clear();
     this.#updating = true;
@@ -266,6 +272,7 @@ class CSSStyleDeclarationImpl {
       return "";
     }
     const prevValue = this.#values.get(property);
+    this.#cachedCssText = null;
     this.#values.delete(property);
     this._priorities.delete(property);
     this.#updateStyleAttribute();
@@ -304,6 +311,7 @@ class CSSStyleDeclarationImpl {
     if (!Object.hasOwn(propertyDescriptors, property)) {
       return;
     }
+    this.#cachedCssText = null;
     if (priority) {
       this._priorities.set(property, priority);
     } else {
@@ -350,6 +358,7 @@ class CSSStyleDeclarationImpl {
       this._priorities.delete(property);
     }
 
+    this.#cachedCssText = null;
     this.#values.set(property, value);
 
     if (this.#ownerNode && !this.#updating && this.cssText !== originalText) {

--- a/test/web-platform-tests/to-upstream/css/cssom/style-cssText-mutations.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-cssText-mutations.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>cssText reflects changes after it has been read</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+for (const kind of ["inline", "rule"]) {
+  test(() => {
+    let style;
+    if (kind === "inline") {
+      style = document.createElement("div").style;
+    } else {
+      const sheet = new CSSStyleSheet();
+      sheet.insertRule("div {}");
+      style = sheet.cssRules[0].style;
+    }
+
+    assert_equals(style.cssText, "");
+    style.color = "red";
+    assert_equals(style.cssText, "color: red;");
+    style.color = "blue";
+    assert_equals(style.cssText, "color: blue;");
+    style.setProperty("color", "blue", "important");
+    assert_equals(style.cssText, "color: blue !important;");
+    style.setProperty("color", "blue");
+    assert_equals(style.cssText, "color: blue;");
+    style.removeProperty("color");
+    assert_equals(style.cssText, "");
+
+    style.setProperty("--custom", "one", "important");
+    assert_equals(style.cssText, "--custom: one !important;");
+    style.setProperty("--custom", "two");
+    assert_equals(style.cssText, "--custom: two;");
+    style.setProperty("--custom", "");
+    assert_equals(style.cssText, "");
+
+    style.margin = "1px";
+    assert_equals(style.cssText, "margin: 1px;");
+    style.marginLeft = "2px";
+    assert_equals(style.cssText, "margin: 1px 1px 1px 2px;");
+    style.cssText = "color: green !important;";
+    assert_equals(style.cssText, "color: green !important;");
+    style.cssText = "invalid";
+    assert_equals(style.cssText, "");
+    style.color = "red";
+    assert_equals(style.cssText, "color: red;");
+    style.cssText = "";
+    assert_equals(style.cssText, "");
+  }, `${kind} cssText reflects property, priority, shorthand, and declaration replacements`);
+}
+
+test(() => {
+  const div = document.createElement("div");
+  div.style.color = "red";
+  assert_equals(div.style.cssText, "color: red;");
+  div.setAttribute("style", "color:blue!important");
+  assert_equals(div.style.cssText, "color: blue !important;");
+  assert_equals(div.getAttribute("style"), "color:blue!important");
+  div.removeAttribute("style");
+  assert_equals(div.style.cssText, "");
+  div.style.color = "green";
+  assert_equals(div.getAttribute("style"), "color: green;");
+}, "cssText reflects style attribute replacement and removal");
+
+test(t => {
+  const div = document.createElement("div");
+  div.style.color = "red";
+  assert_equals(div.style.cssText, "color: red;");
+  const observer = new MutationObserver(() => {});
+  t.add_cleanup(() => observer.disconnect());
+  observer.observe(div, { attributes: true, attributeOldValue: true });
+
+  div.style.color = "red";
+  assert_equals(observer.takeRecords().length, 0);
+  div.style.color = "blue";
+  assert_equals(div.style.cssText, "color: blue;");
+  div.style.removeProperty("color");
+  assert_equals(div.style.cssText, "");
+  const records = observer.takeRecords();
+  assert_array_equals(records.map(record => record.oldValue), ["color: red;", "color: blue;"]);
+  assert_equals(div.getAttribute("style"), "");
+}, "Reading cssText preserves style mutation records");
+</script>


### PR DESCRIPTION
Cache `cssText` until a property or priority changes, so style setters can reuse it when comparing and updating the style attribute.

Compared with main at 4a65f353 on Node 26.8.1:

| Benchmark | Before | After |
| --- | ---: | ---: |
| Style properties, 20 elements | 2.65 ms | 1.43 ms |
| Base UI hidden-input styles, 20 elements | 4.55 ms | 2.13 ms |
| Base UI form mount + unmount, run 1 | 3.15 ms | 2.45 ms |
| Base UI form mount + unmount, run 2 | 2.95 ms | 2.49 ms |
