### PR TITLE
Fix HTMLMediaElement.playbackRate to throw NotSupportedError for unsupported rates

### DIFF
--- a/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMediaElement-impl.js
@@ -63,6 +63,9 @@ class HTMLMediaElementImpl extends HTMLElementImpl {
   }
 
   set playbackRate(v) {
+    if (v === 0.0) {
+      throw DOMException.create(this._globalObject, ["The operation is not supported.", "NotSupportedError"]);
+    }
     if (v !== this._playbackRate) {
       this._playbackRate = v;
       this._dispatchRateChange();

--- a/test/web-platform-tests/to-upstream/html/semantics/embedded-content/media-elements/playbackrate-unsupported.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/embedded-content/media-elements/playbackrate-unsupported.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTMLMediaElement playbackRate unsupported values throw NotSupportedError</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-defaultplaybackrate">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+
+<script>
+"use strict";
+
+test(() => {
+  const audio = document.createElement("audio");
+  assert_throws_dom("NotSupportedError", () => {
+    audio.playbackRate = 0;
+  });
+}, "Setting playbackRate to 0 throws NotSupportedError");
+
+test(() => {
+  const audio = document.createElement("audio");
+  assert_throws_dom("NotSupportedError", () => {
+    audio.defaultPlaybackRate = 0;
+  });
+}, "Setting defaultPlaybackRate to 0 throws NotSupportedError");
+</script>


### PR DESCRIPTION
Media players and test harnesses that mirror browser behavior expect setting `playbackRate` to an unsupported value such as `0` to throw `NotSupportedError`. jsdom already did this for `defaultPlaybackRate`, but `playbackRate` accepted `0`.

This change throws `NotSupportedError` for `playbackRate = 0`, matching `defaultPlaybackRate`, and adds a to-upstream WPT covering both setters.

Fixes #3731