### PR TITLE
Reuse border definitions during serialization

### DIFF
--- a/lib/jsdom/living/css/helpers/shorthand-properties.js
+++ b/lib/jsdom/living/css/helpers/shorthand-properties.js
@@ -70,6 +70,9 @@ const borderProperties = new Set([
   ...borderLeft.shorthandFor.keys()
 ]);
 
+const borderLineShorthands = [borderWidth, borderStyle, borderColor];
+const borderPositionShorthands = [borderTop, borderRight, borderBottom, borderLeft];
+
 const borderLines = new Set([WIDTH, STYLE, COLOR]);
 
 const borderPositions = new Set([TOP, RIGHT, BOTTOM, LEFT]);
@@ -1488,42 +1491,26 @@ function prepareProperties(properties) {
  */
 function normalizeProperties(properties) {
   if (properties.has(border.property)) {
-    for (const line of borderLines) {
-      properties.delete(`${border.property}-${line}`);
-    }
-    for (const position of borderPositions) {
-      properties.delete(`${border.property}-${position}`);
-      for (const line of borderLines) {
-        properties.delete(`${border.property}-${position}-${line}`);
-      }
-    }
-    properties.delete(`${border.property}-image`);
-  }
-  for (const line of borderLines) {
-    const lineProperty = `${border.property}-${line}`;
-    if (properties.has(lineProperty)) {
-      for (const position of borderPositions) {
-        const positionProperty = `${border.property}-${position}`;
-        const longhandProperty = `${border.property}-${position}-${line}`;
-        properties.delete(positionProperty);
-        properties.delete(longhandProperty);
+    for (const property of borderProperties) {
+      if (property !== border.property) {
+        properties.delete(property);
       }
     }
   }
-  for (const position of borderPositions) {
-    const positionProperty = `${border.property}-${position}`;
-    if (properties.has(positionProperty)) {
-      const longhandProperties = [];
-      for (const line of borderLines) {
-        const longhandProperty = `${border.property}-${position}-${line}`;
-        longhandProperties.push(longhandProperty);
+  for (const line of borderLineShorthands) {
+    if (properties.has(line.property)) {
+      for (const position of borderPositionShorthands) {
+        properties.delete(position.property);
       }
-      if (longhandProperties.length === 3) {
-        for (const longhandProperty of longhandProperties) {
-          properties.delete(longhandProperty);
-        }
-      } else {
-        properties.delete(positionProperty);
+      for (const property of line.shorthandFor.keys()) {
+        properties.delete(property);
+      }
+    }
+  }
+  for (const position of borderPositionShorthands) {
+    if (properties.has(position.property)) {
+      for (const property of position.shorthandFor.keys()) {
+        properties.delete(property);
       }
     }
   }


### PR DESCRIPTION
Use the existing border property definitions to remove redundant longhands during serialization, instead of rebuilding property names on every call.

Base UI form mount + unmount, Node 26.8.1:

| Run | #4286 | + this change |
| --- | ---: | ---: |
| 1 | 2.42 ms | 2.20 ms |
| 2 | 2.55 ms | 2.29 ms |
