### PR TITLE
Skip recursive traversal generators for leaves

### DIFF
--- a/benchmark/dom/tree-modification.js
+++ b/benchmark/dom/tree-modification.js
@@ -68,5 +68,27 @@ module.exports = () => {
     }
   });
 
+  for (const count of [1, 100]) {
+    for (const shadow of [false, true]) {
+      for (const connected of [false, true]) {
+        const parent = document.createElement("div");
+        const subtree = document.createElement("div");
+        const container = shadow ? subtree.attachShadow({ mode: "closed" }) : subtree;
+        container.innerHTML = "<label><span>Name</span><input></label>".repeat(count);
+        parent.appendChild(subtree);
+        const name = `${connected ? "connected" : "detached"} ${shadow ? "shadow" : "light"} subtree (${count} fields)`;
+        bench.add(`appendChild: ${name}`, () => {
+          parent.appendChild(subtree);
+        }, {
+          beforeAll() {
+            if (connected) {
+              document.body.appendChild(parent);
+            }
+          }
+        });
+      }
+    }
+  }
+
   return bench;
 };

--- a/lib/jsdom/living/helpers/shadow-dom.js
+++ b/lib/jsdom/living/helpers/shadow-dom.js
@@ -240,33 +240,19 @@ function signalSlotChange(slot) {
 
 // https://dom.spec.whatwg.org/#concept-shadow-including-descendant
 function* shadowIncludingInclusiveDescendantsIterator(node) {
-  yield node;
-
-  if (node._shadowRoot) {
-    yield* shadowIncludingInclusiveDescendantsIterator(node._shadowRoot);
-  }
-
-  for (const child of domSymbolTree.childrenIterator(node)) {
-    // Avoid a recursive generator for leaves, but check after yielding in case the tree changes.
-    yield child;
-    if (child._shadowRoot || domSymbolTree.hasChildren(child)) {
-      yield* shadowIncludingDescendantsIterator(child);
+  for (const descendant of domSymbolTree.treeIterator(node)) {
+    yield descendant;
+    if (descendant._shadowRoot) {
+      yield* shadowIncludingInclusiveDescendantsIterator(descendant._shadowRoot);
     }
   }
 }
 
 // https://dom.spec.whatwg.org/#concept-shadow-including-descendant
-function* shadowIncludingDescendantsIterator(node) {
-  if (node._shadowRoot) {
-    yield* shadowIncludingInclusiveDescendantsIterator(node._shadowRoot);
-  }
-
-  for (const child of domSymbolTree.childrenIterator(node)) {
-    yield child;
-    if (child._shadowRoot || domSymbolTree.hasChildren(child)) {
-      yield* shadowIncludingDescendantsIterator(child);
-    }
-  }
+function shadowIncludingDescendantsIterator(node) {
+  const iterator = shadowIncludingInclusiveDescendantsIterator(node);
+  iterator.next();
+  return iterator;
 }
 
 module.exports = {

--- a/lib/jsdom/living/helpers/shadow-dom.js
+++ b/lib/jsdom/living/helpers/shadow-dom.js
@@ -247,7 +247,11 @@ function* shadowIncludingInclusiveDescendantsIterator(node) {
   }
 
   for (const child of domSymbolTree.childrenIterator(node)) {
-    yield* shadowIncludingInclusiveDescendantsIterator(child);
+    // Avoid a recursive generator for leaves, but check after yielding in case the tree changes.
+    yield child;
+    if (child._shadowRoot || domSymbolTree.hasChildren(child)) {
+      yield* shadowIncludingDescendantsIterator(child);
+    }
   }
 }
 
@@ -258,7 +262,10 @@ function* shadowIncludingDescendantsIterator(node) {
   }
 
   for (const child of domSymbolTree.childrenIterator(node)) {
-    yield* shadowIncludingInclusiveDescendantsIterator(child);
+    yield child;
+    if (child._shadowRoot || domSymbolTree.hasChildren(child)) {
+      yield* shadowIncludingDescendantsIterator(child);
+    }
   }
 }
 

--- a/test/web-platform-tests/to-upstream/custom-elements/shadow-descendant-lifecycle-order.html
+++ b/test/web-platform-tests/to-upstream/custom-elements/shadow-descendant-lifecycle-order.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Custom element lifecycle order through nested shadow trees</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-upgrade">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+setup({ allow_uncaught_exception: true });
+
+test(t => {
+  const root = document.createElement("x-traversal-order");
+  root.id = "root";
+  root.innerHTML = '<x-traversal-order id="light">' +
+    '<x-traversal-order id="leaf"></x-traversal-order></x-traversal-order>';
+  const shadow = root.attachShadow({ mode: "closed" });
+  shadow.innerHTML = '<x-traversal-order id="shadow"></x-traversal-order>';
+  shadow.firstChild.attachShadow({ mode: "open" }).innerHTML = '<x-traversal-order id="nested"></x-traversal-order>';
+  t.add_cleanup(() => root.remove());
+
+  const calls = [];
+  customElements.define("x-traversal-order", class extends HTMLElement {
+    constructor() {
+      super();
+      calls.push(`upgrade:${this.id}`);
+    }
+    connectedCallback() {
+      calls.push(`connect:${this.id}`);
+    }
+    disconnectedCallback() {
+      calls.push(`disconnect:${this.id}`);
+    }
+    adoptedCallback() {
+      calls.push(`adopt:${this.id}`);
+    }
+  });
+
+  const order = ["root", "shadow", "nested", "light", "leaf"];
+  customElements.upgrade(root);
+  assert_array_equals(calls, order.map(id => `upgrade:${id}`));
+  calls.length = 0;
+
+  document.body.appendChild(root);
+  assert_array_equals(calls, order.map(id => `connect:${id}`));
+  calls.length = 0;
+
+  root.remove();
+  assert_array_equals(calls, order.map(id => `disconnect:${id}`));
+  calls.length = 0;
+
+  document.implementation.createHTMLDocument().adoptNode(root);
+  assert_array_equals(calls, order.map(id => `adopt:${id}`));
+}, "Upgrade, connection, removal, and adoption visit closed and nested shadow trees before light children");
+
+test(t => {
+  const root = document.createElement("div");
+  root.innerHTML = '<x-traversal-failure id="failed"></x-traversal-failure>' +
+    '<x-traversal-failure id="sibling"></x-traversal-failure>';
+  const shadow = root.firstChild.attachShadow({ mode: "closed" });
+  shadow.innerHTML = '<x-traversal-failure id="shadow"></x-traversal-failure>';
+  t.add_cleanup(() => root.remove());
+
+  const failure = new Error("Expected constructor failure");
+  const errors = [];
+  function onError(event) {
+    errors.push(event.error);
+    event.preventDefault();
+  }
+  window.addEventListener("error", onError);
+  t.add_cleanup(() => window.removeEventListener("error", onError));
+
+  const calls = [];
+  customElements.define("x-traversal-failure", class extends HTMLElement {
+    constructor() {
+      super();
+      calls.push(`upgrade:${this.id}`);
+      if (this.id === "failed") {
+        throw failure;
+      }
+    }
+    connectedCallback() {
+      calls.push(`connect:${this.id}`);
+    }
+  });
+
+  customElements.upgrade(root);
+  assert_array_equals(errors, [failure]);
+  assert_array_equals(calls, ["upgrade:failed", "upgrade:shadow", "upgrade:sibling"]);
+  calls.length = 0;
+  document.body.appendChild(root);
+  assert_array_equals(calls, ["connect:shadow", "connect:sibling"]);
+}, "A failed upgrade does not skip shadow descendants or following siblings");
+</script>


### PR DESCRIPTION
Skip recursive generators for leaf nodes during DOM traversal. Found while profiling a Base UI form; subtree moves improved, but the full form showed no consistent gain.

100-field subtrees on Node 26.8.1:

| Subtree | Main | This change |
| --- | ---: | ---: |
| Detached, light DOM | 0.161 ms | 0.141 ms |
| Connected, light DOM | 0.232 ms | 0.200 ms |
| Detached, shadow DOM | 0.148 ms | 0.128 ms |
| Connected, shadow DOM | 0.192 ms | 0.162 ms |
