### PR TITLE
Cache repeated attribute query results

### DIFF
--- a/benchmark/dom/memoized-queries.js
+++ b/benchmark/dom/memoized-queries.js
@@ -53,5 +53,51 @@ module.exports = () => {
     queryRoot.getElementsByTagName("a");
   });
 
+  for (const size of [20, 250]) {
+    const container = document.createElement("div");
+    container.innerHTML = Array.from({ length: size }, (_, i) => {
+      return `<div data-testid="row-${i}"><span></span></div>`;
+    }).join("");
+    const last = container.lastElementChild;
+    const selectors = ["[data-testid]", `[data-testid="row-${size - 1}"]`, '[data-testid="missing"]'];
+    const options = {
+      beforeAll() {
+        document.body.append(container);
+        for (const selector of selectors) {
+          container.querySelectorAll(selector);
+        }
+      }
+    };
+
+    for (const selector of selectors) {
+      bench.add(`querySelectorAll(${selector}): ${size} rows, warm`, () => {
+        return container.querySelectorAll(selector).length;
+      }, options);
+    }
+
+    for (const reads of [1, 5, 20]) {
+      for (const mutation of ["attribute", "subtree"]) {
+        bench.add(`querySelectorAll(): ${size} rows, ${mutation} mutation then ${reads} query pairs`, () => {
+          if (mutation === "attribute") {
+            last.toggleAttribute("data-dirty");
+          } else {
+            last.replaceChildren(document.createElement("span"));
+          }
+          let matches = 0;
+          for (let i = 0; i < reads; ++i) {
+            matches += container.querySelectorAll(selectors[0]).length;
+            matches += container.querySelectorAll(selectors[1]).length;
+          }
+          return matches;
+        }, options);
+      }
+    }
+
+    let selectorIndex = 0;
+    bench.add(`querySelectorAll(): ${size} rows, cycle through 32 selectors`, () => {
+      return container.querySelectorAll(`[data-testid="row-${selectorIndex++ % 32}"]`).length;
+    }, options);
+  }
+
   return bench;
 };

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -110,6 +110,7 @@ function createMemoizedQueries() {
     collectionsByClassNames: null,
     collectionsByQualifiedName: null,
     collectionsByNamespaceAndLocalName: null,
+    attributeSelectorResults: null,
     labelAssociations: null
   };
 }

--- a/lib/jsdom/living/nodes/ParentNode-impl.js
+++ b/lib/jsdom/living/nodes/ParentNode-impl.js
@@ -6,6 +6,12 @@ const { domSymbolTree } = require("../helpers/internal-constants");
 const NODE_TYPE = require("../node-type");
 const { convertNodesIntoNode } = require("../node");
 
+const MAX_CACHED_ATTRIBUTE_SELECTORS = 16;
+const MAX_CACHED_SELECTOR_LENGTH = 256;
+
+// A conservative subset whose matches depend only on the queried subtree, not ancestors or dynamic state.
+const simpleAttributeSelector = /^\[[a-zA-Z_][\w-]*(?:=(?:"[^"\\\n\r\f]*"|'[^'\\\n\r\f]*'))?\]$/u;
+
 class ParentNodeImpl {
   get children() {
     if (!this._childrenList) {
@@ -74,10 +80,35 @@ class ParentNodeImpl {
     if (shouldAlwaysSelectNothing(this)) {
       return NodeList.createImpl(this._globalObject, [], { nodes: [] });
     }
-    const domSelector = this._ownerDocument._getDOMSelector();
-    const nodes = domSelector.querySelectorAll(selectors, this);
+    const nodes = querySelectorAllNodes(this, selectors);
     return NodeList.createImpl(this._globalObject, [], { nodes });
   }
+}
+
+function querySelectorAllNodes(root, selectors) {
+  let results;
+  if (selectors.length <= MAX_CACHED_SELECTOR_LENGTH && simpleAttributeSelector.test(selectors)) {
+    const memoizedQueries = root._getMemoizedQueries();
+    results = memoizedQueries.attributeSelectorResults;
+    if (results === null) {
+      results = new Map();
+      memoizedQueries.attributeSelectorResults = results;
+    }
+    const cached = results.get(selectors);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+  const domSelector = root._ownerDocument._getDOMSelector();
+  const nodes = domSelector.querySelectorAll(selectors, root);
+  if (results) {
+    // Bound retention when a root receives many different selectors without intervening mutations.
+    if (results.size === MAX_CACHED_ATTRIBUTE_SELECTORS) {
+      results.delete(results.keys().next().value);
+    }
+    results.set(selectors, nodes);
+  }
+  return nodes;
 }
 
 function shouldAlwaysSelectNothing(elImpl) {

--- a/test/api/fixtures/live-collections-with-gc.js
+++ b/test/api/fixtures/live-collections-with-gc.js
@@ -8,10 +8,14 @@ const { JSDOM } = require("../../..");
   const { document } = new JSDOM().window;
   const parent = document.body.appendChild(document.createElement("div"));
   let child = parent.appendChild(document.createElement("span"));
+  child.setAttribute("data-testid", "child");
 
-  // Materialize both live collections before removing their shared child.
+  // Materialize live collections and selector results before removing their shared child.
   assert.equal(parent.childNodes.length, 1);
   assert.equal(parent.children.length, 1);
+  assert.equal(parent.querySelectorAll("[data-testid]").length, 1);
+  assert.equal(parent.querySelectorAll("[data-testid]").length, 1);
+  assert.equal(document.querySelectorAll("[data-testid]").length, 1);
 
   const childRef = new WeakRef(child);
   parent.removeChild(child);
@@ -27,7 +31,7 @@ const { JSDOM } = require("../../..");
     }
   }
 
-  // Keep the parent and its cached live collections reachable throughout the test.
+  // Keep the parent and its caches reachable throughout the test, without another query after removal.
   assert.equal(parent.isConnected, true);
   console.log(collected ? "collected" : "retained");
 })();

--- a/test/api/from-outside.js
+++ b/test/api/from-outside.js
@@ -66,7 +66,7 @@ describe("Test cases only possible to test from the outside", () => {
     assert(ratio < 0.3);
   });
 
-  it("does not retain removed children through live collections", { timeout: 5000 }, () => {
+  it("does not retain removed children through live collections or selector results", { timeout: 5000 }, () => {
     const fixturePath = path.resolve(__dirname, "./fixtures/live-collections-with-gc.js");
     const { status, stderr, stdout } = spawnSync("node", ["--expose-gc", fixturePath], { encoding: "utf-8" });
 

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-repeated.window.js
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-repeated.window.js
@@ -1,0 +1,212 @@
+"use strict";
+
+for (const kind of ["document", "element", "fragment", "shadow root"]) {
+  for (const selector of ["[data-testid]", '[data-testid="target"]']) {
+    test(() => {
+      const doc = document.implementation.createHTMLDocument();
+      let root;
+      if (kind === "document") {
+        root = doc;
+      } else if (kind === "element") {
+        root = doc.createElement("div");
+      } else if (kind === "fragment") {
+        root = doc.createDocumentFragment();
+      } else {
+        root = doc.createElement("div").attachShadow({ mode: "open" });
+      }
+
+      const parent = kind === "document" ? doc.body : root;
+      const empty = root.querySelectorAll(selector);
+      assert_not_equals(root.querySelectorAll(selector), empty);
+      const first = doc.createElement("span");
+      first.setAttribute("data-testid", "target");
+      parent.append(first);
+      const original = root.querySelectorAll(selector);
+      assert_array_equals([...original], [first]);
+      assert_not_equals(root.querySelectorAll(selector), original);
+      assert_array_equals([...empty], []);
+
+      const second = first.cloneNode();
+      parent.append(second);
+      assert_array_equals([...root.querySelectorAll(selector)], [first, second]);
+      parent.prepend(second);
+      assert_array_equals([...root.querySelectorAll(selector)], [second, first]);
+      first.removeAttribute("data-testid");
+      assert_array_equals([...root.querySelectorAll(selector)], [second]);
+      first.setAttribute("data-testid", "target");
+      assert_array_equals([...root.querySelectorAll(selector)], [second, first]);
+      first.getAttributeNode("data-testid").value = "other";
+      const expected = selector === "[data-testid]" ? [second, first] : [second];
+      assert_array_equals([...root.querySelectorAll(selector)], expected);
+      second.remove();
+      first.remove();
+      assert_array_equals([...root.querySelectorAll(selector)], []);
+      assert_array_equals([...original], [first]);
+    }, `Repeated ${selector} queries on a ${kind} return fresh static results after mutations`);
+  }
+}
+
+test(() => {
+  const root = document.createElement("div");
+  root.innerHTML = '<div><span data-testid="target"></span></div><div></div>';
+  const first = root.firstChild;
+  const second = root.lastChild;
+  const target = first.firstChild;
+  const selector = '[data-testid="target"]';
+  assert_array_equals([...first.querySelectorAll(selector)], [target]);
+  assert_array_equals([...second.querySelectorAll(selector)], []);
+  assert_array_equals([...root.querySelectorAll(selector)], [target]);
+  second.append(target);
+  assert_array_equals([...first.querySelectorAll(selector)], []);
+  assert_array_equals([...second.querySelectorAll(selector)], [target]);
+  assert_array_equals([...root.querySelectorAll(selector)], [target]);
+  second.replaceChildren();
+  assert_array_equals([...root.querySelectorAll(selector)], []);
+}, "Moving and removing a matching subtree updates queries on each ancestor");
+
+test(() => {
+  const root = document.createElement("div");
+  const shadow = root.attachShadow({ mode: "open" });
+  shadow.innerHTML = '<span data-testid="shadow"></span>';
+  root.innerHTML = '<span data-testid="light"></span>';
+  const selector = "[data-testid]";
+  assert_array_equals([...root.querySelectorAll(selector)], [root.firstChild]);
+  assert_array_equals([...shadow.querySelectorAll(selector)], [shadow.firstChild]);
+  shadow.firstChild.remove();
+  assert_array_equals([...shadow.querySelectorAll(selector)], []);
+  assert_array_equals([...root.querySelectorAll(selector)], [root.firstChild]);
+}, "Repeated queries keep light and shadow trees separate");
+
+test(() => {
+  const root = document.createElement("div");
+  root.innerHTML = '<input type="checkbox"><input>';
+  document.body.append(root);
+  try {
+    const checkbox = root.firstChild;
+    const input = root.lastChild;
+    assert_equals(root.querySelectorAll(":checked").length, 0);
+    checkbox.checked = true;
+    assert_array_equals([...root.querySelectorAll(":checked")], [checkbox]);
+    checkbox.checked = false;
+    assert_equals(root.querySelectorAll(":checked").length, 0);
+    assert_equals(root.querySelectorAll(":focus").length, 0);
+    input.focus();
+    assert_array_equals([...root.querySelectorAll(":focus")], [input]);
+    input.blur();
+    assert_equals(root.querySelectorAll(":focus").length, 0);
+  } finally {
+    root.remove();
+  }
+}, "Repeated queries observe property changes and focus changes");
+
+test(() => {
+  const root = document.createElement("div");
+  root.innerHTML = '<span data-testid="target"></span>';
+  const selector = '[data-testid="target"]';
+  assert_equals(root.querySelectorAll(selector).length, 1);
+  for (let i = 0; i < 40; ++i) {
+    assert_equals(root.querySelectorAll(`[data-testid="${i}"]`).length, 0);
+  }
+  assert_array_equals([...root.querySelectorAll(selector)], [root.firstChild]);
+  for (let i = 0; i < 2; ++i) {
+    assert_throws_dom("SyntaxError", () => root.querySelectorAll('[data-testid="target"] invalid['));
+  }
+}, "Many distinct queries preserve results and syntax errors");
+
+test(() => {
+  const html = document.implementation.createHTMLDocument();
+  const xml = document.implementation.createDocument(null, "root");
+  const host = html.createElement("div");
+  host.innerHTML = '<div><span data-testid="target"></span></div>';
+  const shadow = host.attachShadow({ mode: "closed" });
+  shadow.innerHTML = '<span data-testid="shadow"></span>';
+  const roots = [host, host.firstChild, shadow];
+  const selector = "[DATA-TESTID]";
+  for (const root of roots) {
+    assert_equals(root.querySelectorAll(selector).length, 1);
+  }
+  xml.adoptNode(host);
+  for (const root of roots) {
+    assert_equals(root.querySelectorAll(selector).length, 0);
+  }
+  html.adoptNode(host);
+  for (const root of roots) {
+    assert_equals(root.querySelectorAll(selector).length, 1);
+  }
+}, "Adoption updates attribute name matching in descendant and shadow query roots");
+
+test(() => {
+  const root = document.createElement("div");
+  root.innerHTML = "<span></span>";
+  const child = root.firstChild;
+  assert_equals(root.querySelectorAll("[style]").length, 0);
+  child.style.color = "red";
+  assert_array_equals([...root.querySelectorAll("[style]")], [child]);
+  const selector = '[data-testid="target"]';
+  assert_equals(root.querySelectorAll(selector).length, 0);
+  child.dataset.testid = "target";
+  assert_array_equals([...root.querySelectorAll(selector)], [child]);
+  child.attributes.removeNamedItem("data-testid");
+  assert_equals(root.querySelectorAll(selector).length, 0);
+  const attr = document.createAttribute("data-testid");
+  attr.value = "target";
+  child.setAttributeNode(attr);
+  assert_array_equals([...root.querySelectorAll(selector)], [child]);
+  root.innerHTML = '<b data-testid="target"></b>';
+  assert_array_equals([...root.querySelectorAll(selector)], [root.firstChild]);
+}, "Reflected attributes, attribute nodes, and innerHTML update repeated queries");
+
+test(() => {
+  const root = document.createElement("div");
+  root.innerHTML = '<input data-testid="target" type="checkbox">';
+  const input = root.firstChild;
+  const selector = '[data-testid="target"]:checked';
+  assert_equals(root.querySelectorAll(selector).length, 0);
+  input.checked = true;
+  assert_array_equals([...root.querySelectorAll(selector)], [input]);
+  input.checked = false;
+  assert_equals(root.querySelectorAll(selector).length, 0);
+}, "An attribute selector followed by a pseudo-class observes state changes");
+
+for (const selector of [
+  "[data-testid='target']",
+  '[data-testid="TARGET" i]',
+  '[data-testid="tar\\67 et"]',
+  ' [data-testid="target"] '
+]) {
+  test(() => {
+    const root = document.createElement("div");
+    root.innerHTML = '<span data-testid="target"></span>';
+    const child = root.firstChild;
+    const result = root.querySelectorAll(selector);
+    assert_array_equals([...result], [child]);
+    child.removeAttribute("data-testid");
+    assert_equals(root.querySelectorAll(selector).length, 0);
+    assert_array_equals([...result], [child]);
+  }, `Repeated ${selector} queries handle attribute changes`);
+}
+
+for (const length of [230, 300]) {
+  test(() => {
+    const root = document.createElement("div");
+    const child = root.appendChild(document.createElement("span"));
+    const value = "x".repeat(length);
+    const selector = `[data-testid="${value}"]`;
+    assert_equals(root.querySelectorAll(selector).length, 0);
+    child.setAttribute("data-testid", value);
+    assert_array_equals([...root.querySelectorAll(selector)], [child]);
+    child.remove();
+    assert_equals(root.querySelectorAll(selector).length, 0);
+  }, `Attribute equality queries with ${length}-character values handle mutations`);
+}
+
+test(() => {
+  const parent = document.createElement("div");
+  parent.innerHTML = '<div><span data-testid="target"></span></div>';
+  const root = parent.firstChild;
+  const selector = '[data-state="on"] [data-testid]';
+  parent.setAttribute("data-state", "on");
+  assert_array_equals([...root.querySelectorAll(selector)], [root.firstChild]);
+  parent.removeAttribute("data-state");
+  assert_equals(root.querySelectorAll(selector).length, 0);
+}, "Repeated descendant queries observe changes to attributes outside the query root");


### PR DESCRIPTION
Cache matched elements for repeated `querySelectorAll()` calls with simple attribute selectors, such as `[data-testid]` and `[data-testid="target"]`. This avoids rescanning the subtree between repeated Testing Library lookups.

Reuse the existing query-cache invalidation for tree changes, attribute changes, and document adoption, while returning a fresh static NodeList on every call. Limit the cache to 16 selectors of at most 256 characters per root. Other selectors keep using the normal query path.

Testing Library `getByTestId()` benchmarks, with a mutation before each batch of lookups for different IDs. Both builds include our other pending PRs; this measures adding the cache to that build, not against main alone. Times are µs, median of three runs' mean times; lower is better.

| Rows | Lookups per mutation | Without cache | With cache | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 20 | 1 | 14.29 | 14.40 | 0.99× |
| 20 | 5 | 66.79 | 46.40 | 1.44× |
| 20 | 20 | 261.01 | 162.67 | 1.60× |
| 250 | 1 | 156.75 | 156.89 | 1.00× |
| 250 | 5 | 756.23 | 524.51 | 1.44× |
| 250 | 20 | 2997.37 | 1933.22 | 1.55× |

There is still a miss cost: a separate controlled benchmark with one raw query pair after each mutation went from 288.48 to 298.50 µs, about 3.5% slower. One run of the broader mutation benchmark also had latency spikes, so tail latency needs more investigation.

