### PR TITLE
Guard background parsing and normalize whitespace handling

### DIFF
--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -103,6 +103,7 @@ class CSSStyleDeclarationImpl {
     this.#values.clear();
     this._priorities.clear();
     this.#updating = true;
+    text = cssValues.preprocessValue(text);
     const valueObj = csstree.parse(text, { context: "declarationList", parseValue: false });
     if (valueObj?.children) {
       const properties = new Map();
@@ -299,7 +300,7 @@ class CSSStyleDeclarationImpl {
         "NoModificationAllowedError"
       ]);
     }
-    value = value.trim();
+    value = cssValues.preprocessValue(value).trim();
     if (value === "") {
       if (Object.hasOwn(propertyDescriptors, property)) {
         // TODO: Refactor handlers to not require `.call()`.

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -331,17 +331,76 @@ function parsePropertyValue(prop, val, opt = {}) {
   return parsedValue;
 }
 
-function normalizeValue(val) {
-  const ast = parseValue(val);
-  return generateCSSFromAST(ast);
-}
-
 function parseValue(val) {
   return cssTree.parse(val, { context: "value" });
 }
 
 function generateCSSFromAST(ast) {
   return cssTree.generate(ast).replace(/\)(?!\)|\s|,)/g, ") ").replace(/,(?!\s)/g, ", ").trim();
+}
+
+function prepareShorthandValue(val) {
+  if (!val.includes("(") && !val.includes(")")) {
+    return val;
+  }
+  let inString = false;
+  let stringChar = "";
+  let inUrl = false;
+  let value = "";
+  for (let i = 0; i < val.length; i++) {
+    const char = val[i];
+    if (inString) {
+      value += char;
+      if (char === "\\") {
+        value += val[i + 1] || "";
+        i++;
+      } else if (char === stringChar) {
+        inString = false;
+      }
+    } else if (inUrl) {
+      value += char;
+      if (char === "\\") {
+        value += val[i + 1] || "";
+        i++;
+      } else if (char === '"' || char === "'") {
+        inString = true;
+        stringChar = char;
+      } else if (char === ")") {
+        inUrl = false;
+        const nextChar = val[i + 1];
+        if (nextChar && nextChar !== ")" && nextChar !== " " && nextChar !== ",") {
+          value += " ";
+        }
+      }
+    } else if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      value += char;
+    } else if (char === "u" || char === "U") {
+      if (val.slice(i, i + 4).toLowerCase() === "url(") {
+        inUrl = true;
+        value += val.slice(i, i + 4);
+        i += 3;
+      } else {
+        value += char;
+      }
+    } else if (char === ")") {
+      value += char;
+      const nextChar = val[i + 1];
+      if (nextChar && nextChar !== ")" && nextChar !== " " && nextChar !== ",") {
+        value += " ";
+      }
+    } else if (char === ",") {
+      value += char;
+      const nextChar = val[i + 1];
+      if (nextChar && nextChar !== " ") {
+        value += " ";
+      }
+    } else {
+      value += char;
+    }
+  }
+  return value.trim();
 }
 
 /**
@@ -858,8 +917,8 @@ exports.hasCalcFunc = hasCalcFunc;
 exports.hasVarFunc = hasVarFunc;
 exports.isGlobalKeyword = isGlobalKeyword;
 exports.isValidPropertyValue = isValidPropertyValue;
-exports.normalizeValue = normalizeValue;
 exports.parsePropertyValue = parsePropertyValue;
+exports.prepareShorthandValue = prepareShorthandValue;
 exports.resolveBorderShorthandValue = resolveBorderShorthandValue;
 exports.resolveCalc = resolveCalc;
 exports.resolveColor = resolveColor;

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -337,16 +337,7 @@ function normalizeValue(val) {
 }
 
 function parseValue(val) {
-  const cacheKey = `parseValue_${val}`;
-  const cachedValue = lruCache.get(cacheKey);
-  if (cachedValue !== undefined) {
-    return cachedValue;
-  }
-  const ast = cssTree.parse(val, {
-    context: "value"
-  });
-  lruCache.set(cacheKey, ast);
-  return ast;
+  return cssTree.parse(val, { context: "value" });
 }
 
 function generateCSSFromAST(ast) {

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -106,9 +106,7 @@ function isValidPropertyValue(prop, val) {
   }
   let result;
   try {
-    const ast = cssTree.parse(val, {
-      context: "value"
-    });
+    const ast = parseValue(val);
     result = matchPropertyAST(prop, ast) && !mathFunctionHasDisallowedPercentage(prop, ast);
   } catch {
     result = false;
@@ -137,7 +135,7 @@ function resolveCalc(val, opt = { format: "specifiedValue" }) {
   if (typeof cachedValue === "string") {
     return cachedValue;
   }
-  const ast = cssTree.parse(val, { context: "value" });
+  const ast = parseValue(val);
   if (!ast?.children) {
     return undefined;
   }
@@ -247,9 +245,7 @@ function parsePropertyValue(prop, val, opt = {}) {
     ];
   } else {
     try {
-      const ast = cssTree.parse(val, {
-        context: "value"
-      });
+      const ast = parseValue(val);
       if (!matchPropertyAST(prop, ast) || mathFunctionHasDisallowedPercentage(prop, ast)) {
         parsedValue = false;
       } else {
@@ -333,6 +329,19 @@ function parsePropertyValue(prop, val, opt = {}) {
     return undefined;
   }
   return parsedValue;
+}
+
+function parseValue(val) {
+  const cacheKey = `parseValue_${val}`;
+  const cachedValue = lruCache.get(cacheKey);
+  if (cachedValue !== undefined) {
+    return cachedValue;
+  }
+  const ast = cssTree.parse(val, {
+    context: "value"
+  });
+  lruCache.set(cacheKey, ast);
+  return ast;
 }
 
 function generateCSSFromAST(ast) {

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -331,6 +331,11 @@ function parsePropertyValue(prop, val, opt = {}) {
   return parsedValue;
 }
 
+function normalizeValue(val) {
+  const ast = parseValue(val);
+  return generateCSSFromAST(ast);
+}
+
 function parseValue(val) {
   const cacheKey = `parseValue_${val}`;
   const cachedValue = lruCache.get(cacheKey);
@@ -862,6 +867,7 @@ exports.hasCalcFunc = hasCalcFunc;
 exports.hasVarFunc = hasVarFunc;
 exports.isGlobalKeyword = isGlobalKeyword;
 exports.isValidPropertyValue = isValidPropertyValue;
+exports.normalizeValue = normalizeValue;
 exports.parsePropertyValue = parsePropertyValue;
 exports.resolveBorderShorthandValue = resolveBorderShorthandValue;
 exports.resolveCalc = resolveCalc;

--- a/lib/jsdom/living/css/helpers/css-values.js
+++ b/lib/jsdom/living/css/helpers/css-values.js
@@ -403,6 +403,11 @@ function prepareShorthandValue(val) {
   return value.trim();
 }
 
+// https://drafts.csswg.org/css-syntax-3/#input-preprocessing
+function preprocessValue(val) {
+  return String(val).replace(/\f|\r\n?/g, "\n").replace(/[\0\uD800-\uDFFF]|\\$/g, "\uFFFD");
+}
+
 /**
  * Parses a numeric value (number, dimension, percentage).
  * Helper function for serializeNumber, serializeLength, etc.
@@ -919,6 +924,7 @@ exports.isGlobalKeyword = isGlobalKeyword;
 exports.isValidPropertyValue = isValidPropertyValue;
 exports.parsePropertyValue = parsePropertyValue;
 exports.prepareShorthandValue = prepareShorthandValue;
+exports.preprocessValue = preprocessValue;
 exports.resolveBorderShorthandValue = resolveBorderShorthandValue;
 exports.resolveCalc = resolveCalc;
 exports.resolveColor = resolveColor;

--- a/lib/jsdom/living/css/helpers/shorthand-properties.js
+++ b/lib/jsdom/living/css/helpers/shorthand-properties.js
@@ -1300,6 +1300,9 @@ function processBorderProperties(borders) {
       }
       if (property === border.property) {
         const lineItems = border.parse(value);
+        if (!lineItems) {
+          return "";
+        }
         for (const [key, initialValue] of border.initialValues) {
           if (!Object.hasOwn(lineItems, key)) {
             lineItems[key] = initialValue;

--- a/lib/jsdom/living/css/helpers/shorthand-properties.js
+++ b/lib/jsdom/living/css/helpers/shorthand-properties.js
@@ -222,6 +222,9 @@ function replaceBackgroundShorthand(property, properties) {
   });
   const { value: shorthandValue } = properties.get(background.property);
   const bgValues = background.parse(shorthandValue);
+  if (!Array.isArray(bgValues)) {
+    return "";
+  }
   const bgLength = bgValues.length;
   if (property === backgroundColor.property) {
     bgValues[bgLength - 1][property] = values[0];

--- a/lib/jsdom/living/css/helpers/shorthand-properties.js
+++ b/lib/jsdom/living/css/helpers/shorthand-properties.js
@@ -1301,7 +1301,7 @@ function processBorderProperties(borders) {
       if (property === border.property) {
         const lineItems = border.parse(value);
         if (!lineItems) {
-          return "";
+          return new Map();
         }
         for (const [key, initialValue] of border.initialValues) {
           if (!Object.hasOwn(lineItems, key)) {

--- a/lib/jsdom/living/css/properties/background.js
+++ b/lib/jsdom/living/css/properties/background.js
@@ -280,9 +280,11 @@ function parse(v) {
   } else if (parsers.hasCalcFunc(v)) {
     v = parsers.resolveCalc(v);
   }
-  if (/\)(?!\)|\s|,)/.test(v)) {
-    v = parsers.normalizeValue(v);
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
   }
+  v = prepared;
   if (!parsers.isValidPropertyValue(property, v)) {
     return undefined;
   }

--- a/lib/jsdom/living/css/properties/background.js
+++ b/lib/jsdom/living/css/properties/background.js
@@ -280,12 +280,12 @@ function parse(v) {
   } else if (parsers.hasCalcFunc(v)) {
     v = parsers.resolveCalc(v);
   }
+  if (/\)(?!\)|\s|,)/.test(v)) {
+    v = parsers.normalizeValue(v);
+  }
   if (!parsers.isValidPropertyValue(property, v)) {
     return undefined;
   }
-  // Normalize whitespace after function closing parentheses ')'.
-  // Other boundaries like ',' and '/' are explicitly handled as delimiters.
-  v = v.replace(/\)(?!\)|\s|,)/g, ") ");
   const values = parsers.splitValue(v, {
     delimiter: ","
   });

--- a/lib/jsdom/living/css/properties/background.js
+++ b/lib/jsdom/living/css/properties/background.js
@@ -284,11 +284,10 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  if (!parsers.isValidPropertyValue(property, v)) {
+  if (!parsers.isValidPropertyValue(property, prepared)) {
     return undefined;
   }
-  const values = parsers.splitValue(v, {
+  const values = parsers.splitValue(prepared, {
     delimiter: ","
   });
   const bgValues = [];

--- a/lib/jsdom/living/css/properties/background.js
+++ b/lib/jsdom/living/css/properties/background.js
@@ -283,6 +283,9 @@ function parse(v) {
   if (!parsers.isValidPropertyValue(property, v)) {
     return undefined;
   }
+  // Normalize whitespace after function closing parentheses ')'.
+  // Other boundaries like ',' and '/' are explicitly handled as delimiters.
+  v = v.replace(/\)(?!\)|\s|,)/g, ") ");
   const values = parsers.splitValue(v, {
     delimiter: ","
   });

--- a/lib/jsdom/living/css/properties/border.js
+++ b/lib/jsdom/living/css/properties/border.js
@@ -70,8 +70,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.splitValue(v);
+  const values = parsers.splitValue(prepared);
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val);

--- a/lib/jsdom/living/css/properties/border.js
+++ b/lib/jsdom/living/css/properties/border.js
@@ -66,6 +66,9 @@ function parse(v) {
   if (v === "" || parsers.hasVarFunc(v)) {
     return v;
   }
+  if (/\)(?!\)|\s|,)/.test(v)) {
+    v = parsers.normalizeValue(v);
+  }
   const values = parsers.splitValue(v);
   const parsedValues = new Map();
   for (const val of values) {

--- a/lib/jsdom/living/css/properties/border.js
+++ b/lib/jsdom/living/css/properties/border.js
@@ -66,9 +66,11 @@ function parse(v) {
   if (v === "" || parsers.hasVarFunc(v)) {
     return v;
   }
-  if (/\)(?!\)|\s|,)/.test(v)) {
-    v = parsers.normalizeValue(v);
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
   }
+  v = prepared;
   const values = parsers.splitValue(v);
   const parsedValues = new Map();
   for (const val of values) {

--- a/lib/jsdom/living/css/properties/borderBottom.js
+++ b/lib/jsdom/living/css/properties/borderBottom.js
@@ -61,8 +61,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.splitValue(v);
+  const values = parsers.splitValue(prepared);
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val);

--- a/lib/jsdom/living/css/properties/borderBottom.js
+++ b/lib/jsdom/living/css/properties/borderBottom.js
@@ -57,6 +57,11 @@ function parse(v) {
   if (v === "") {
     return v;
   }
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
+  }
+  v = prepared;
   const values = parsers.splitValue(v);
   const parsedValues = new Map();
   for (const val of values) {

--- a/lib/jsdom/living/css/properties/borderColor.js
+++ b/lib/jsdom/living/css/properties/borderColor.js
@@ -51,8 +51,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.parsePropertyValue(property, v);
+  const values = parsers.parsePropertyValue(property, prepared);
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {
     if (values.length > 4) {

--- a/lib/jsdom/living/css/properties/borderColor.js
+++ b/lib/jsdom/living/css/properties/borderColor.js
@@ -47,6 +47,11 @@ function parse(v) {
   if (v === "") {
     return v;
   }
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
+  }
+  v = prepared;
   const values = parsers.parsePropertyValue(property, v);
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/lib/jsdom/living/css/properties/borderLeft.js
+++ b/lib/jsdom/living/css/properties/borderLeft.js
@@ -61,8 +61,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.splitValue(v);
+  const values = parsers.splitValue(prepared);
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val);

--- a/lib/jsdom/living/css/properties/borderLeft.js
+++ b/lib/jsdom/living/css/properties/borderLeft.js
@@ -57,6 +57,11 @@ function parse(v) {
   if (v === "") {
     return v;
   }
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
+  }
+  v = prepared;
   const values = parsers.splitValue(v);
   const parsedValues = new Map();
   for (const val of values) {

--- a/lib/jsdom/living/css/properties/borderRight.js
+++ b/lib/jsdom/living/css/properties/borderRight.js
@@ -61,8 +61,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.splitValue(v);
+  const values = parsers.splitValue(prepared);
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val);

--- a/lib/jsdom/living/css/properties/borderRight.js
+++ b/lib/jsdom/living/css/properties/borderRight.js
@@ -57,6 +57,11 @@ function parse(v) {
   if (v === "") {
     return v;
   }
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
+  }
+  v = prepared;
   const values = parsers.splitValue(v);
   const parsedValues = new Map();
   for (const val of values) {

--- a/lib/jsdom/living/css/properties/borderStyle.js
+++ b/lib/jsdom/living/css/properties/borderStyle.js
@@ -51,8 +51,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.parsePropertyValue(property, v);
+  const values = parsers.parsePropertyValue(property, prepared);
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {
     if (values.length > 4) {

--- a/lib/jsdom/living/css/properties/borderStyle.js
+++ b/lib/jsdom/living/css/properties/borderStyle.js
@@ -47,6 +47,11 @@ function parse(v) {
   if (v === "") {
     return v;
   }
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
+  }
+  v = prepared;
   const values = parsers.parsePropertyValue(property, v);
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/lib/jsdom/living/css/properties/borderTop.js
+++ b/lib/jsdom/living/css/properties/borderTop.js
@@ -61,8 +61,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.splitValue(v);
+  const values = parsers.splitValue(prepared);
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val);

--- a/lib/jsdom/living/css/properties/borderTop.js
+++ b/lib/jsdom/living/css/properties/borderTop.js
@@ -57,6 +57,11 @@ function parse(v) {
   if (v === "") {
     return v;
   }
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
+  }
+  v = prepared;
   const values = parsers.splitValue(v);
   const parsedValues = new Map();
   for (const val of values) {

--- a/lib/jsdom/living/css/properties/borderWidth.js
+++ b/lib/jsdom/living/css/properties/borderWidth.js
@@ -51,8 +51,7 @@ function parse(v) {
   if (!prepared) {
     return undefined;
   }
-  v = prepared;
-  const values = parsers.parsePropertyValue(property, v);
+  const values = parsers.parsePropertyValue(property, prepared);
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {
     if (values.length > 4) {

--- a/lib/jsdom/living/css/properties/borderWidth.js
+++ b/lib/jsdom/living/css/properties/borderWidth.js
@@ -47,6 +47,11 @@ function parse(v) {
   if (v === "") {
     return v;
   }
+  const prepared = parsers.prepareShorthandValue(v);
+  if (!prepared) {
+    return undefined;
+  }
+  v = prepared;
   const values = parsers.parsePropertyValue(property, v);
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,6 +1,5 @@
 css/css-backgrounds/background-no-whitespace.html:
   "A background shorthand with no space with invalid url() and no-repeat": [fail, Need to fix background shorthand]
-css/css-borders/border-no-whitespace.html: [fail, Need to fix border shorthand]
 css/css-borders/border-radius-shorthand.html:
   "longhand from shorthand": [fail, border-radius and its longhands are not implemented]
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,5 +1,6 @@
 css/css-backgrounds/background-no-whitespace.html:
-  "A background shorthand with no space with invalid url() and no-repeat": [fail, Need to fix background shorthand]
+  "A background shorthand with escaped quotes in url()": [fail, Need to fix background shorthand]
+  "A background shorthand with HTML entities in url() and no-repeat": [fail, Need to fix background shorthand]
 css/css-borders/border-radius-shorthand.html:
   "longhand from shorthand": [fail, border-radius and its longhands are not implemented]
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,7 +1,6 @@
 css/css-backgrounds/background-no-whitespace.html:
-  "A background shorthand with escaped quotes in url()": [fail, Need to fix background shorthand]
-  "A background shorthand with HTML entities in url() and no-repeat": [fail, Need to fix background shorthand]
-css/css-borders/border-radius-shorthand.html:
+  "A trailing escape in a truncated inline style is replaced at EOF": [fail, Need to fix surrogate code points in input]
+css/css-backgrounds/border-radius-shorthand.html:
   "longhand from shorthand": [fail, border-radius and its longhands are not implemented]
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]
 css/css-conditional/container-queries-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3597]

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,5 +1,3 @@
-css/css-backgrounds/background-no-whitespace.html:
-  "A trailing escape in a truncated inline style is replaced at EOF": [fail, Need to fix surrogate code points in input]
 css/css-backgrounds/border-radius-shorthand.html:
   "longhand from shorthand": [fail, border-radius and its longhands are not implemented]
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]

--- a/test/web-platform-tests/to-upstream-expectations.yaml
+++ b/test/web-platform-tests/to-upstream-expectations.yaml
@@ -1,4 +1,7 @@
-css/css-backgrounds/border-radius-shorthand.html:
+css/css-backgrounds/background-no-whitespace.html:
+  "A background shorthand with no space with invalid url() and no-repeat": [fail, Need to fix background shorthand]
+css/css-borders/border-no-whitespace.html: [fail, Need to fix border shorthand]
+css/css-borders/border-radius-shorthand.html:
   "longhand from shorthand": [fail, border-radius and its longhands are not implemented]
 css/css-cascade/layers-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3785]
 css/css-conditional/container-queries-basic.html: [fail, https://github.com/jsdom/jsdom/issues/3597]

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
@@ -28,7 +28,8 @@ test(() => {
   );
 
   assert_equals(
-    div.style.backgroundImage, 'url("a.png")',
+    div.style.backgroundImage,
+    'url("a.png")',
     "The background-image should be correctly parsed."
   );
 
@@ -55,7 +56,8 @@ test(() => {
   );
 
   assert_equals(
-    div.style.backgroundImage, 'url("\ufffd")',
+    div.style.backgroundImage,
+    'url("\ufffd")',
     "The background-image should return url() with replacement character."
   );
 

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
@@ -8,6 +8,8 @@
 
 <div id="div" style="background:url(a.png)no-repeat;color:red"></div>
 <div id="div2" style="background:url(\"a)b.png\")no-repeat;color:red"></div>
+<div id="div3"></div>
+<div id="div4" style="background:url(&quot;a)b.png&quot;)no-repeat;color:red"></div>
 
 <script>
 "use strict";
@@ -24,7 +26,7 @@ test(() => {
   assert_equals(
     div.style.color,
     "red",
-    "The color property should be parsed and set despite the missing space in background."
+    "The color property should be correctly parsed."
   );
 
   assert_equals(
@@ -67,5 +69,62 @@ test(() => {
     "repeat",
     "The background-repeat should return the initial value."
   );
-}, "A background shorthand with no space with invalid url() and no-repeat");
+}, "A background shorthand with escaped quotes in url()");
+
+test(() => {
+  const div = document.getElementById("div3");
+  div.style.cssText = 'url("a)b.png")no-repeat';
+
+  assert_equals(
+    div.style.background,
+    "",
+    "The background shorthand should be an empty string."
+  );
+
+  assert_equals(
+    div.style.color,
+    "",
+    "The color property should not be parsed and returns empty string."
+  );
+
+  assert_equals(
+    div.style.backgroundImage,
+    "",
+    "The background-image should return an empty string."
+  );
+
+  assert_equals(
+    div.style.backgroundRepeat,
+    "",
+    "The background-repeat should return empty string."
+  );
+}, "Dynamically add a background shorthand with url() and no-repeat");
+
+test(() => {
+  const div = document.getElementById("div4");
+
+  assert_equals(
+    div.style.background,
+    'url("a)b.png") no-repeat',
+    "The background shorthand should be correctly parsed."
+  );
+
+  assert_equals(
+    div.style.color,
+    "red",
+    "The color property should be correctly parsed."
+  );
+
+  assert_equals(
+    div.style.backgroundImage,
+    'url("a)b.png")',
+    "The background-image should be be correctly parsed."
+  );
+
+  assert_equals(
+    div.style.backgroundRepeat,
+    "no-repeat",
+    "The background-repeat should be correctly parsed."
+  );
+}, "A background shorthand with HTML entities in url() and no-repeat");
 </script>

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Background shorthand without whitespace</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- regression test for https://github.com/jsdom/jsdom/issues/4285 -->
+
+<div id="div" style="background:url(a.png)no-repeat;color:red"></div>
+
+<script>
+test(() => {
+  const div = document.getElementById("div");
+
+  assert_equals(div.style.background, "url(\"a.png\") no-repeat", "The background shorthand should be correctly parsed.");
+
+  assert_equals(div.style.color, "red", "The color property should be parsed and set despite the missing space in background.");
+
+  assert_true(div.style.backgroundImage.includes("a.png"), "The background-image should be correctly parsed.");
+
+  assert_equals(div.style.backgroundRepeat, "no-repeat", "The background-repeat should be correctly parsed.");
+
+}, "A background shorthand with no space between url() and no-repeat should not break CSS parsing");
+</script>

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
@@ -9,16 +9,32 @@
 <div id="div" style="background:url(a.png)no-repeat;color:red"></div>
 
 <script>
+"use strict";
+
 test(() => {
   const div = document.getElementById("div");
 
-  assert_equals(div.style.background, "url(\"a.png\") no-repeat", "The background shorthand should be correctly parsed.");
+  assert_equals(
+    div.style.background,
+    "url(\"a.png\") no-repeat",
+    "The background shorthand should be correctly parsed."
+  );
 
-  assert_equals(div.style.color, "red", "The color property should be parsed and set despite the missing space in background.");
+  assert_equals(
+    div.style.color,
+    "red",
+    "The color property should be parsed and set despite the missing space in background."
+  );
 
-  assert_true(div.style.backgroundImage.includes("a.png"), "The background-image should be correctly parsed.");
+  assert_true(
+    div.style.backgroundImage.includes("a.png"),
+    "The background-image should be correctly parsed."
+  );
 
-  assert_equals(div.style.backgroundRepeat, "no-repeat", "The background-repeat should be correctly parsed.");
-
-}, "A background shorthand with no space between url() and no-repeat should not break CSS parsing");
+  assert_equals(
+    div.style.backgroundRepeat,
+    "no-repeat",
+    "The background-repeat should be correctly parsed."
+  );
+}, "A background shorthand with no space between url() and no-repeat");
 </script>

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
@@ -7,6 +7,7 @@
 <!-- regression test for https://github.com/jsdom/jsdom/issues/4285 -->
 
 <div id="div" style="background:url(a.png)no-repeat;color:red"></div>
+<div id="div2" style="background:url(\"a)b.png\")no-repeat;color:red"></div>
 
 <script>
 "use strict";
@@ -26,8 +27,8 @@ test(() => {
     "The color property should be parsed and set despite the missing space in background."
   );
 
-  assert_true(
-    div.style.backgroundImage.includes("a.png"),
+  assert_equals(
+    div.style.backgroundImage, 'url("a.png")',
     "The background-image should be correctly parsed."
   );
 
@@ -37,4 +38,32 @@ test(() => {
     "The background-repeat should be correctly parsed."
   );
 }, "A background shorthand with no space between url() and no-repeat");
+
+test(() => {
+  const div = document.getElementById("div2");
+
+  assert_equals(
+    div.style.background,
+    'url("\ufffd")',
+    "The background shorthand should be parsed as a url() with replacement character."
+  );
+
+  assert_equals(
+    div.style.color,
+    "",
+    "The color property should not be parsed and returns empty string."
+  );
+
+  assert_equals(
+    div.style.backgroundImage, 'url("\ufffd")',
+    "The background-image should return url() with replacement character."
+  );
+
+  // Chrome returns `initial`.
+  assert_equals(
+    div.style.backgroundRepeat,
+    "repeat",
+    "The background-repeat should return the initial value."
+  );
+}, "A background shorthand with no space with invalid url() and no-repeat");
 </script>

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/background-no-whitespace.html
@@ -1,130 +1,236 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Background shorthand without whitespace</title>
+<title>Background shorthand component boundaries without whitespace</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background">
+<link rel="help" href="https://drafts.csswg.org/css-syntax/#tokenization">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<!-- regression test for https://github.com/jsdom/jsdom/issues/4285 -->
-
-<div id="div" style="background:url(a.png)no-repeat;color:red"></div>
-<div id="div2" style="background:url(\"a)b.png\")no-repeat;color:red"></div>
-<div id="div3"></div>
-<div id="div4" style="background:url(&quot;a)b.png&quot;)no-repeat;color:red"></div>
+<!-- Regression test for https://github.com/jsdom/jsdom/issues/4285 -->
 
 <script>
 "use strict";
 
+function assertBackground(style, expected) {
+  assert_equals(style.background, expected.serialized, "background");
+  for (const [property, value] of Object.entries(expected.longhands ?? {})) {
+    assert_equals(style[property], value, property);
+  }
+}
+
+function testBackgroundValue(input, expected, description) {
+  test(() => {
+    const div = document.createElement("div");
+    div.style.background = input;
+    assertBackground(div.style, expected);
+  }, `${description} via the background setter`);
+
+  test(() => {
+    const div = document.createElement("div");
+    div.style.cssText = `background:${input};color:red`;
+    assertBackground(div.style, expected);
+    assert_equals(div.style.color, "red", "following declaration");
+  }, `${description} via cssText before another declaration`);
+}
+
+const backgroundCases = [
+  {
+    input: "url(a.png)no-repeat",
+    serialized: 'url("a.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundRepeat: "no-repeat"
+    },
+    description: "An unquoted url() followed by an identifier"
+  },
+  {
+    input: 'url("a.png")no-repeat',
+    serialized: 'url("a.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundRepeat: "no-repeat"
+    },
+    description: "A quoted url() followed by an identifier"
+  },
+  {
+    input: 'url("a)b.png")no-repeat',
+    serialized: 'url("a)b.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a)b.png")',
+      backgroundRepeat: "no-repeat"
+    },
+    description: "A quoted url() containing a right parenthesis followed by an identifier"
+  },
+  {
+    input: 'url("a)b.png") no-repeat',
+    serialized: 'url("a)b.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a)b.png")',
+      backgroundRepeat: "no-repeat"
+    },
+    description: "A quoted url() containing a right parenthesis with ordinary whitespace"
+  },
+  {
+    input: "url(a\\)b.png)no-repeat",
+    serialized: 'url("a)b.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a)b.png")',
+      backgroundRepeat: "no-repeat"
+    },
+    description: "An unquoted url() containing an escaped right parenthesis followed by an identifier"
+  },
+  {
+    input: "linear-gradient(red,blue)no-repeat",
+    serialized: "linear-gradient(red, blue) no-repeat",
+    longhands: {
+      backgroundImage: "linear-gradient(red, blue)",
+      backgroundRepeat: "no-repeat"
+    },
+    description: "A function followed by an identifier"
+  },
+  {
+    input: "linear-gradient(rgb(1 2 3),rgb(4 5 6))no-repeat",
+    serialized: "linear-gradient(rgb(1, 2, 3), rgb(4, 5, 6)) no-repeat",
+    longhands: {
+      backgroundImage: "linear-gradient(rgb(1, 2, 3), rgb(4, 5, 6))",
+      backgroundRepeat: "no-repeat"
+    },
+    description: "A function containing nested functions followed by an identifier"
+  },
+  {
+    input: "url(a.png)fixed",
+    serialized: 'url("a.png") fixed',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundAttachment: "fixed"
+    },
+    description: "A url() followed by an attachment keyword"
+  },
+  {
+    input: "url(a.png)10px",
+    serialized: 'url("a.png") 10px center',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundPosition: "10px center"
+    },
+    description: "A url() followed by a dimension"
+  },
+  {
+    input: "url(a.png)50%",
+    serialized: 'url("a.png") 50% center',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundPosition: "50% center"
+    },
+    description: "A url() followed by a percentage"
+  },
+  {
+    input: "url(a.png)center/cover",
+    serialized: 'url("a.png") center center / cover',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundPosition: "center center",
+      backgroundSize: "cover"
+    },
+    description: "A url() followed by a position and size"
+  },
+  {
+    input: "url(a.png)rgb(0 0 0)",
+    serialized: 'url("a.png") rgb(0, 0, 0)',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundColor: "rgb(0, 0, 0)"
+    },
+    description: "A url() followed by a color function"
+  },
+  {
+    input: "url(a.png)#fff",
+    serialized: 'url("a.png") rgb(255, 255, 255)',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundColor: "rgb(255, 255, 255)"
+    },
+    description: "A url() followed by a hash color"
+  },
+  {
+    input: "url(a.png)/**/no-repeat",
+    serialized: 'url("a.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundRepeat: "no-repeat"
+    },
+    description: "A url() followed by a comment and an identifier"
+  },
+  {
+    input: "url(a.png)no-repeat,url(b.png)fixed",
+    serialized: 'url("a.png") no-repeat, url("b.png") fixed',
+    description: "Multiple comma-separated layers containing adjacent components"
+  }
+];
+
+for (const { input, description, ...expected } of backgroundCases) {
+  testBackgroundValue(input, expected, description);
+}
+
 test(() => {
-  const div = document.getElementById("div");
-
-  assert_equals(
-    div.style.background,
-    "url(\"a.png\") no-repeat",
-    "The background shorthand should be correctly parsed."
-  );
-
-  assert_equals(
-    div.style.color,
-    "red",
-    "The color property should be correctly parsed."
-  );
-
-  assert_equals(
-    div.style.backgroundImage,
-    'url("a.png")',
-    "The background-image should be correctly parsed."
-  );
-
-  assert_equals(
-    div.style.backgroundRepeat,
-    "no-repeat",
-    "The background-repeat should be correctly parsed."
-  );
-}, "A background shorthand with no space between url() and no-repeat");
+  const container = document.createElement("div");
+  container.innerHTML = '<div style="background:url(a.png)no-repeat;color:red"></div>';
+  const div = container.firstElementChild;
+  assertBackground(div.style, {
+    serialized: 'url("a.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a.png")',
+      backgroundRepeat: "no-repeat"
+    }
+  });
+  assert_equals(div.style.color, "red", "following declaration");
+}, "An inline background declaration containing adjacent components");
 
 test(() => {
-  const div = document.getElementById("div2");
-
+  const container = document.createElement("div");
+  container.innerHTML =
+    '<div style="background:url(&quot;a)b.png&quot;)no-repeat;color:red"></div>';
+  const div = container.firstElementChild;
   assert_equals(
-    div.style.background,
-    'url("\ufffd")',
-    "The background shorthand should be parsed as a url() with replacement character."
+    div.getAttribute("style"),
+    'background:url("a)b.png")no-repeat;color:red',
+    "decoded style attribute"
   );
-
-  assert_equals(
-    div.style.color,
-    "",
-    "The color property should not be parsed and returns empty string."
-  );
-
-  assert_equals(
-    div.style.backgroundImage,
-    'url("\ufffd")',
-    "The background-image should return url() with replacement character."
-  );
-
-  // Chrome returns `initial`.
-  assert_equals(
-    div.style.backgroundRepeat,
-    "repeat",
-    "The background-repeat should return the initial value."
-  );
-}, "A background shorthand with escaped quotes in url()");
+  assertBackground(div.style, {
+    serialized: 'url("a)b.png") no-repeat',
+    longhands: {
+      backgroundImage: 'url("a)b.png")',
+      backgroundRepeat: "no-repeat"
+    }
+  });
+  assert_equals(div.style.color, "red", "following declaration");
+}, "Character references in an inline style are decoded before CSS parsing");
 
 test(() => {
-  const div = document.getElementById("div3");
+  const container = document.createElement("div");
+  container.innerHTML = String.raw`<div style="background:url(\"a)b.png\")no-repeat;color:red"></div>`;
+  const div = container.firstElementChild;
+
+  // A backslash does not escape an HTML attribute delimiter, so the CSS value ends with the backslash.
+  assert_equals(div.getAttribute("style"), "background:url(\\", "truncated style attribute");
+  assert_equals(div.style.background, 'url("\uFFFD")', "background");
+  assert_equals(div.style.backgroundImage, 'url("\uFFFD")', "backgroundImage");
+  // Chrome returns "initial".
+  assert_equals(div.style.backgroundRepeat, "repeat", "backgroundRepeat");
+  assert_equals(div.style.color, "", "color");
+}, "A trailing escape in a truncated inline style is replaced at EOF");
+
+test(() => {
+  const div = document.createElement("div");
   div.style.cssText = 'url("a)b.png")no-repeat';
+  assert_equals(div.style.cssText, "");
+}, "A declaration value without a property name is ignored by cssText");
 
-  assert_equals(
-    div.style.background,
-    "",
-    "The background shorthand should be an empty string."
-  );
-
-  assert_equals(
-    div.style.color,
-    "",
-    "The color property should not be parsed and returns empty string."
-  );
-
-  assert_equals(
-    div.style.backgroundImage,
-    "",
-    "The background-image should return an empty string."
-  );
-
-  assert_equals(
-    div.style.backgroundRepeat,
-    "",
-    "The background-repeat should return empty string."
-  );
-}, "Dynamically add a background shorthand with url() and no-repeat");
-
-test(() => {
-  const div = document.getElementById("div4");
-
-  assert_equals(
-    div.style.background,
-    'url("a)b.png") no-repeat',
-    "The background shorthand should be correctly parsed."
-  );
-
-  assert_equals(
-    div.style.color,
-    "red",
-    "The color property should be correctly parsed."
-  );
-
-  assert_equals(
-    div.style.backgroundImage,
-    'url("a)b.png")',
-    "The background-image should be be correctly parsed."
-  );
-
-  assert_equals(
-    div.style.backgroundRepeat,
-    "no-repeat",
-    "The background-repeat should be correctly parsed."
-  );
-}, "A background shorthand with HTML entities in url() and no-repeat");
+for (const invalidValue of [")x", "url(x))x", "rgb())x", "foo(])x"]) {
+  test(() => {
+    const div = document.createElement("div");
+    div.style.background = "red";
+    div.style.background = invalidValue;
+    assert_equals(div.style.background, "red", "previous value");
+  }, `An invalid background value is ignored without throwing: ${invalidValue}`);
+}
 </script>

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/border-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/border-no-whitespace.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Border shorthand without whitespace</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#the-border-shorthands">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="div" style="border:rgb(0 0 0)solid 1px;color:red"></div>
+
+<script>
+"use strict";
+
+test(() => {
+  const div = document.getElementById("div");
+
+  assert_equals(
+    div.style.color,
+    "red",
+    "The color property should be parsed and set despite the missing space in border."
+  );
+
+  assert_equals(
+    div.style.border,
+    "1px solid rgb(0, 0, 0)",
+    "The border shorthand should be correctly parsed and serialized."
+  );
+
+  assert_equals(
+    div.style.borderColor,
+    "rgb(0, 0, 0)",
+    "The border-color should be correctly parsed from the modern rgb() syntax."
+  );
+
+  assert_equals(
+    div.style.borderStyle,
+    "solid",
+    "The border-style should be correctly parsed."
+  );
+
+  assert_equals(
+    div.style.borderWidth,
+    "1px",
+    "The border-width should be correctly parsed."
+  );
+}, "A border shorthand with no space between rgb() and solid");
+</script>

--- a/test/web-platform-tests/to-upstream/css/css-backgrounds/border-no-whitespace.html
+++ b/test/web-platform-tests/to-upstream/css/css-backgrounds/border-no-whitespace.html
@@ -1,46 +1,91 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Border shorthand without whitespace</title>
+<title>Border shorthand component boundaries without whitespace</title>
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#the-border-shorthands">
+<link rel="help" href="https://drafts.csswg.org/css-syntax/#tokenization">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-
-<div id="div" style="border:rgb(0 0 0)solid 1px;color:red"></div>
 
 <script>
 "use strict";
 
+const borderProperties = [
+  { css: "border", idl: "border" },
+  { css: "border-top", idl: "borderTop" },
+  { css: "border-right", idl: "borderRight" },
+  { css: "border-bottom", idl: "borderBottom" },
+  { css: "border-left", idl: "borderLeft" }
+];
+
+const borderCases = [
+  {
+    input: "rgb(0 0 0)solid 1px",
+    serialized: "1px solid rgb(0, 0, 0)",
+    description: "A color function followed by an identifier"
+  },
+  {
+    input: "rgb(0 0 0)1px solid",
+    serialized: "1px solid rgb(0, 0, 0)",
+    description: "A color function followed by a dimension"
+  },
+  {
+    input: "rgb(0 0 0)solid",
+    serialized: "solid rgb(0, 0, 0)",
+    description: "A color function followed by an identifier with an omitted width"
+  },
+  {
+    input: "rgb(calc(0) 0 0)solid 1px",
+    serialized: "1px solid rgb(0, 0, 0)",
+    description: "A color function containing a nested function followed by an identifier"
+  },
+  {
+    input: "rgb(0 0 0)/**/solid 1px",
+    serialized: "1px solid rgb(0, 0, 0)",
+    description: "A color function followed by a comment and an identifier"
+  },
+  {
+    input: "rgb(0 0 0) solid 1px",
+    serialized: "1px solid rgb(0, 0, 0)",
+    description: "A color function followed by ordinary whitespace"
+  }
+];
+
+for (const { css, idl } of borderProperties) {
+  for (const { input, serialized, description } of borderCases) {
+    test(() => {
+      const div = document.createElement("div");
+      div.style[idl] = input;
+      assert_equals(div.style[idl], serialized);
+    }, `${description} via the ${idl} setter`);
+
+    test(() => {
+      const div = document.createElement("div");
+      div.style.cssText = `${css}:${input};color:red`;
+      assert_equals(div.style[idl], serialized, idl);
+      assert_equals(div.style.color, "red", "following declaration");
+    }, `${description} via cssText for ${css}`);
+  }
+}
+
 test(() => {
-  const div = document.getElementById("div");
+  const container = document.createElement("div");
+  container.innerHTML = '<div style="border:rgb(0 0 0)solid 1px;color:red"></div>';
+  const div = container.firstElementChild;
+  assert_equals(div.style.border, "1px solid rgb(0, 0, 0)", "border");
+  assert_equals(div.style.borderWidth, "1px", "borderWidth");
+  assert_equals(div.style.borderStyle, "solid", "borderStyle");
+  assert_equals(div.style.borderColor, "rgb(0, 0, 0)", "borderColor");
+  assert_equals(div.style.color, "red", "following declaration");
+}, "An inline border declaration containing adjacent components");
 
-  assert_equals(
-    div.style.color,
-    "red",
-    "The color property should be parsed and set despite the missing space in border."
-  );
-
-  assert_equals(
-    div.style.border,
-    "1px solid rgb(0, 0, 0)",
-    "The border shorthand should be correctly parsed and serialized."
-  );
-
-  assert_equals(
-    div.style.borderColor,
-    "rgb(0, 0, 0)",
-    "The border-color should be correctly parsed from the modern rgb() syntax."
-  );
-
-  assert_equals(
-    div.style.borderStyle,
-    "solid",
-    "The border-style should be correctly parsed."
-  );
-
-  assert_equals(
-    div.style.borderWidth,
-    "1px",
-    "The border-width should be correctly parsed."
-  );
-}, "A border shorthand with no space between rgb() and solid");
+for (const { idl } of borderProperties) {
+  for (const invalidValue of [")x", "url(x))x", "rgb())x", "foo(])x"]) {
+    test(() => {
+      const div = document.createElement("div");
+      div.style[idl] = "1px solid red";
+      div.style[idl] = invalidValue;
+      assert_equals(div.style[idl], "1px solid red", "previous value");
+    }, `An invalid ${idl} value is ignored without throwing: ${invalidValue}`);
+  }
+}
 </script>


### PR DESCRIPTION
Fix #4285 

Fixed 2 issues:
* Should not throw, but return an empty string if the CSS is invalid.
* Gracefully handle edge cases like missing whitespace (e.g., url()no-repeat).
