### PR TITLE
Use internal attribute records for selector matching

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -271,7 +271,8 @@ class DocumentImpl extends NodeImpl {
     if (!this.#domSelector) {
       this.#domSelector = new DOMSelector(this._globalObject, this._ownerDocument, {
         domSymbolTree,
-        idlUtils
+        idlUtils,
+        getAttributeList: element => element._attributeList
       });
     }
     return this.#domSelector;

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-overridden-attributes.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-overridden-attributes.html
@@ -13,7 +13,9 @@ for (const selector of ["[data-test]", '[data-test="target"]', '[data-test^="tar
     const root = document.createElement("div");
     root.innerHTML = '<span data-test="target"></span>';
     const child = root.firstChild;
-    const fail = () => { throw new Error("Public attribute accessor was called"); };
+    function fail() {
+      throw new Error("Public attribute accessor was called");
+    }
     for (const method of ["hasAttribute", "getAttribute", "getAttributeNames", "hasAttributeNS"]) {
       child[method] = fail;
     }

--- a/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-overridden-attributes.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelectorAll-overridden-attributes.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Attribute selectors ignore overridden public attribute accessors</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+for (const selector of ["[data-test]", '[data-test="target"]', '[data-test^="tar"]']) {
+  test(() => {
+    const root = document.createElement("div");
+    root.innerHTML = '<span data-test="target"></span>';
+    const child = root.firstChild;
+    const fail = () => { throw new Error("Public attribute accessor was called"); };
+    for (const method of ["hasAttribute", "getAttribute", "getAttributeNames", "hasAttributeNS"]) {
+      child[method] = fail;
+    }
+    Object.defineProperty(child, "attributes", { get: fail });
+
+    const matches = root.querySelectorAll(selector);
+    assert_equals(matches.length, 1);
+    assert_true(matches[0] === child);
+  }, `querySelectorAll(${selector}) ignores overridden attribute accessors`);
+}
+</script>


### PR DESCRIPTION
Let dom-selector read jsdom’s attribute records directly instead of going through public DOM wrappers.

Attribute queries after a DOM change. Both versions use the same selector update; this measures just the jsdom callback. Lower is better.

| Rows | Query | Before | After | Less time |
| ---: | --- | ---: | ---: | ---: |
| 20 | Starts with: `[data-testid^="row-"]` | 36.36 µs | 10.20 µs | 72% |
| 20 | Ends with: `[data-testid$="9"]` | 36.18 µs | 9.73 µs | 73% |
| 20 | Contains word: `[data-words~="two"]` | 37.07 µs | 10.86 µs | 71% |
| 250 | Starts with: `[data-testid^="row-"]` | 468.69 µs | 147.62 µs | 69% |
| 250 | Ends with: `[data-testid$="9"]` | 465.01 µs | 145.30 µs | 69% |
| 250 | Contains word: `[data-words~="two"]` | 473.15 µs | 156.48 µs | 67% |

Medians of four runs in separate processes, alternating before/after order. Node 26.8.1, Apple M4 Max.

<details>
<summary>Other queries and benchmark details</summary>

These queries don't use the callback and were roughly unchanged. The Testing Library case runs 20 `getByTestId()` calls after each DOM change.

| Rows | Query | Before | After |
| ---: | --- | ---: | ---: |
| 20 | `[data-testid]` | 4.39 µs | 4.42 µs |
| 20 | Exact attribute match | 10.60 µs | 10.44 µs |
| 20 | `.row > span` | 16.33 µs | 15.71 µs |
| 20 | Testing Library, 20 lookups | 197.72 µs | 200.70 µs |
| 250 | `[data-testid]` | 43.80 µs | 44.56 µs |
| 250 | Exact attribute match | 144.39 µs | 147.18 µs |
| 250 | `.row > span` | 174.85 µs | 173.75 µs |
| 250 | Testing Library, 20 lookups | 2349.24 µs | 2358.49 µs |

Each query or batch follows an unrelated attribute change. Each case gets 300 ms of warmup and 800 ms of measurement. The only difference between versions is whether jsdom supplies the attribute-list callback.

</details>

Needs [dom-selector#343](https://github.com/asamuzaK/domSelector/pull/343) to land and release before the dependency can be bumped. Until then, the new prefix-selector test will fail in CI.
