### PR TITLE
Avoid reparsing cached computed styles

### DIFF
--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -46,6 +46,15 @@ class CSSStyleDeclarationImpl {
     this.#ownerNode = ownerNode || null;
   }
 
+  _copyDeclarationsFrom(source) {
+    for (const [property, value] of source.#values) {
+      this.#values.set(property, value);
+    }
+    for (const [property, priority] of source._priorities) {
+      this._priorities.set(property, priority);
+    }
+  }
+
   /**
    * Returns the textual representation of the declaration block.
    *

--- a/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
+++ b/lib/jsdom/living/css/CSSStyleDeclaration-impl.js
@@ -430,9 +430,6 @@ class CSSStyleDeclarationImpl {
     if (longhands) {
       if (isColor) {
         value = asciiLowercase(value);
-        if (systemColors.has(value)) {
-          return value;
-        }
       }
       return this.#resolveShorthand(property, value);
     }

--- a/lib/jsdom/living/css/helpers/computed-style.js
+++ b/lib/jsdom/living/css/helpers/computed-style.js
@@ -29,12 +29,7 @@ function getComputedStyleDeclaration(elementImpl) {
       ownerNode: elementImpl
     });
 
-    for (let i = 0; i < cachedDeclaration.length; i++) {
-      const property = cachedDeclaration.item(i);
-      const value = cachedDeclaration.getPropertyValue(property);
-      const priority = cachedDeclaration.getPropertyPriority(property);
-      clonedDeclaration.setProperty(property, value, priority);
-    }
+    clonedDeclaration._copyDeclarationsFrom(cachedDeclaration);
     clonedDeclaration._readonly = true;
 
     return clonedDeclaration;

--- a/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-repeat.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-repeat.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Repeated getComputedStyle() calls preserve property values</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+function createElement(t, cssText) {
+  const element = document.createElement("div");
+  element.style.cssText = cssText;
+  document.body.append(element);
+  t.add_cleanup(() => element.remove());
+  return element;
+}
+
+for (const [cssText, properties] of [
+  ["font: initial", ["font", "font-family"]],
+  ["color-scheme: dark; color: CanvasText; border: 1px solid CanvasText", ["color", "border-color"]]
+]) {
+  test(t => {
+    const element = createElement(t, cssText);
+    const first = getComputedStyle(element);
+    const values = properties.map(property => first.getPropertyValue(property));
+
+    for (let i = 0; i < 2; ++i) {
+      const repeated = getComputedStyle(element);
+      assert_not_equals(repeated, first);
+      for (let j = 0; j < properties.length; ++j) {
+        assert_equals(repeated.getPropertyValue(properties[j]), values[j], properties[j]);
+      }
+    }
+  }, `Repeated computed styles preserve property values for ${cssText}`);
+}
+
+test(t => {
+  const parent = createElement(t, "font-size: 20px; color: rgb(1, 2, 3)");
+  const child = document.createElement("div");
+  child.style.cssText = "font-size: 150%; padding: 2em; color: inherit; --Marker: TokenValue";
+  parent.append(child);
+  const properties = [...getComputedStyle(child)];
+
+  for (let i = 0; i < 3; ++i) {
+    const computed = getComputedStyle(child);
+    assert_array_equals([...computed], properties);
+    assert_equals(computed.fontSize, "30px");
+    assert_equals(computed.paddingTop, "60px");
+    assert_equals(computed.paddingLeft, "60px");
+    assert_equals(computed.padding, "60px");
+    assert_equals(computed.color, "rgb(1, 2, 3)");
+    assert_equals(computed.getPropertyValue("--Marker"), "TokenValue");
+  }
+
+  // Resolving the child's inherited values may have already computed the parent's style.
+  const parentStyle = getComputedStyle(parent);
+  assert_equals(parentStyle.fontSize, "20px");
+  assert_equals(parentStyle.color, "rgb(1, 2, 3)");
+
+  parent.style.fontSize = "10px";
+  parent.style.color = "rgb(4, 5, 6)";
+  for (let i = 0; i < 2; ++i) {
+    const computed = getComputedStyle(child);
+    assert_array_equals([...computed], properties);
+    assert_equals(computed.fontSize, "15px");
+    assert_equals(computed.padding, "30px");
+    assert_equals(computed.color, "rgb(4, 5, 6)");
+    assert_equals(computed.getPropertyValue("--Marker"), "TokenValue");
+  }
+}, "Repeated computed styles preserve declarations and resolve inherited values after parent mutations");
+
+test(t => {
+  const element = createElement(t, "border: 5px none rgb(1, 2, 3)");
+
+  for (let i = 0; i < 3; ++i) {
+    const computed = getComputedStyle(element);
+    assert_equals(computed.borderTopWidth, "0px");
+    assert_equals(computed.borderTopStyle, "none");
+    assert_equals(computed.borderTopColor, "rgb(1, 2, 3)");
+  }
+}, "Repeated computed styles return resolved border widths");
+
+test(t => {
+  const element = createElement(t, "visibility: hidden");
+  const first = getComputedStyle(element);
+  const repeated = getComputedStyle(element);
+  assert_equals(first.visibility, "hidden");
+  assert_equals(repeated.visibility, "hidden");
+  assert_throws_dom("NoModificationAllowedError", () => repeated.setProperty("visibility", "visible"));
+  assert_throws_dom("NoModificationAllowedError", () => repeated.removeProperty("visibility"));
+
+  element.style.visibility = "visible";
+  assert_equals(getComputedStyle(element).visibility, "visible");
+  assert_equals(getComputedStyle(element).visibility, "visible");
+}, "Repeated computed styles stay read-only and new calls reflect mutations");
+</script>

--- a/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-system-color-shorthand.html
+++ b/test/web-platform-tests/to-upstream/css/cssom/getComputedStyle-system-color-shorthand.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Computed border-color resolves system colors</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+for (const colorScheme of ["light", "dark"]) {
+  for (const declaration of ["border-color: CanvasText", "border: 1px solid CanvasText"]) {
+    test(t => {
+      const element = document.createElement("div");
+      element.style.cssText = `color-scheme: ${colorScheme}; color: CanvasText; ${declaration}`;
+      document.body.append(element);
+      t.add_cleanup(() => element.remove());
+
+      for (let i = 0; i < 3; ++i) {
+        const computed = getComputedStyle(element);
+        assert_equals(computed.borderTopColor, computed.color);
+        assert_equals(computed.borderRightColor, computed.color);
+        assert_equals(computed.borderBottomColor, computed.color);
+        assert_equals(computed.borderLeftColor, computed.color);
+        assert_equals(computed.borderColor, computed.borderTopColor);
+      }
+    }, `${declaration} resolves its shorthand on first and repeated reads in ${colorScheme} mode`);
+  }
+}
+</script>


### PR DESCRIPTION
Copy cached computed-style declarations without resolving and reparsing every property.

Also fixes system-color shorthand resolution so first and repeated reads return resolved border colors.

For a 20-field React form mounting, updating three times, querying after each render, and unmounting:

| Queries | Before | After | Less elapsed time |
| --- | ---: | ---: | ---: |
| Role | 62.88 ms | 57.71 ms | 8.2% |
| Label + role + test ID | 69.25 ms | 63.56 ms | 8.2% |

jsdom's existing `style/get-computed-style-property-access` benchmark measures repeated computed-style calls followed by property reads. Using the same commits and five alternating process pairs:

| Property reads | Before | After | Less elapsed time |
| --- | ---: | ---: | ---: |
| 4 properties, including color | 5.763 µs | 3.913 µs | 32.1% |
| 4 properties without color or length resolution | 4.301 µs | 2.360 µs | 45.1% |
| 30 properties | 23.303 µs | 20.720 µs | 11.1% |
