### PR TITLE
Avoid a second ancestor walk during node insertion

### DIFF
--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -116,13 +116,13 @@ function createMemoizedQueries() {
 
 // https://dom.spec.whatwg.org/#concept-tree-host-including-inclusive-ancestor
 function isHostInclusiveAncestor(nodeImplA, nodeImplB) {
-  for (const ancestor of domSymbolTree.ancestorsIterator(nodeImplB)) {
+  let rootImplB = nodeImplB;
+  for (let ancestor = nodeImplB; ancestor !== null; ancestor = domSymbolTree.parent(ancestor)) {
     if (ancestor === nodeImplA) {
       return true;
     }
+    rootImplB = ancestor;
   }
-
-  const rootImplB = nodeRoot(nodeImplB);
   if (rootImplB._host) {
     return isHostInclusiveAncestor(nodeImplA, rootImplB._host);
   }


### PR DESCRIPTION
`isHostInclusiveAncestor` walks the ancestors, then looks up the root separately. Keep the root from the first walk so both checks share one traversal.

somewhat related to #4291