### PR TITLE
Keep attribute lookups correct after prefix changes

### DIFF
--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -148,14 +148,20 @@ exports.replaceAttribute = function (element, oldAttr, newAttr) {
       newAttr._ownerDocument = element._ownerDocument;
 
       // Sync name cache
+      const oldName = oldAttr._qualifiedName;
       const name = newAttr._qualifiedName;
       const cache = element._attributesByNameMap;
-      let entry = cache.get(name);
-      if (!entry) {
-        entry = [];
-        cache.set(name, entry);
+      const entry = cache.get(oldName);
+      if (oldName === name) {
+        entry.splice(entry.indexOf(oldAttr), 1, newAttr);
+      } else {
+        entry.splice(entry.indexOf(oldAttr), 1);
+        if (entry.length === 0) {
+          cache.delete(oldName);
+        }
+        // The replacement keeps its position in the attribute list, including among same-name attributes.
+        cache.set(name, attributeList.filter(attr => attr._qualifiedName === name));
       }
-      entry.splice(entry.indexOf(oldAttr), 1, newAttr);
 
       // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is changed."
       element._attrModified(name, newAttr._value, oldAttr._value);

--- a/test/web-platform-tests/to-upstream/dom/nodes/Element-setAttributeNodeNS.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Element-setAttributeNodeNS.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Attribute name lookups after replacing an attribute prefix</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+for (const namespacedFirst of [false, true]) {
+  test(() => {
+    const element = document.createElement("div");
+    if (namespacedFirst) {
+      element.setAttributeNS("urn:test", "p:id", "namespaced");
+    }
+    element.setAttributeNS(null, "id", "plain");
+    if (!namespacedFirst) {
+      element.setAttributeNS("urn:test", "p:id", "namespaced");
+    }
+
+    const replacement = document.createAttributeNS("urn:test", "id");
+    replacement.value = "replacement";
+    element.setAttributeNodeNS(replacement);
+
+    assert_equals(element.getAttribute("p:id"), null);
+    assert_false(element.hasAttribute("p:id"));
+    assert_equals(element.getAttribute("id"), namespacedFirst ? "replacement" : "plain");
+    assert_equals(element.getAttributeNS(null, "id"), "plain");
+    assert_equals(element.getAttributeNS("urn:test", "id"), "replacement");
+
+    element.removeAttributeNS("urn:test", "id");
+    assert_equals(element.getAttribute("id"), "plain");
+    assert_equals(element.id, "plain");
+  }, `Replacing an attribute prefix preserves name lookup order with namespacedFirst=${namespacedFirst}`);
+}
+
+test(() => {
+  const element = document.createElement("div");
+  element.setAttributeNS("urn:test", "p:id", "namespaced");
+  const attribute = document.createAttribute("p:id");
+  attribute.value = "plain";
+  element.setAttributeNode(attribute);
+
+  const replacement = document.createAttributeNS("urn:test", "q:id");
+  replacement.value = "replacement";
+  element.setAttributeNodeNS(replacement);
+
+  assert_equals(element.getAttribute("p:id"), "plain");
+  assert_equals(element.getAttributeNode("p:id"), attribute);
+  assert_equals(element.getAttribute("q:id"), "replacement");
+  element.removeAttribute("q:id");
+  assert_equals(element.getAttribute("p:id"), "plain");
+  assert_equals(element.getAttribute("q:id"), null);
+}, "Replacing an attribute prefix preserves other attributes with the old qualified name");
+</script>


### PR DESCRIPTION
Fix stale attribute lookups when `setAttributeNodeNS()` replaces an attribute with a different prefix, preserving other attributes with the same name and their order. 
