### PR TITLE
Update webidl2js to 21.0.0

### DIFF
--- a/lib/jsdom/living/helpers/is-window.js
+++ b/lib/jsdom/living/helpers/is-window.js
@@ -1,18 +1,9 @@
 "use strict";
 const idlUtils = require("../../../generated/idl/utils");
 
-// Until webidl2js gains support for checking for Window, this would have to do.
-module.exports = val => {
-  if (typeof val !== "object") {
-    return false;
-  }
-  const wrapper = idlUtils.wrapperForImpl(val);
-  if (typeof wrapper === "object") {
-    return wrapper === wrapper._globalProxy;
-  }
-
-  // `val` may be either impl or wrapper currently, because webidl2js currently unwraps Window objects (and their global
-  // proxies) to their underlying EventTargetImpl during conversion, which is not what we want. But at the same time,
-  // some internal usage call this constructor with the actual global proxy.
-  return module.exports(idlUtils.implForWrapper(val));
+// Window is implemented outside webidl2js, and callers can supply either its wrapper or its EventTarget implementation.
+module.exports = value => {
+  const impl = idlUtils.tryImplForWrapper(value);
+  const wrapper = idlUtils.wrapperForImpl(impl);
+  return wrapper !== null && wrapper === wrapper._globalProxy;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "server-destroy": "^1.0.1",
         "tinybench": "^6.1.2",
         "webidl2": "^24.5.0",
-        "webidl2js": "^20.1.0",
+        "webidl2js": "^21.0.0",
         "wireit": "^0.14.13"
       },
       "engines": {
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.45.0.tgz",
-      "integrity": "sha512-A/UMxFob1fefCuMeGxQBulGfFE38g2Gm23ynr3u6b+b7fY7/ajGbNsa3ikMIkGMLJW/TRoQaMoP1kME7S+815w==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.66.0.tgz",
+      "integrity": "sha512-2Me9eoptv6ERdEuI2P8AOlYdHHraXebJaM6SC0kc2Dfb+mLrep2db+fedBPKaYn673h/vBgvP4tkOdAbaudX6w==",
       "cpu": [
         "arm"
       ],
@@ -521,9 +521,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.45.0.tgz",
-      "integrity": "sha512-L63z4uZmHjgvvqvMJD7mwff8aSBkM0+X4uFr6l6U5t6+Qc9DCLVZWIunJ7Gm4fn4zHPdSq6FFQnhu9yqqobxIg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.66.0.tgz",
+      "integrity": "sha512-u7O+bSSF0HGsDKkQQxBqvLGVepu93RA+JKu+ONqvfh4sCnCEbj31wZj4iG5gk3XfRwrmYj0/8catkO2LcblQKQ==",
       "cpu": [
         "arm64"
       ],
@@ -538,9 +538,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.45.0.tgz",
-      "integrity": "sha512-UV34dd623FzqT+outIGndsCA/RBB+qgB3XVQhgmmJ9PJwa37NzPC9qzgKeOhPKxVk2HW+JKldQrVL54zs4Noww==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.66.0.tgz",
+      "integrity": "sha512-/ikyMIVjX/sdo7KtjxoEsSUosfPzveVhT9RWMx9yGqFDKFJ89JAEKuEeLBmurDjrkb4w8tOnAdSO3SBaplY3bw==",
       "cpu": [
         "arm64"
       ],
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.45.0.tgz",
-      "integrity": "sha512-pMNJv0CMa1pDefVPeNbuQxibh8ITpWDFEhMC/IBB9Zlu76EbgzYwrzI4Cb11mqX2+rIYN70UTrh3z06TM59ptQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.66.0.tgz",
+      "integrity": "sha512-q5xUsKeFqawa9NXa6ZGXWimFV19m8MogKPdTaSVDAAk2EQKBmBZRDeluwcl1p8ty/OFc9s9888OKEh3xfPVH0g==",
       "cpu": [
         "x64"
       ],
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.45.0.tgz",
-      "integrity": "sha512-xTcRoxbbo61sW2+ZRPeH+vp/o9G8gkdhiVumFU+TpneiPm14c79l6GFlxPXlCE9bNWikigbsrvJw46zCVAQFfg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.66.0.tgz",
+      "integrity": "sha512-CR+x4VzMY0pRXLK/xFQ/RzsSFkP5t2Z2mef0QY6OP/rTRcMUoMLCOM62/3Fp/t0K+UDoBKxvMyeb6D0zPMjleA==",
       "cpu": [
         "x64"
       ],
@@ -589,9 +589,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.45.0.tgz",
-      "integrity": "sha512-hWL8Hdni+3U1mPFx1UtWeGp3tNb6EhBAUHRMbKUxVkOp3WwoJbpVO2bfUVbS4PfpledviXXNHSTl1veTa6FhkQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.66.0.tgz",
+      "integrity": "sha512-ZEYmO/LbH9tTQCADILHGZE4GeOXOAj2VzedHkASNwjmwlwtutJCLpCJbIs37wRGTFgWRoEcD72jpMX+IBJUGjQ==",
       "cpu": [
         "arm"
       ],
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.45.0.tgz",
-      "integrity": "sha512-6Blt/0OBT7vvfQpqYuYbpbFLPqSiaYpEJzUUWhinPEuADypDbtV1+LdjM0vYBNGPvnj85ex7lTerEX6JGcPt9w==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.66.0.tgz",
+      "integrity": "sha512-hNtR9/oU0CeTkq7JnRkmBQwqe17v2ZaAMLC4VcN7IIOWeRyWDk0knSPWS9iiLmtbZ2RRBBtsG01jQgkZmKCJeQ==",
       "cpu": [
         "arm"
       ],
@@ -623,9 +623,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.45.0.tgz",
-      "integrity": "sha512-jLjoLfe+hGfjhA8hNBSdw85yCA8ePKq7ME4T+g6P9caQXvmt6IhE2X7iVjnVdkmYUWEzZrxlh4p6RkDmAMJY/A==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.66.0.tgz",
+      "integrity": "sha512-uwOVQ8i6I1LT/+eDzfsgrrcZp8Fn6NPVUPn8fF5gdFGekFf0PddF+LEuwsD0/pbNUcKZhDj2rQ5UpITh9gF4iQ==",
       "cpu": [
         "arm64"
       ],
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.45.0.tgz",
-      "integrity": "sha512-XQKXZIKYJC3GQJ8FnD3iMntpw69Wd9kDDK/Xt79p6xnFYlGGxSNv2vIBvRTDg5CKByWFWWZLCRDOXoP/m6YN4g==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.66.0.tgz",
+      "integrity": "sha512-tTkF2Dmx4nGAjmBlZb+UtTGqR/EK4ZrW9qBfzte07a9XWqzoGGKzpFFlyNDhQe+Uwql94+ReCTeNbhOXscw1Dg==",
       "cpu": [
         "arm64"
       ],
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.45.0.tgz",
-      "integrity": "sha512-+g5RiG+xOkdrCWkKodv407nTvMq4vYM18Uox2MhZBm/YoqFxxJpWKsloskFFG5NU13HGPw1wzYjjOVcyd9moCA==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.66.0.tgz",
+      "integrity": "sha512-F3cKHUav4yXOHn6GFnwpBhSYsJOYKKf9eqO/9jlEuqPxNw9zb98E9ZFct79gcg8pibUGkbveEu9WDlmXJpDzKw==",
       "cpu": [
         "ppc64"
       ],
@@ -683,9 +683,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.45.0.tgz",
-      "integrity": "sha512-V7dXKoSyEbWAkkSF4JJNtF+NJZDmJoSarSoP30WCsB3X636Rehd3CvxBj49FIJxEBFWhvcUjGSHVeU8Erck1bQ==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.66.0.tgz",
+      "integrity": "sha512-K5fDaNZfDyQMYA/3qL21bqyN0X9T15LLwwbFPt2aHc94+ZG7bh0vZEsy2y7NlRnjjHFSwN+Hzg6ldJtbOriH4Q==",
       "cpu": [
         "riscv64"
       ],
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.45.0.tgz",
-      "integrity": "sha512-Vdelft1sAEYojVGgcODEFXSWYQYlIvoyIGWebKCuUibd1tvS1TjTx413xG2ZLuHpYj45CkN/ztMLMX6jrgqpgg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.66.0.tgz",
+      "integrity": "sha512-44Yc+I+qOmTElRcEhm5hUKIUJEQIOugymz4ua4tB0Wox7tGAfIbjzmXz/HDAtw1Ij6gmBwZlzh4hc9679RhWeA==",
       "cpu": [
         "riscv64"
       ],
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.45.0.tgz",
-      "integrity": "sha512-RR7xKgNpqwENnK0aYCGYg0JycY2n93J0reNjHyes+I9Gq52dH95x+CBlnlAQHCPfz6FGnKA9HirgUl14WO6o7w==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.66.0.tgz",
+      "integrity": "sha512-1e29Eg9hEj2kRBB19M0seIehPbbXHCk35GvImjDvb79rjjYjXCRmtbUNHJcgoktZAMIzXrTbxDBKmTc1V4bg3A==",
       "cpu": [
         "s390x"
       ],
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.45.0.tgz",
-      "integrity": "sha512-U/QQ0+BQNSHxjuXR/utvXnQ50Vu5kUuqEomZvQ1/3mhgbBiMc2WU9q5kZ5WwLp3gnFIx9ibkveoRSe2EZubkqg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.66.0.tgz",
+      "integrity": "sha512-vODY1UQo10gngn0+D4xHKU84F1Twm1LqrzV4SqPXvmQKSd87paehvZ6jqA5wKs6XQrlWul9clYMDVHcoW9CPMA==",
       "cpu": [
         "x64"
       ],
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.45.0.tgz",
-      "integrity": "sha512-o5TLOUCF0RWQjsIS06yVC+kFgp092/yLe6qBGSUvtnmTVw9gxjpdQSXc3VN5Cnive4K11HNstEZF8ROKHfDFSw==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.66.0.tgz",
+      "integrity": "sha512-YDzXx2JsT4+HL4MdkVrYjO55NS5lUKNm8rLC4ZPou8+seu0v0jhecSh+ufoO6+xEa8gccEezMlI2WHJi4ApUgw==",
       "cpu": [
         "x64"
       ],
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.45.0.tgz",
-      "integrity": "sha512-RnGcV3HgPuOjsGx/k9oyRNKmOp+NBLGzZTdPDYbc19r7NGeYPplnUU/BfU35bX2Y/O4ejvHxcfkvW2WoYL/gsg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.66.0.tgz",
+      "integrity": "sha512-mJjUYd8lj0+j4JkYyEM+5qKBf1Rnrpgjn/SVYKJhicVDqLz566ooa7Fs8zflPqt+dnZDV7X054rVIQX6ZcQNlQ==",
       "cpu": [
         "arm64"
       ],
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.45.0.tgz",
-      "integrity": "sha512-v3Vj7iKKsUFwt9w5hsqIIoErKVoENC6LoqfDlteOQ5QMDCXihlqLoxpmviUhXnNncg4zV6U9BPwlBbwa+qm4wg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.66.0.tgz",
+      "integrity": "sha512-soV+0vESv7e5ntCHWC61x4gg8OSak6IHHnWsZmHrJFlvMj2AK+kmldErCNkVkrvc1Ts2/++rJXn+IuAb2WMXhw==",
       "cpu": [
         "arm64"
       ],
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.45.0.tgz",
-      "integrity": "sha512-N8yotPBX6ph0H3toF4AEpdCeVPrdcSetj+8eGiZGsrLsng3bs/Q5HPu4bbSxip5GBPx5hGbGHrZwH4+rcrjhHA==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.66.0.tgz",
+      "integrity": "sha512-YCPi23uRIEYuIKTZohAkKbPFpujQ5QBuUM5iDv+UqbCmTPAkaFsxjsSuB8xlBpRT0G7eP/4HMF+cPDSqHtOD9A==",
       "cpu": [
         "ia32"
       ],
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.45.0.tgz",
-      "integrity": "sha512-w5MMTRCK1dpQeRA+HHqXQXyN33DlG/N2LOYxJmaT4fJjcmZrbNnqw7SmIk7I2/a2493PPLZ+2E/Ar6t2iKVMug==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.66.0.tgz",
+      "integrity": "sha512-bwTQcv/JVRPkOqQtMF0X7vpvpncDQiBcXHxZ9S2hR12Hlo8bvBdUR5x5XnxzDZ3kM0qoZw1rv7KaD66Ly+pFWA==",
       "cpu": [
         "x64"
       ],
@@ -2695,9 +2695,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.45.0.tgz",
-      "integrity": "sha512-0o/COoN9fY50bjVeM7PQsNgbhndKurBIeTIcspW033OumksjJJmIVDKjAk5HMwU/GHTxSOdGDdhJ6BRzGPmsHg==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.66.0.tgz",
+      "integrity": "sha512-FfvqR8RFtV6JJpRrpkfqyVCQ7HDvZ/VriWFx7veftCgL1B5ZO9qNr+1rvPieycMQnNfVG0PWyJQiy7p0hq1I5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2710,28 +2710,40 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.45.0",
-        "@oxfmt/binding-android-arm64": "0.45.0",
-        "@oxfmt/binding-darwin-arm64": "0.45.0",
-        "@oxfmt/binding-darwin-x64": "0.45.0",
-        "@oxfmt/binding-freebsd-x64": "0.45.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.45.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.45.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.45.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.45.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.45.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.45.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.45.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.45.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.45.0",
-        "@oxfmt/binding-linux-x64-musl": "0.45.0",
-        "@oxfmt/binding-openharmony-arm64": "0.45.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.45.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.45.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.45.0"
+        "@oxfmt/binding-android-arm-eabi": "0.66.0",
+        "@oxfmt/binding-android-arm64": "0.66.0",
+        "@oxfmt/binding-darwin-arm64": "0.66.0",
+        "@oxfmt/binding-darwin-x64": "0.66.0",
+        "@oxfmt/binding-freebsd-x64": "0.66.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.66.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.66.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.66.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.66.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.66.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.66.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.66.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.66.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.66.0",
+        "@oxfmt/binding-linux-x64-musl": "0.66.0",
+        "@oxfmt/binding-openharmony-arm64": "0.66.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.66.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.66.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.66.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {
@@ -3468,13 +3480,13 @@
       }
     },
     "node_modules/webidl2js": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/webidl2js/-/webidl2js-20.1.0.tgz",
-      "integrity": "sha512-DoVmJIet15CfILhy+sxL8QtTMJxoeQ1Q/NeYaTLQl+pxiaVeRBRvU+HBMq2qMVQ3QdBLAV6GVcgGaKoI0wVBYw==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/webidl2js/-/webidl2js-21.0.0.tgz",
+      "integrity": "sha512-ZQVSv3MOAD+OoIew4BKwAcBmMcxl+ArOvD25KzEcqqQWUJZUG/aFBAw++45rRl+97pJh0F+kNE9E8fYkeh3F/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "oxfmt": "^0.45.0",
+        "oxfmt": "^0.66.0",
         "webidl-conversions": "^8.0.1",
         "webidl2": "^24.5.0"
       },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "server-destroy": "^1.0.1",
     "tinybench": "^6.1.2",
     "webidl2": "^24.5.0",
-    "webidl2js": "^20.1.0",
+    "webidl2js": "^21.0.0",
     "wireit": "^0.14.13"
   },
   "scripts": {

--- a/test/web-platform-tests/to-upstream/dom/nodes/Node-proxy-brand-checks.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Node-proxy-brand-checks.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Proxies around nodes do not pass Web IDL brand checks</title>
+<link rel="help" href="https://webidl.spec.whatwg.org/#implements">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-attributes">
+<link rel="help" href="https://webidl.spec.whatwg.org/#es-operations">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+test(() => {
+  const element = document.createElement("span");
+  element.innerHTML = "before";
+  const proxy = new Proxy(element, {});
+
+  assert_throws_js(TypeError, () => {
+    proxy.innerHTML = "after";
+  });
+  assert_equals(element.innerHTML, "before");
+}, "Setting innerHTML through a transparent proxy throws without modifying the element");
+
+const { get: getInnerHTML, set: setInnerHTML } = Object.getOwnPropertyDescriptor(Element.prototype, "innerHTML");
+
+for (const [name, createProxy] of [
+  ["transparent proxy", element => new Proxy(element, {})],
+  [
+    "revoked proxy", element => {
+      const { proxy, revoke } = Proxy.revocable(element, {});
+      revoke();
+      return proxy;
+    }
+  ]
+]) {
+  test(() => {
+    const element = document.createElement("span");
+    assert_throws_js(TypeError, () => getInnerHTML.call(createProxy(element)));
+  }, `The innerHTML getter rejects a ${name} as its receiver`);
+
+  test(() => {
+    const element = document.createElement("span");
+    element.innerHTML = "before";
+    assert_throws_js(TypeError, () => setInnerHTML.call(createProxy(element), "after"));
+    assert_equals(element.innerHTML, "before");
+  }, `The innerHTML setter rejects a ${name} as its receiver`);
+
+  test(() => {
+    const element = document.createElement("span");
+    const child = document.createTextNode("child");
+    assert_throws_js(TypeError, () => Node.prototype.appendChild.call(createProxy(element), child));
+    assert_equals(child.parentNode, null);
+  }, `appendChild rejects a ${name} as its receiver`);
+
+  test(() => {
+    const parent = document.createElement("div");
+    const child = document.createElement("span");
+    assert_throws_js(TypeError, () => parent.appendChild(createProxy(child)));
+    assert_equals(child.parentNode, null);
+  }, `appendChild rejects a ${name} as its Node argument`);
+}
+
+test(() => {
+  const element = document.createElement("span");
+  function unexpectedTrap() {
+    assert_unreached("Brand checks must not invoke proxy traps");
+  }
+  const proxy = new Proxy(element, {
+    get: unexpectedTrap,
+    getOwnPropertyDescriptor: unexpectedTrap,
+    getPrototypeOf: unexpectedTrap
+  });
+
+  assert_throws_js(TypeError, () => getInnerHTML.call(proxy));
+  assert_throws_js(TypeError, () => setInnerHTML.call(proxy, "after"));
+  assert_throws_js(TypeError, () => Node.prototype.appendChild.call(proxy, document.createTextNode("child")));
+  assert_throws_js(TypeError, () => element.appendChild(proxy));
+}, "Rejecting a proxy as a receiver or Node argument does not invoke its traps");
+</script>

--- a/test/web-platform-tests/to-upstream/uievents/constructors/constructor-view-proxy.html
+++ b/test/web-platform-tests/to-upstream/uievents/constructors/constructor-view-proxy.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>UI event constructors reject proxies around Window as view</title>
+<link rel="help" href="https://w3c.github.io/uievents/#dom-uieventinit-view">
+<link rel="help" href="https://webidl.spec.whatwg.org/#implements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+for (const EventConstructor of [UIEvent, MouseEvent]) {
+  test(() => {
+    assert_equals(new EventConstructor("test", { view: window }).view, window);
+    assert_equals(new EventConstructor("test", { view: null }).view, null);
+  }, `${EventConstructor.name} accepts the actual WindowProxy and null as view`);
+
+  test(() => {
+    const proxy = new Proxy(window, {});
+    assert_throws_js(TypeError, () => new EventConstructor("test", { view: proxy }));
+  }, `${EventConstructor.name} rejects a transparent proxy around Window as view`);
+
+  test(() => {
+    const { proxy, revoke } = Proxy.revocable(window, {});
+    revoke();
+    assert_throws_js(TypeError, () => new EventConstructor("test", { view: proxy }));
+  }, `${EventConstructor.name} rejects a revoked proxy around Window as view`);
+}
+</script>


### PR DESCRIPTION
Update to webidl2js 21.0.0 so proxy-wrapped DOM objects correctly fail brand checks, fixing the browser mismatches reported in #2265 and #2973.
