### PR TITLE
Preserve request cancellation across redirects

### DIFF
--- a/lib/jsdom/browser/resources/jsdom-dispatcher.js
+++ b/lib/jsdom/browser/resources/jsdom-dispatcher.js
@@ -165,10 +165,13 @@ class JSDOMDispatcher extends Dispatcher {
 
     // Create a proxy controller that forwards to the current underlying controller.
     // This provides a stable reference across redirect hops.
-    let currentController;
+    let currentController, abortReason;
     let onRequestStartCalled = false;
+    let aborted = false;
     const proxyController = {
       abort(reason) {
+        aborted = true;
+        abortReason = reason;
         currentController.abort(reason);
       },
       pause() {
@@ -181,10 +184,10 @@ class JSDOMDispatcher extends Dispatcher {
         return currentController.paused;
       },
       get aborted() {
-        return currentController.aborted;
+        return aborted || currentController.aborted;
       },
       get reason() {
-        return currentController.reason;
+        return aborted ? abortReason : currentController.reason;
       },
       get rawHeaders() {
         return currentController.rawHeaders;
@@ -200,6 +203,9 @@ class JSDOMDispatcher extends Dispatcher {
       if (!onRequestStartCalled) {
         onRequestStartCalled = true;
         handler.onRequestStart?.(proxyController, ctx);
+      } else if (aborted) {
+        // Cancellation can occur after one hop finishes but before the next hop supplies its controller.
+        controller.abort(abortReason);
       }
     }
 

--- a/lib/jsdom/browser/resources/jsdom-dispatcher.js
+++ b/lib/jsdom/browser/resources/jsdom-dispatcher.js
@@ -165,10 +165,16 @@ class JSDOMDispatcher extends Dispatcher {
 
     // Create a proxy controller that forwards to the current underlying controller.
     // This provides a stable reference across redirect hops.
-    let currentController;
+    let currentController, abortReason;
     let onRequestStartCalled = false;
+    let aborted = false;
     const proxyController = {
       abort(reason) {
+        if (aborted) {
+          return;
+        }
+        aborted = true;
+        abortReason = reason;
         currentController.abort(reason);
       },
       pause() {
@@ -181,10 +187,10 @@ class JSDOMDispatcher extends Dispatcher {
         return currentController.paused;
       },
       get aborted() {
-        return currentController.aborted;
+        return aborted || currentController.aborted;
       },
       get reason() {
-        return currentController.reason;
+        return aborted ? abortReason : currentController.reason;
       },
       get rawHeaders() {
         return currentController.rawHeaders;
@@ -196,15 +202,14 @@ class JSDOMDispatcher extends Dispatcher {
 
     // Callback for #doSingleRequest to invoke when a controller becomes available
     function onControllerReady(controller) {
-      const previousController = currentController;
       currentController = controller;
-      if (previousController?.aborted) {
-        // Preserve cancellation while the next connection was being established.
-        controller.abort(previousController.reason);
-      }
       if (!onRequestStartCalled) {
         onRequestStartCalled = true;
         handler.onRequestStart?.(proxyController, ctx);
+      } else if (aborted) {
+        // Cancellation can occur after one hop finishes but before the next hop supplies its controller.
+        // The previous controller's `aborted` can also indicate normal completion of a cached response.
+        controller.abort(abortReason);
       }
     }
 

--- a/lib/jsdom/browser/resources/jsdom-dispatcher.js
+++ b/lib/jsdom/browser/resources/jsdom-dispatcher.js
@@ -165,13 +165,10 @@ class JSDOMDispatcher extends Dispatcher {
 
     // Create a proxy controller that forwards to the current underlying controller.
     // This provides a stable reference across redirect hops.
-    let currentController, abortReason;
+    let currentController;
     let onRequestStartCalled = false;
-    let aborted = false;
     const proxyController = {
       abort(reason) {
-        aborted = true;
-        abortReason = reason;
         currentController.abort(reason);
       },
       pause() {
@@ -184,10 +181,10 @@ class JSDOMDispatcher extends Dispatcher {
         return currentController.paused;
       },
       get aborted() {
-        return aborted || currentController.aborted;
+        return currentController.aborted;
       },
       get reason() {
-        return aborted ? abortReason : currentController.reason;
+        return currentController.reason;
       },
       get rawHeaders() {
         return currentController.rawHeaders;
@@ -199,13 +196,15 @@ class JSDOMDispatcher extends Dispatcher {
 
     // Callback for #doSingleRequest to invoke when a controller becomes available
     function onControllerReady(controller) {
+      const previousController = currentController;
       currentController = controller;
+      if (previousController?.aborted) {
+        // Preserve cancellation while the next connection was being established.
+        controller.abort(previousController.reason);
+      }
       if (!onRequestStartCalled) {
         onRequestStartCalled = true;
         handler.onRequestStart?.(proxyController, ctx);
-      } else if (aborted) {
-        // Cancellation can occur after one hop finishes but before the next hop supplies its controller.
-        controller.abort(abortReason);
       }
     }
 

--- a/test/api/resources-dispatcher.js
+++ b/test/api/resources-dispatcher.js
@@ -10,6 +10,46 @@ describe("JSDOMDispatcher unit tests", () => {
   // - origin, path, method, body, headers, query, idempotent, blocking,
   //   upgrade, headersTimeout, bodyTimeout, reset, throwOnError, expectContinue
 
+  it("should preserve the first reason when aborting the controller repeatedly", async () => {
+    const abortController = new AbortController();
+    const dispatcher = new JSDOMDispatcher({
+      cookieJar: new toughCookie.CookieJar(),
+      baseDispatcher: {
+        dispatch(opts, handler) {
+          const controller = {
+            abort(reason) {
+              abortController.abort(reason);
+            },
+            get aborted() {
+              return abortController.signal.aborted;
+            },
+            get reason() {
+              return abortController.signal.reason;
+            }
+          };
+          handler.onRequestStart(controller, {});
+          handler.onResponseError(controller, controller.reason);
+          return true;
+        }
+      }
+    });
+    const firstReason = new Error("first abort");
+    let proxyController;
+    const error = await new Promise(resolve => {
+      dispatcher.dispatch({ origin: "http://localhost", path: "/", method: "GET" }, {
+        onRequestStart(controller) {
+          proxyController = controller;
+          controller.abort(firstReason);
+          controller.abort(new Error("second abort"));
+        },
+        onResponseError: (controller, err) => resolve(err)
+      });
+    });
+    assert.equal(error, firstReason);
+    assert.equal(proxyController.aborted, true);
+    assert.equal(proxyController.reason, firstReason);
+  });
+
   it("should pass through method, body, and other DispatchOptions unchanged", async () => {
     const { dispatcher, getCapturedOpts } = createCapturingDispatcher();
     const body = Buffer.from("test body");

--- a/test/api/resources-interceptors.js
+++ b/test/api/resources-interceptors.js
@@ -2,11 +2,14 @@
 const assert = require("node:assert/strict");
 const { describe, it } = require("mocha-sugar-free");
 const delay = require("node:timers/promises").setTimeout;
+const { Agent, interceptors, cacheStores } = require("undici");
 const canvas = require("../../lib/jsdom/utils.js").Canvas;
 
 const { JSDOM, VirtualConsole, requestInterceptor } = require("../..");
 
 const {
+  createServer,
+  serverURL,
   pngBytes,
   resourceServer,
   imageServer,
@@ -22,6 +25,41 @@ const {
 } = require("./helpers/resources.js");
 
 describe("API: resources interceptors option", () => {
+  it("should follow a cached redirect without canceling the target request", async () => {
+    const agent = new Agent();
+    const cache = interceptors.cache({ store: new cacheStores.MemoryCacheStore() });
+    let redirectRequests = 0;
+    let targetRequests = 0;
+    const target = await createServer((req, res) => {
+      targetRequests++;
+      res.writeHead(200, { "Content-Type": "text/html", "Cache-Control": "no-store" });
+      res.end("<p>redirect target</p>");
+    });
+    const redirect = await createServer((req, res) => {
+      redirectRequests++;
+      res.writeHead(302, { "Location": serverURL(target), "Cache-Control": "public, max-age=3600" });
+      res.end();
+    });
+
+    try {
+      for (let i = 0; i < 2; i++) {
+        const dom = await JSDOM.fromURL(serverURL(redirect), {
+          resources: { dispatcher: agent, interceptors: [cache] }
+        });
+        try {
+          assert.equal(dom.window.document.querySelector("p").textContent, "redirect target");
+        } finally {
+          dom.window.close();
+        }
+      }
+      assert.equal(redirectRequests, 1, "The second redirect response must come from the cache");
+      assert.equal(targetRequests, 2, "Both loads must reach the redirect target");
+    } finally {
+      await agent.destroy();
+      await Promise.all([redirect.destroy(), target.destroy()]);
+    }
+  });
+
   describe("passing through requests", () => {
     it("should be called for JSDOM.fromURL()'s initial request", async () => {
       const url = await htmlServer("Hello");

--- a/test/api/resources.js
+++ b/test/api/resources.js
@@ -6,6 +6,8 @@ const { version: packageVersion } = require("../../package.json");
 const { JSDOM } = require("../..");
 
 const {
+  createServer,
+  serverURL,
   emptyServer,
   resourceServer,
   neverRequestedServer,
@@ -496,6 +498,32 @@ describe("API: resource loading configuration", () => {
     });
 
     describe("canceling requests", () => {
+      it("should not run a redirected script after stopping the window", async () => {
+        const target = await createServer((req, res) => {
+          res.writeHead(200, { "Content-Type": "text/javascript" });
+          res.end("window.redirectedScriptRan = true;");
+        });
+        const redirect = await createServer((req, res) => {
+          res.writeHead(302, { Location: serverURL(target) });
+          res.end();
+        });
+        const { window } = new JSDOM(`<script src="${serverURL(redirect)}"></script>`, {
+          resources: "usable", runScripts: "dangerously"
+        });
+        // Stop as the redirect target accepts the connection, before it sends the script.
+        target.once("connection", () => window.stop());
+
+        try {
+          await new Promise(resolve => {
+            window.addEventListener("load", resolve, { once: true });
+          });
+          assert.equal(window.redirectedScriptRan, undefined);
+        } finally {
+          window.close();
+          await Promise.all([redirect.destroy(), target.destroy()]);
+        }
+      });
+
       it("should abort a script request when closing the window", async () => {
         const [url, neverRequestedPromise] = await neverRequestedServer();
         const dom = new JSDOM(`<script>window.y = 6;</script>`, {

--- a/test/api/resources.js
+++ b/test/api/resources.js
@@ -1,6 +1,7 @@
 "use strict";
 const assert = require("node:assert/strict");
 const { describe, it } = require("mocha-sugar-free");
+const { Agent } = require("undici");
 const { Canvas } = require("../../lib/jsdom/utils.js");
 const { version: packageVersion } = require("../../package.json");
 const { JSDOM } = require("../..");
@@ -499,7 +500,10 @@ describe("API: resource loading configuration", () => {
 
     describe("canceling requests", () => {
       it("should not run a redirected script after stopping the window", async () => {
+        const agent = new Agent();
+        let targetRequests = 0;
         const target = await createServer((req, res) => {
+          targetRequests++;
           res.writeHead(200, { "Content-Type": "text/javascript" });
           res.end("window.redirectedScriptRan = true;");
         });
@@ -508,18 +512,25 @@ describe("API: resource loading configuration", () => {
           res.end();
         });
         const { window } = new JSDOM(`<script src="${serverURL(redirect)}"></script>`, {
-          resources: "usable", runScripts: "dangerously"
+          resources: { dispatcher: agent }, runScripts: "dangerously"
         });
         // Stop as the redirect target accepts the connection, before it sends the script.
-        target.once("connection", () => window.stop());
+        const stopped = new Promise(resolve => {
+          target.once("connection", () => {
+            window.stop();
+            resolve();
+          });
+        });
 
         try {
-          await new Promise(resolve => {
-            window.addEventListener("load", resolve, { once: true });
-          });
+          await stopped;
+          // `close()` waits for pending requests to finish without canceling them.
+          await agent.close();
+          assert.equal(targetRequests, 0, "Stopping must cancel the request before it is sent");
           assert.equal(window.redirectedScriptRan, undefined);
         } finally {
           window.close();
+          await agent.destroy();
           await Promise.all([redirect.destroy(), target.destroy()]);
         }
       });


### PR DESCRIPTION
Fix redirected scripts executing after `window.stop()`, found while improving resource-loading shutdown.