### PR TITLE
Avoid intermediate style attribute updates

### DIFF
--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -32,6 +32,7 @@ class CSSStyleDeclarationImpl {
   parentRule;
   #ownerNode;
   #updating = false;
+  #pendingStyleUpdate = false;
 
   // Internal private fields.
   #computedValueOpts = new Map();
@@ -57,11 +58,10 @@ class CSSStyleDeclarationImpl {
     if (this.#cachedCssText !== null) {
       return this.#cachedCssText;
     }
-    const properties = new Map();
+    const properties = new Set();
     for (const property of this.#values.keys()) {
-      const value = this.getPropertyValue(property);
-      const priority = this._priorities.get(property) ?? "";
       if (shorthandProperties.has(property)) {
+        const priority = this._priorities.get(property) ?? "";
         const { shorthandFor } = shorthandProperties.get(property);
         for (const [longhand] of shorthandFor) {
           if (priority || !this._priorities.get(longhand)) {
@@ -69,11 +69,13 @@ class CSSStyleDeclarationImpl {
           }
         }
       }
-      properties.set(property, { property, value, priority });
+      properties.add(property);
     }
     const normalizedProperties = normalizeProperties(properties);
     const parts = [];
-    for (const { property, value, priority } of normalizedProperties.values()) {
+    for (const property of normalizedProperties) {
+      const value = this.getPropertyValue(property);
+      const priority = this._priorities.get(property) ?? "";
       if (priority) {
         parts.push(`${property}: ${value} !${priority};`);
       } else {
@@ -287,6 +289,10 @@ class CSSStyleDeclarationImpl {
    * @param {string} [priority=""] - The priority (e.g. "important").
    */
   setProperty(property, value, priority = "") {
+    this._updateStyle(() => this._setPropertyValue(property, value, priority));
+  }
+
+  _setPropertyValue(property, value, priority) {
     if (this._readonly) {
       throw DOMException.create(this._globalObject, [
         `Property ${property} can not be modified.`,
@@ -328,8 +334,30 @@ class CSSStyleDeclarationImpl {
     return index >= 0 && index < this.#values.size;
   }
 
+  _updateStyle(update) {
+    if (this.#updating || !this.#ownerNode) {
+      update();
+      return;
+    }
+    const originalText = this.cssText;
+    this.#updating = true;
+    this.#pendingStyleUpdate = false;
+    try {
+      update();
+    } finally {
+      this.#updating = false;
+      if (this.#pendingStyleUpdate && this.cssText !== originalText) {
+        this.#updateStyleAttribute();
+      }
+    }
+  }
+
   // https://drafts.csswg.org/cssom/#update-style-attribute-for
   #updateStyleAttribute() {
+    if (this.#updating) {
+      this.#pendingStyleUpdate = true;
+      return;
+    }
     if (this._computed || !this.#ownerNode || this.#ownerNode._settingCssText) {
       return;
     }
@@ -361,7 +389,9 @@ class CSSStyleDeclarationImpl {
     this.#cachedCssText = null;
     this.#values.set(property, value);
 
-    if (this.#ownerNode && !this.#updating && this.cssText !== originalText) {
+    if (this.#updating) {
+      this.#pendingStyleUpdate = true;
+    } else if (this.#ownerNode && this.cssText !== originalText) {
       this.#updateStyleAttribute();
     }
   }

--- a/lib/jsdom/living/css/CSSStyleProperties-impl.js
+++ b/lib/jsdom/living/css/CSSStyleProperties-impl.js
@@ -9,10 +9,19 @@ class CSSStylePropertiesImpl extends CSSStyleDeclarationImpl {
   }
 
   set cssFloat(value) {
-    propertyDescriptors.float.set.call(this, value);
+    this._updateStyle(() => propertyDescriptors.float.set.call(this, value));
   }
 }
 
-Object.defineProperties(CSSStylePropertiesImpl.prototype, propertyDescriptors);
+for (const [property, descriptor] of Object.entries(propertyDescriptors)) {
+  Object.defineProperty(CSSStylePropertiesImpl.prototype, property, {
+    get: descriptor.get,
+    set(value) {
+      this._updateStyle(() => descriptor.set.call(this, value));
+    },
+    enumerable: descriptor.enumerable,
+    configurable: descriptor.configurable
+  });
+}
 
 exports.implementation = CSSStylePropertiesImpl;

--- a/lib/jsdom/living/css/helpers/shorthand-properties.js
+++ b/lib/jsdom/living/css/helpers/shorthand-properties.js
@@ -1486,8 +1486,8 @@ function prepareProperties(properties) {
 /**
  * Cleans up redundancy in border properties by removing longhands that are covered by shorthands.
  *
- * @param {Map} properties - The map of properties to normalize.
- * @returns {Map} The normalized properties map.
+ * @param {Set<string>} properties - The property names to normalize.
+ * @returns {Set<string>} The normalized property names.
  */
 function normalizeProperties(properties) {
   if (properties.has(border.property)) {

--- a/test/web-platform-tests/to-upstream/css/cssom/style-mutation-reentrancy.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-mutation-reentrancy.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Style mutations during custom element reactions and value conversion</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+/* global assert_throws_exactly */
+
+let nextId = 0;
+for (const [setterName, setter] of [
+  [
+    "property assignment", element => {
+      element.style.padding = "1px 2px";
+    }
+  ],
+  [
+    "setProperty()", element => {
+      element.style.setProperty("padding", "1px 2px");
+    }
+  ],
+  [
+    "cssText", element => {
+      element.style.cssText = "padding: 1px 2px;";
+    }
+  ],
+  [
+    "setAttribute()", element => {
+      element.setAttribute("style", "padding: 1px 2px;");
+    }
+  ]
+]) {
+  for (const [name, change, expected] of [
+    [
+      "property assignment", element => {
+        element.style.margin = "3px 4px";
+      }, "padding: 1px 2px; margin: 3px 4px;"
+    ],
+    [
+      "setProperty()", element => {
+        element.style.setProperty("padding", "5px");
+      }, "padding: 5px;"
+    ],
+    [
+      "cssText", element => {
+        element.style.cssText = "color: red;";
+      }, "color: red;"
+    ],
+    [
+      "setAttribute()", element => {
+        element.setAttribute("style", "color: blue;");
+      }, "color: blue;"
+    ],
+    [
+      "removeAttribute()", element => {
+        element.removeAttribute("style");
+      }, null
+    ]
+  ]) {
+    const tag = `style-reentrant-${nextId++}`;
+    test(t => {
+      const callbacks = [];
+      let changed = false;
+      customElements.define(tag, class extends HTMLElement {
+        static observedAttributes = ["style"];
+        attributeChangedCallback(attribute, oldValue, newValue) {
+          callbacks.push([oldValue, newValue, this.getAttribute("style"), this.style.cssText]);
+          if (!changed) {
+            changed = true;
+            change(this);
+          }
+        }
+      });
+      const element = document.createElement(tag);
+      const observer = new MutationObserver(() => {});
+      observer.observe(element, { attributes: true, attributeOldValue: true });
+      t.add_cleanup(() => observer.disconnect());
+      setter(element);
+      assert_equals(callbacks.length, 2, "Both reactions run before returning");
+      assert_array_equals(callbacks[0], [null, "padding: 1px 2px;", "padding: 1px 2px;", "padding: 1px 2px;"]);
+      assert_array_equals(callbacks[1], ["padding: 1px 2px;", expected, expected, expected === null ? "" : expected]);
+      assert_equals(element.getAttribute("style"), expected);
+      assert_equals(element.style.cssText, expected === null ? "" : expected);
+      assert_array_equals(observer.takeRecords().map(record => record.oldValue), [null, "padding: 1px 2px;"]);
+      element.style.color = "green";
+      assert_equals(element.style.color, "green", "Subsequent writes still work");
+      assert_equals(element.getAttribute("style"), element.style.cssText);
+    }, `Style mutation via ${setterName} reenters via ${name} in attributeChangedCallback`);
+  }
+}
+
+for (const useSetProperty of [false, true]) {
+  for (const throws of [false, true]) {
+    test(t => {
+      const element = document.createElement("div");
+      const observer = new MutationObserver(() => {});
+      observer.observe(element, { attributes: true, attributeOldValue: true });
+      t.add_cleanup(() => observer.disconnect());
+      const failure = new Error("conversion failed");
+      const value = {
+        [Symbol.toPrimitive]() {
+          element.style.margin = "3px";
+          assert_equals(element.getAttribute("style"), "margin: 3px;", "Conversion writes synchronously");
+          assert_array_equals(observer.takeRecords().map(record => record.oldValue), [null]);
+          if (throws) {
+            throw failure;
+          }
+          return "1px 2px";
+        }
+      };
+      function setValue() {
+        if (useSetProperty) {
+          element.style.setProperty("padding", value);
+        } else {
+          element.style.padding = value;
+        }
+      }
+      if (throws) {
+        assert_throws_exactly(failure, setValue);
+        assert_equals(element.style.cssText, "margin: 3px;");
+        assert_equals(observer.takeRecords().length, 0);
+      } else {
+        setValue();
+        assert_equals(element.style.cssText, "margin: 3px; padding: 1px 2px;");
+        assert_array_equals(observer.takeRecords().map(record => record.oldValue), ["margin: 3px;"]);
+      }
+      element.style.color = "green";
+      assert_equals(element.getAttribute("style"), element.style.cssText);
+    }, `Reentrant value conversion: setProperty=${useSetProperty}, throws=${throws}`);
+  }
+}
+</script>

--- a/test/web-platform-tests/to-upstream/css/cssom/style-shorthand-mutation-records.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/style-shorthand-mutation-records.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Shorthand updates write the style attribute once</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+for (const [property, value] of [
+  ["flex", "1 1 auto"],
+  ["font", "italic 16px serif"],
+  ["padding", "1px 2px 3px 4px"],
+  ["margin", "1px 2px 3px 4px"],
+  ["border", "1px solid red"],
+  ["border-width", "1px 2px 3px 4px"],
+  ["border-style", "solid dashed dotted double"],
+  ["border-color", "red green blue black"],
+  ...["top", "right", "bottom", "left"].map(side => [`border-${side}`, "1px solid red"])
+]) {
+  for (const useSetProperty of [false, true]) {
+    test(t => {
+      const element = document.createElement("div");
+      element.setAttribute("style", "color: red;");
+      const observer = new MutationObserver(() => {});
+      t.add_cleanup(() => observer.disconnect());
+      observer.observe(element, { attributes: true, attributeOldValue: true });
+
+      if (useSetProperty) {
+        element.style.setProperty(property, value);
+      } else {
+        element.style[property] = value;
+      }
+
+      const records = observer.takeRecords();
+      assert_equals(records.length, 1, "Only the completed declaration block is written");
+      assert_equals(records[0].attributeName, "style");
+      assert_equals(records[0].oldValue, "color: red;");
+      assert_equals(element.style.getPropertyValue(property), value);
+      assert_equals(element.getAttribute("style"), element.style.cssText);
+    }, `${property} via ${useSetProperty ? "setProperty" : "property assignment"} emits one mutation`);
+  }
+}
+
+for (const [shorthand, initialValue, property, value] of [
+  ["padding", "1px", "padding-top", "2px"],
+  ["margin", "1px", "margin-left", "2px"],
+  ["flex", "1 1 auto", "flex-grow", "2"],
+  ["flex-flow", "row wrap", "flex-direction", "column"]
+]) {
+  for (const useSetProperty of [false, true]) {
+    test(t => {
+      const element = document.createElement("div");
+      element.style.setProperty(shorthand, initialValue);
+      const oldValue = element.getAttribute("style");
+      const observer = new MutationObserver(() => {});
+      t.add_cleanup(() => observer.disconnect());
+      observer.observe(element, { attributes: true, attributeOldValue: true });
+
+      function setValue(nextValue) {
+        if (useSetProperty) {
+          element.style.setProperty(property, nextValue);
+        } else {
+          element.style[property] = nextValue;
+        }
+      }
+      setValue(value);
+      const records = observer.takeRecords();
+      assert_equals(records.length, 1);
+      assert_equals(records[0].oldValue, oldValue);
+      assert_equals(element.style.getPropertyValue(property), value);
+      assert_equals(element.getAttribute("style"), element.style.cssText);
+
+      setValue(value);
+      assert_equals(observer.takeRecords().length, 0, "Rebuilding an unchanged shorthand does not write the attribute");
+
+      setValue("");
+      assert_equals(observer.takeRecords().length, 1, "Removing a longhand writes the attribute once");
+      assert_equals(element.style.getPropertyValue(property), "");
+      assert_equals(element.getAttribute("style"), element.style.cssText);
+    }, `${property} updating ${shorthand} via ${useSetProperty ? "setProperty" : "property assignment"}`);
+  }
+}
+
+test(t => {
+  const element = document.createElement("div");
+  element.style.padding = "1px";
+  const observer = new MutationObserver(() => {});
+  t.add_cleanup(() => observer.disconnect());
+  observer.observe(element, { attributes: true, attributeOldValue: true });
+
+  element.style.padding = "1px";
+  element.style.padding = "invalid";
+  assert_equals(observer.takeRecords().length, 0, "Unchanged and invalid assignments do not write the attribute");
+
+  element.style.padding = "";
+  const records = observer.takeRecords();
+  assert_equals(records.length, 1, "Clearing a shorthand writes the attribute once");
+  assert_equals(records[0].oldValue, "padding: 1px;");
+  assert_equals(element.style.padding, "");
+  assert_equals(element.style.paddingTop, "");
+  assert_equals(element.getAttribute("style"), "");
+}, "Shorthand no-ops and removals do not expose intermediate declarations");
+
+test(t => {
+  const element = document.createElement("div");
+  element.style.setProperty("padding", "1px");
+  const observer = new MutationObserver(() => {});
+  t.add_cleanup(() => observer.disconnect());
+  observer.observe(element, { attributes: true, attributeOldValue: true });
+
+  element.style.setProperty("padding", "1px", "important");
+  const records = observer.takeRecords();
+  assert_equals(records.length, 1);
+  assert_equals(records[0].oldValue, "padding: 1px;");
+  assert_equals(element.getAttribute("style"), "padding: 1px !important;");
+  assert_equals(element.style.getPropertyPriority("padding"), "important");
+
+}, "Changing only shorthand priority updates the attribute once");
+
+test(t => {
+  const element = document.createElement("div");
+  const observer = new MutationObserver(() => {});
+  t.add_cleanup(() => observer.disconnect());
+  observer.observe(element, { attributes: true, attributeOldValue: true });
+
+  element.style.cssText = "padding: 1px 2px; margin: 3px 4px;";
+  const records = observer.takeRecords();
+  assert_equals(records.length, 1, "cssText wraps all of its property assignments");
+  assert_equals(records[0].oldValue, null);
+  assert_equals(element.style.padding, "1px 2px");
+  assert_equals(element.style.margin, "3px 4px");
+}, "cssText assignments containing multiple shorthands update the attribute once");
+</script>


### PR DESCRIPTION
Generally been avoiding css changes since i saw a big pr with a revamp of css coming. This one seemed interesting enough. Even if pendingStyleUpdate isn't very good using a set instead of a map here is pretty interesting.

Setting a shorthand can update and serialize the style attribute several times as its longhands change. This batches those changes within each property assignment and updates the attribute once with the completed declaration, avoiding intermediate mutation records and repeated serialization.

Also avoids allocating temporary property objects during `cssText` serialization, reading values and priorities after redundant properties have been removed. Adds mutation observer coverage for shorthand and longhand assignments, removals, unchanged values, and priority changes.

Results from `node --run benchmark -- --suite style/style-property --format markdown`, comparing main with this branch using the same dependencies. Each operation creates 20 elements; times are averaged across two runs with the order reversed for the second run.

| Benchmark | Before | After | Speedup |
|---|---:|---:|---:|
| `innerHTML`, no styles | 0.116 ms | 0.116 ms | 1.00× |
| `innerHTML`, inline styles | 1.949 ms | 1.934 ms | 1.01× |
| `createElement` + style properties | 0.767 ms | 0.277 ms | 2.77× |
| `createElement` + `setAttribute("style")` | 1.793 ms | 1.760 ms | 1.02× |
| `createElement` + `style.cssText` | 1.819 ms | 1.829 ms | 0.99× |
