### PR TITLE
Fix viewport lookup inside SVG symbols

### DIFF
--- a/lib/jsdom/living/nodes/SVGElement-impl.js
+++ b/lib/jsdom/living/nodes/SVGElement-impl.js
@@ -44,9 +44,10 @@ class SVGElementImpl extends ElementImpl {
   get viewportElement() {
     // Get the nearest ancestor that establishes the viewport.
     // https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport
+    // A `symbol` only establishes a viewport in a `use` instance tree, which jsdom does not implement.
     let e = domSymbolTree.parent(this);
     while (e && e.namespaceURI === SVG_NS) {
-      if (e.localName === "svg" || e.localName === "symbol") {
+      if (e.localName === "svg") {
         return e;
       }
       e = domSymbolTree.parent(e);

--- a/test/web-platform-tests/to-upstream/svg/struct/scripted/element-symbol.html
+++ b/test/web-platform-tests/to-upstream/svg/struct/scripted/element-symbol.html
@@ -2,6 +2,8 @@
 <title>SVGSymbolElement interface</title>
 <link rel="author" title="Timothy Gu" href="mailto:timothygu99@gmail.com">
 <link rel="help" href="https://svgwg.org/svg2-draft/struct.html#InterfaceSVGSymbolElement">
+<link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__viewportElement">
+<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport">
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -55,10 +57,10 @@
     const circ = document.getElementById("myCircle");
 
     assert_equals(g.ownerSVGElement, svg);
-    assert_equals(g.viewportElement, sym);
+    assert_equals(g.viewportElement, svg);
     assert_equals(circ.ownerSVGElement, svg);
-    assert_equals(circ.viewportElement, sym);
-  }, "Viewport of children");
+    assert_equals(circ.viewportElement, svg);
+  }, "Viewport of children of an uninstantiated symbol");
 }
 
 test(() => {


### PR DESCRIPTION
The viewportElement getter currently treats every symbol ancestor as an SVG viewport, so descendants of an uninstantiated symbol return that symbol instead of the enclosing svg element. Skip these ancestors: SVG 2 only lets symbols establish viewports in use instance trees, which jsdom does not implement.

Correct the group and circle expectations in test/web-platform-tests/to-upstream/svg/struct/scripted/element-symbol.html and synchronize the file with the upstream correction: https://github.com/web-platform-tests/wpt/pull/62645